### PR TITLE
Explorer spawn fix

### DIFF
--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
@@ -19680,6 +19680,11 @@
 	},
 /turf/open/floor/f13,
 /area/f13/ambientlighting/building/o)
+"hQt" = (
+/obj/structure/chair/bench,
+/obj/effect/landmark/start/f13/explorer,
+/turf/open/floor/f13/wood,
+/area/f13/legioncamp)
 "hQv" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -36327,6 +36332,13 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"oFg" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/landmark/start/f13/explorer,
+/turf/open/floor/plasteel/f13/stone/rugged,
+/area/f13/legioncamp)
 "oFl" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
@@ -140541,7 +140553,7 @@ mfr
 vMO
 kSG
 eCk
-vMO
+hQt
 rcP
 rcP
 vMO
@@ -145979,7 +145991,7 @@ eOX
 tyd
 mPp
 vQW
-vQW
+oFg
 cTk
 rNY
 exv


### PR DESCRIPTION
## About The Pull Request
Explorer had the issue of spawning in a box rather than the actual camp, this should solve the issue with the spawn both landmarks are in the camp. One in the mess hall the other in the armory.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
wH0 T00Kthejam made the following changes:
Added two legion explorer spawn landmarks to the camp
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
