### PR TITLE
Mapping changes+Dungeon addition.

### DIFF
--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
@@ -708,6 +708,13 @@
 "apD" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
+"apG" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/turf/closed/mineral/random,
+/area/f13/caves)
 "aqa" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -825,6 +832,16 @@
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalinnermain1"
 	},
+/area/f13/wasteland)
+"asa" = (
+/obj/structure/flora/tree/oak_three,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
 "ase" = (
 /obj/effect/overlay/desert/sonora/edge{
@@ -1139,6 +1156,12 @@
 /obj/structure/car/rubbish2,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"awu" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "awH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/fulltile/house{
@@ -1223,6 +1246,21 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"axL" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/obj/item/stock_parts/cell/high/empty,
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "axO" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/h)
@@ -1941,6 +1979,33 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"aLB" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/obj/structure/nest/ghoul,
+/obj/item/stock_parts/cell/high/empty,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aLX" = (
 /obj/structure/chair/left,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1959,6 +2024,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/abandoned/t)
+"aMj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "aMr" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -2074,6 +2147,13 @@
 /obj/structure/obstacle/barbedwire/end,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"aOP" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "aPj" = (
 /obj/structure/fence/corner{
 	dir = 4
@@ -2258,6 +2338,10 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/abandoned/t)
+"aRK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/caves)
 "aRO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/junglebush/b,
@@ -2297,6 +2381,13 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ambientlighting/building/c)
+"aSa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "aSi" = (
 /obj/effect/overlay/desert_side,
 /obj/effect/overlay/desert_side{
@@ -2855,6 +2946,16 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/y)
+"bbc" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/item/stock_parts/cell/ammo/ultracite,
+/obj/item/stock_parts/cell/hyper,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bbs" = (
 /obj/structure/table/booth,
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
@@ -3154,6 +3255,12 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"bhQ" = (
+/obj/structure/fence/corner{
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/water/running,
+/area/f13/wasteland)
 "bhW" = (
 /obj/structure/table,
 /obj/item/locked_box/misc/attachments,
@@ -3840,6 +3947,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/building/powered)
+"bwE" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bwK" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
@@ -4145,6 +4256,23 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
+"bDG" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/stock_parts/cell/empty,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bDL" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -4493,6 +4621,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/m)
+"bLJ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/simple_door/room,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/ambientlighting/building/g)
 "bMj" = (
 /obj/structure/simple_door/metal/dirtystore,
 /obj/effect/decal/cleanable/dirt,
@@ -5350,6 +5486,10 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"cbW" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ccb" = (
 /obj/effect/overlay/desert_side,
 /obj/effect/overlay/desert_side{
@@ -5590,6 +5730,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/e)
+"cht" = (
+/obj/structure/flora/wasteplant/wild_broc,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
 "chN" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticaldegraded"
@@ -5640,6 +5786,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/wasteland)
+"cje" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "cjj" = (
 /obj/structure/barricade/tentclothedge,
 /turf/open/indestructible/ground/inside/dirt,
@@ -6055,6 +6208,18 @@
 	},
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
+"crt" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "crI" = (
 /obj/effect/overlay/desert/sonora/edge{
 	dir = 1
@@ -6349,6 +6514,21 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/brotherhood/surface)
+"cwn" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cwp" = (
 /obj/structure/fence,
 /obj/structure/fence/corner{
@@ -6362,6 +6542,12 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
+/area/f13/wasteland)
+"cxe" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water/running,
 /area/f13/wasteland)
 "cxi" = (
 /obj/effect/overlay/desert/sonora/edge{
@@ -6803,6 +6989,13 @@
 	},
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/building/powered)
+"cDx" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/turf/closed/mineral/random,
+/area/f13/wasteland)
 "cDB" = (
 /obj/structure/wreck/trash/machinepiletwo{
 	pixel_x = 2;
@@ -6854,6 +7047,11 @@
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /turf/open/floor/carpet/royalblue,
 /area/f13/building/abandoned/s)
+"cEy" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cEA" = (
 /obj/structure/rack,
 /obj/item/multitool,
@@ -8096,6 +8294,10 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"daI" = (
+/obj/structure/fence/end,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "daL" = (
 /obj/structure/junk/locker,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
@@ -8460,6 +8662,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/a)
+"dhZ" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/turf/closed/mineral/random,
+/area/f13/wasteland)
 "dia" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/bunker,
@@ -9829,6 +10038,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/ambientlighting/building/e)
+"dJF" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/closed/mineral/random,
+/area/f13/caves)
 "dJI" = (
 /obj/structure/table/abductor,
 /obj/effect/decal/cleanable/dirt,
@@ -11273,6 +11486,19 @@
 /obj/item/storage/toolbox/ammo/surplus,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"emg" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "emi" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/curtain{
@@ -11606,6 +11832,14 @@
 	icon_state = "horizontaloutermain2left"
 	},
 /area/f13/wasteland)
+"eqB" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "eqJ" = (
 /turf/closed/mineral/random/no_caves,
 /area/f13/building/abandoned/g)
@@ -11792,6 +12026,14 @@
 "etL" = (
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/city)
+"etX" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "eua" = (
 /obj/effect/turf_decal/delivery/red,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12696,6 +12938,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/abandoned/t)
+"eLo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "eLw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/bar,
@@ -12725,6 +12972,13 @@
 	smooth = 1
 	},
 /area/f13/building/abandoned/m)
+"eMa" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/ambientlighting/building/k)
 "eMr" = (
 /obj/structure/barricade/tentleatheredge,
 /obj/structure/decoration/rag{
@@ -13009,6 +13263,18 @@
 /area/f13/building/powered)
 "eSP" = (
 /obj/structure/flora/tree/oak_five,
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/wasteland)
+"eSY" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
 "eTa" = (
@@ -13499,6 +13765,12 @@
 /obj/item/stack/f13Cash/aureus,
 /turf/open/floor/carpet/red,
 /area/f13/legioncamp)
+"fbD" = (
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/hostile/ghoul,
+/obj/item/stock_parts/cell/high/empty,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fbI" = (
 /obj/structure/window/fulltile/house,
 /turf/open/indestructible/ground/outside/desert,
@@ -13714,6 +13986,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"fgv" = (
+/obj/structure/fence/wooden{
+	dir = 1;
+	icon_state = "post_wood"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/grass/dirtpath{
+	dir = 8
+	},
+/area/f13/wasteland)
 "fgw" = (
 /obj/structure/rack,
 /obj/item/clothing/head/f13/cowboy,
@@ -13903,6 +14187,12 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plating/wooden,
 /area/engine/workshop)
+"fiR" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/ambientlighting/building/g)
 "fiY" = (
 /obj/structure/chair/wood,
 /turf/open/indestructible/ground/outside/grass,
@@ -13990,6 +14280,38 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ambientlighting/building/j)
+"fjZ" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/mob/living/simple_animal/hostile/ghoul/legendary{
+	melee_damage_lower = 30;
+	melee_damage_upper = 45;
+	name = "Dump Site Manager Big Bob";
+	resize = 1.1;
+	resize_height = 1.1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fki" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -14027,6 +14349,11 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
+"fkM" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2"
+	},
+/area/f13/ambientlighting/building/g)
 "fkX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -16510,6 +16837,9 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
+"geR" = (
+/turf/open/indestructible/ground/outside/road,
+/area/f13/caves)
 "geW" = (
 /obj/structure/sink/well,
 /turf/open/indestructible/ground/inside/dirt,
@@ -17318,6 +17648,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/h)
+"gtc" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertop2"
+	},
+/area/f13/wasteland)
 "gtm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt{
@@ -18027,6 +18363,10 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
+"gHy" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/wood/house,
+/area/f13/ambientlighting/building/g)
 "gHD" = (
 /obj/structure/table/booth,
 /obj/item/candle,
@@ -18224,6 +18564,15 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerbordercorner"
 	},
+/area/f13/wasteland)
+"gJX" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
 "gKm" = (
 /obj/structure/closet/crate/grave,
@@ -18845,10 +19194,41 @@
 	icon_state = "horizontaltopborderbottomright"
 	},
 /area/f13/wasteland)
+"gUl" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gUn" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/abandoned/g)
+"gUt" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "gUx" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -19498,6 +19878,10 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/legioncamp)
+"hhh" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hhl" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19826,6 +20210,40 @@
 /obj/structure/debris/v2,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"hmw" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hmC" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -20576,6 +20994,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
+"hze" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/ambientlighting/building/g)
 "hzf" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -20631,6 +21054,11 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland/legion)
+"hAb" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hAd" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -21213,6 +21641,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/ambientlighting/building/j)
+"hIl" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hIH" = (
 /obj/structure/bed/wooden{
 	pixel_y = 15
@@ -21338,6 +21779,18 @@
 	icon_state = "verticalleftborderleft2"
 	},
 /area/f13/ambientlighting/building/y)
+"hKS" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/obj/structure/nest/ghoul,
+/obj/item/stock_parts/cell/high/empty,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hKZ" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "outerborder"
@@ -22235,6 +22688,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"iby" = (
+/obj/structure/fence,
+/turf/open/indestructible/ground/outside/water/running,
+/area/f13/wasteland)
 "ibC" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23429,6 +23886,17 @@
 	icon_state = "horizontalinnermain2left"
 	},
 /area/f13/wasteland)
+"izb" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/turf/closed/mineral/random,
+/area/f13/caves)
 "izf" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedvertical"
@@ -23944,6 +24412,15 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"iHG" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/item/stock_parts/cell/high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "iHH" = (
 /obj/effect/spawner/lootdrop/toolsbasic,
 /turf/open/indestructible/ground/outside/dirt{
@@ -24251,6 +24728,12 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building/tribal)
+"iNM" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/stock_parts/cell/high/empty,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "iOU" = (
 /obj/structure/sign/legion/prison,
 /turf/open/indestructible/ground/outside/desert,
@@ -24261,6 +24744,13 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"iPb" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/turf/closed/mineral/random,
 /area/f13/wasteland)
 "iPm" = (
 /obj/effect/turf_decal/huge{
@@ -24832,6 +25322,19 @@
 	},
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
+"jaM" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/ghoul/glowing/strong{
+	name = "Dump Site Worker Billy Bob"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/ambientlighting/building/g)
 "jaN" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -25189,6 +25692,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/g)
+"jhX" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/caves)
 "jio" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/ruins,
@@ -25225,6 +25740,20 @@
 	icon_state = "horizontalbottomborderbottom0"
 	},
 /area/f13/wasteland)
+"jiP" = (
+/obj/structure/table/wood,
+/obj/item/paper,
+/obj/item/paper{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/pen,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/ambientlighting/building/g)
 "jiS" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase,
@@ -25277,6 +25806,12 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"jjw" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "jjE" = (
 /obj/structure/wreck/car,
 /turf/open/indestructible/ground/outside/road,
@@ -25758,6 +26293,13 @@
 "jsC" = (
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/c)
+"jsG" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "jsI" = (
 /obj/structure/bed/mattress/pregame,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
@@ -27395,6 +27937,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/wasteland)
+"jVF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/mineral/random,
+/area/f13/caves)
 "jVM" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -27535,6 +28081,11 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"jYM" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/caves)
 "jYN" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -28061,6 +28612,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legioncamp)
+"khZ" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kib" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28366,6 +28926,32 @@
 /obj/item/radio/tribal,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/w)
+"kof" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/item/stock_parts/cell/empty,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kos" = (
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -28489,6 +29075,10 @@
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/x)
+"kqU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "kqV" = (
 /obj/structure/decoration/hatch{
 	dir = 8
@@ -29218,6 +29808,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"kFH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2right"
+	},
+/area/f13/wasteland)
 "kFS" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
@@ -29724,6 +30320,36 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/white/whiteyellowchess/whiteyellowchess2,
 /area/f13/ambientlighting/building/j)
+"kNy" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kNN" = (
 /obj/effect/decal/cleanable/oil{
 	pixel_x = 15
@@ -29806,6 +30432,12 @@
 	icon_state = "catwalk"
 	},
 /area/f13/ambientlighting/building/o)
+"kPz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop1"
+	},
+/area/f13/wasteland)
 "kPD" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 8
@@ -30044,6 +30676,16 @@
 "kTc" = (
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/v)
+"kTq" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kTs" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -30085,6 +30727,12 @@
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt"
+	},
+/area/f13/wasteland)
+"kUI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2left"
 	},
 /area/f13/wasteland)
 "kVk" = (
@@ -30423,6 +31071,14 @@
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/y)
+"laX" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/ambientlighting/building/g)
 "laY" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/bandana/skull,
@@ -31110,6 +31766,13 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"lqh" = (
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/hostile/ghoul,
+/obj/structure/nest/ghoul,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lqm" = (
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/siding/wood{
@@ -31907,6 +32570,19 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
+"lFj" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/structure/nest/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lFv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -32557,6 +33233,9 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/e)
+"lSV" = (
+/turf/closed/wall/f13/wood/house,
+/area/f13/caves)
 "lSW" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/table/wood,
@@ -32600,6 +33279,11 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"lTG" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/ambientlighting/building/g)
 "lTR" = (
 /obj/structure/car/rubbish1,
 /obj/structure/car/rubbish3,
@@ -32928,6 +33612,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"mae" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "mah" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -33208,6 +33899,13 @@
 	icon_state = "dark"
 	},
 /area/f13/ambientlighting/building/o)
+"meG" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "meK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -33513,6 +34211,10 @@
 	icon_state = "transition1"
 	},
 /area/f13/wasteland)
+"mkQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "mlw" = (
 /obj/structure/wreck/trash/two_barrels,
 /obj/effect/decal/cleanable/dirt,
@@ -33615,6 +34317,20 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/legion)
+"mmO" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mmP" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -34522,6 +35238,14 @@
 	icon_state = "verticaloutermain3"
 	},
 /area/f13/wasteland/followers)
+"mEB" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/closed/mineral/random,
+/area/f13/wasteland)
 "mEE" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/desert,
@@ -34830,6 +35554,10 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/surface)
+"mLy" = (
+/mob/living/simple_animal/hostile/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mLz" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "garage";
@@ -35707,6 +36435,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/j)
+"nbU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2right"
+	},
+/area/f13/wasteland)
 "ncb" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -35743,6 +36477,13 @@
 "ncr" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/wasteland/town)
+"ncu" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/caves)
 "ncG" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/dirt{
@@ -35821,6 +36562,13 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"nek" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nel" = (
 /obj/structure/window/fulltile/wood{
 	layer = 2.8;
@@ -35857,6 +36605,9 @@
 "neO" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/abandoned/t)
+"neZ" = (
+/turf/closed/wall/f13/wood,
+/area/f13/caves)
 "nfa" = (
 /obj/structure/closet/fridge/meat,
 /turf/open/floor/f13{
@@ -36114,6 +36865,10 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"nju" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/indestructible/ground/inside/dirt,
+/area/f13/wasteland)
 "njx" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /obj/effect/decal/cleanable/dirt{
@@ -36248,6 +37003,17 @@
 /obj/structure/debris/v1,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"nma" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nmf" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/overlay/desert_side{
@@ -36452,6 +37218,13 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ambientlighting/building/i)
+"npY" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "hospitalgarage1";
+	name = "Garage"
+	},
+/turf/open/indestructible/ground/outside/road,
+/area/f13/ambientlighting/building/g)
 "nqa" = (
 /obj/effect/overlay/desert/sonora/edge{
 	dir = 1
@@ -36898,6 +37671,15 @@
 	},
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"nxs" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/caves)
 "nxD" = (
 /obj/structure/table,
 /obj/item/tank/internals/anesthetic,
@@ -37356,6 +38138,19 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"nFM" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/grassybush,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/wasteland)
 "nFN" = (
 /obj/structure/lamp_post{
 	dir = 4
@@ -37760,6 +38555,13 @@
 /area/f13/wasteland)
 "nNZ" = (
 /turf/open/indestructible/ground/outside/grass/corner,
+/area/f13/wasteland)
+"nOi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
 /area/f13/wasteland)
 "nOm" = (
 /obj/effect/overlay/junk/curtain,
@@ -39015,6 +39817,12 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"olF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2right"
+	},
+/area/f13/ambientlighting/building/g)
 "olN" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -39048,6 +39856,10 @@
 	icon_state = "bar"
 	},
 /area/f13/ambientlighting/building/m)
+"olU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/ambientlighting/building/g)
 "olV" = (
 /obj/structure/bed/mattress/pregame,
 /obj/item/bedsheet/blanket,
@@ -39114,6 +39926,11 @@
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building/abandoned/x)
+"onw" = (
+/mob/living/simple_animal/hostile/ghoul,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "onI" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
@@ -39845,6 +40662,24 @@
 /mob/living/simple_animal/hostile/giantant,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ambientlighting/building/k)
+"oDj" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oDq" = (
 /obj/effect/decal/marking{
 	pixel_x = -14
@@ -39983,6 +40818,14 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
+"oFS" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermainleft"
+	},
+/area/f13/caves)
 "oFZ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -40448,6 +41291,31 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/abandoned/j)
+"oNT" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oNV" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -40815,6 +41683,15 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/abandoned/t)
+"oUL" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/wasteland)
 "oUO" = (
 /obj/structure/sign/poster/contraband/red_rum{
 	pixel_x = -32
@@ -41499,6 +42376,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"pjw" = (
+/turf/closed/mineral/random,
+/area/f13/caves)
 "pjA" = (
 /obj/structure/fence{
 	dir = 8
@@ -42620,6 +43500,9 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pGg" = (
+/turf/open/indestructible/ground/outside/road,
+/area/f13/ambientlighting/building/g)
 "pGk" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/carpet/royalblack,
@@ -42838,6 +43721,17 @@
 	icon_state = "housewood2"
 	},
 /area/f13/wasteland)
+"pKv" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/nest/ghoul,
+/obj/item/stock_parts/cell/high,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pKw" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/meatsmoked,
@@ -42952,6 +43846,35 @@
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
+"pLR" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pLY" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
@@ -43631,6 +44554,14 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/powered)
+"pYs" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pYy" = (
 /obj/structure/rack,
 /obj/item/lockpick_set,
@@ -43679,6 +44610,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/tentclothcorner,
 /turf/open/indestructible/ground/inside/dirt,
+/area/f13/wasteland)
+"pZA" = (
+/obj/structure/railing{
+	layer = 3.1
+	},
+/turf/open/indestructible/ground/outside/water/running,
 /area/f13/wasteland)
 "pZS" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -43836,6 +44773,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/building/abandoned/m)
+"qcq" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qcu" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/outside/dirt{
@@ -44872,6 +45818,13 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"qwc" = (
+/obj/structure/billboard/poseidenenergy1,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "qwl" = (
 /obj/effect/turf_decal/huge,
 /obj/item/storage/trash_stack,
@@ -45603,6 +46556,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"qLq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop2left"
+	},
+/area/f13/ambientlighting/building/g)
 "qLu" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -46127,6 +47086,10 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland/legion)
+"qVa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "qVm" = (
 /obj/structure/debris/v4,
 /obj/structure/grille,
@@ -46829,6 +47792,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/wasteland)
+"rhc" = (
+/obj/structure/billboard/redrocket1,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "rhe" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/dirt{
@@ -46994,6 +47964,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"rjo" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/ambientlighting/building/g)
 "rjJ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/toolsbasic,
@@ -47511,6 +48487,12 @@
 /turf/open/floor/wood_common{
 	icon_state = "common-broken2"
 	},
+/area/f13/wasteland)
+"rtu" = (
+/obj/structure/fence/end{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "rtC" = (
 /obj/effect/decal/fakelattice,
@@ -48189,6 +49171,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
+"rHB" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rHX" = (
 /obj/structure/curtain{
 	pixel_y = -32
@@ -49008,6 +49998,13 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"rYo" = (
+/obj/effect/decal/cleanable/greenglow,
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/obj/item/stock_parts/cell/hyper,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rYp" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
@@ -49077,7 +50074,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/open/indestructible/ground/outside/grass,
+/turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "saE" = (
 /obj/structure/closet/crate/solarpanel_small,
@@ -49349,6 +50346,18 @@
 	icon_state = "outerborder"
 	},
 /area/f13/building/powered)
+"sfZ" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermainleft"
+	},
+/area/f13/caves)
+"sgb" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "sgk" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
@@ -50657,6 +51666,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/ambientlighting/building/o)
+"sEJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/ambientlighting/building/g)
 "sEL" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/carpet/green,
@@ -52275,6 +53290,16 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ambientlighting/building/y)
+"thA" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/ambientlighting/building/g)
 "thD" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -52828,6 +53853,37 @@
 	dir = 8
 	},
 /area/f13/wasteland/followers)
+"trA" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "trD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/wood/house/broken,
@@ -52844,6 +53900,16 @@
 	icon_state = "verticalrightborderright3"
 	},
 /area/f13/ambientlighting/building/y)
+"tsv" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tsF" = (
 /obj/effect/overlay/desert_side{
 	dir = 1
@@ -53688,6 +54754,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/y)
+"tIn" = (
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tID" = (
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -54691,6 +55761,12 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/legion)
+"uax" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "uaR" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -56067,6 +57143,16 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building/abandoned/j)
+"uAe" = (
+/obj/structure/flora/tree/tall{
+	layer = 2;
+	pixel_y = 9
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "uAo" = (
 /obj/structure/fence/handrail{
 	dir = 8;
@@ -56511,6 +57597,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ambientlighting/building/i)
+"uHe" = (
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/obj/item/stock_parts/cell/hyper,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "uHk" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/bodypart/l_arm/robot/surplus_upgraded,
@@ -57390,6 +58482,13 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/ambientlighting/building/g)
+"uWy" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/tree/cactus_alt,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "uWC" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/outside/dirt{
@@ -57560,6 +58659,11 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/wasteland)
+"uYQ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/ambientlighting/building/g)
 "uZd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
@@ -58020,6 +59124,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"vgZ" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vhb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -58635,6 +59747,12 @@
 /obj/structure/fence/corner/wooden{
 	dir = 8
 	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/grass/dirtpath{
 	dir = 1
 	},
@@ -58726,6 +59844,41 @@
 /obj/effect/overlay/desert_side,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/legion)
+"vvK" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/item/stock_parts/cell/high/empty,
+/obj/item/gun/energy/gammagun,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vvL" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/grass,
@@ -58736,6 +59889,10 @@
 /obj/item/radio/old,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/building/abandoned/m)
+"vwf" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vwo" = (
 /obj/structure/table/wood/settler,
 /turf/open/floor/wood_common,
@@ -60381,6 +61538,14 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/abandoned/q)
+"wes" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "hospitalgarage1";
+	name = "Garage"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/ambientlighting/building/g)
 "weH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood{
@@ -61857,6 +63022,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/followers)
+"wCL" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow,
+/turf/closed/mineral/random,
+/area/f13/wasteland)
 "wCV" = (
 /obj/structure/fence/pole_t,
 /obj/structure/railing{
@@ -62698,6 +63868,12 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/ambientlighting/building/w)
+"wRD" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermainleft"
+	},
+/area/f13/caves)
 "wRG" = (
 /obj/structure/table/wood,
 /obj/item/paper,
@@ -63730,6 +64906,15 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/ambientlighting/building/i)
+"xjR" = (
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xjS" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt{
@@ -63798,6 +64983,19 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"xli" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/mob/living/simple_animal/hostile/ghoul,
+/obj/structure/nest/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xlj" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/grass/dirtpath{
@@ -65007,6 +66205,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building/abandoned/t)
+"xDI" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "xDP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/greenglow,
@@ -65329,6 +66533,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ambientlighting/building/w)
+"xKW" = (
+/obj/structure/flora/tree/oak_three,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/wasteland)
 "xLc" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -65343,6 +66554,14 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"xLn" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xLz" = (
 /obj/item/ammo_casing/spent,
 /mob/living/simple_animal/hostile/raider,
@@ -65563,6 +66782,40 @@
 	icon_state = "horizontalbottomborderbottom2"
 	},
 /area/f13/wasteland/town)
+"xQh" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/greenglow,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/item/stock_parts/cell/high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xQD" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/grass/corner{
@@ -66423,6 +67676,31 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/k)
+"ygi" = (
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/item/stock_parts/cell/hyper,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ygn" = (
 /obj/structure/railing,
 /obj/structure/table/reinforced,
@@ -67484,8 +68762,8 @@ yfv
 yfv
 yfv
 yfv
-yfv
-yfv
+neZ
+neZ
 yfv
 yfv
 yfv
@@ -67783,6 +69061,15 @@ aTW
 aTW
 aTW
 aTW
+neZ
+bwE
+taO
+taO
+vwf
+taO
+taO
+bwE
+neZ
 aTW
 aTW
 aTW
@@ -67791,17 +69078,8 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+aHq
+aHq
 aTW
 aTW
 aTW
@@ -67965,27 +69243,27 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (5,1,1) = {"
@@ -68083,30 +69361,30 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+pjw
+pjw
+taO
+vwf
+taO
+taO
+vwf
+hKS
+onw
+taO
+vwf
+taO
+neZ
+izb
+pjw
+pjw
+pjw
+pjw
+pjw
+pjw
+aHq
+aHq
+aHq
+aHq
 aTW
 aTW
 aTW
@@ -68267,27 +69545,27 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (6,1,1) = {"
@@ -68385,31 +69663,31 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+pjw
+pjw
+vwf
+vwf
+taO
+vwf
+taO
+vwf
+vwf
+vwf
+taO
+taO
+taO
+lFj
+dJF
+pjw
+neZ
+bwE
+taO
+taO
+taO
+bwE
+neZ
+aHq
+aHq
 aTW
 aTW
 aTW
@@ -68570,26 +69848,26 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (7,1,1) = {"
@@ -68687,33 +69965,33 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+pjw
+pjw
+cEy
+taO
+vwf
+vwf
+vwf
+taO
+taO
+vwf
+vwf
+vwf
+taO
+taO
+taO
+vwf
+iNM
+vwf
+taO
+taO
+vwf
+vwf
+taO
+taO
+aHq
+aHq
+aHq
 aTW
 aTW
 yfv
@@ -68873,25 +70151,25 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (8,1,1) = {"
@@ -68989,33 +70267,33 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+pjw
+pjw
+taO
+vwf
+taO
+taO
+pjw
+pjw
+neZ
+jsG
+taO
+taO
+vwf
+vwf
+vwf
+vwf
+taO
+vwf
+vwf
+vwf
+vwf
+vwf
+vwf
+taO
+pYs
+cwn
+aHq
 aTW
 aTW
 yfv
@@ -69177,23 +70455,23 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (9,1,1) = {"
@@ -69291,34 +70569,34 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+pjw
+pjw
+taO
+vwf
+vwf
+taO
+pjw
+pjw
+taO
+taO
+etX
+taO
+neZ
+pjw
+taO
+vwf
+vwf
+taO
+neZ
+pjw
+aHq
+taO
+vwf
+vwf
+taO
+bbc
+aHq
+pjw
 aTW
 yfv
 yfv
@@ -69481,21 +70759,21 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (10,1,1) = {"
@@ -69593,34 +70871,34 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+pjw
+pjw
+taO
+taO
+vwf
+taO
+taO
+pjw
+aLB
+mLy
+taO
+pjw
+pjw
+apG
+meG
+jsG
+vwf
+jVF
+pjw
+pjw
+aHq
+mmO
+xLn
+vwf
+taO
+taO
+neZ
+aHq
 aTW
 aTW
 aTW
@@ -69784,20 +71062,20 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (11,1,1) = {"
@@ -69895,34 +71173,34 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+pjw
+pjw
+pjw
+jsG
+vwf
+taO
+taO
+neZ
+apG
+apG
+pjw
+pjw
+pjw
+pjw
+pjw
+taO
+vwf
+vwf
+qcq
+pjw
+aHq
+pKv
+rHB
+ygi
+pLR
+oNT
+taO
+aHq
 aTW
 azA
 azA
@@ -70087,19 +71365,19 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (12,1,1) = {"
@@ -70197,34 +71475,34 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+pjw
+pjw
+pjw
+neZ
+vwf
+vwf
+taO
+taO
+bwE
+pjw
+pjw
+pjw
+pjw
+pjw
+pjw
+pjw
+taO
+vwf
+taO
+pjw
+aHq
+taO
+taO
+hmw
+fjZ
+xQh
+vwf
+aHq
 aTW
 aTW
 azA
@@ -70390,18 +71668,18 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (13,1,1) = {"
@@ -70499,34 +71777,34 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+pjw
+pjw
+pjw
+pjw
+nek
+taO
+vwf
+vwf
+vwf
+vwf
+taO
+neZ
+pjw
+pjw
+pjw
+pjw
+emg
+rYo
+taO
+pjw
+aHq
+taO
+vwf
+kof
+vvK
+kNy
+taO
+aHq
 aTW
 azA
 azA
@@ -70694,16 +71972,16 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (14,1,1) = {"
@@ -70800,35 +72078,35 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+neZ
+taO
+lqh
+xjR
+neZ
+pjw
+pjw
+jsG
+vwf
+hAb
+vwf
+taO
+taO
+taO
+taO
+pjw
+pjw
+pjw
+pjw
+pjw
+pjw
+aHq
+neZ
+vwf
+vwf
+taO
+vwf
+taO
+aHq
 aTW
 aTW
 azA
@@ -70996,16 +72274,16 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (15,1,1) = {"
@@ -71103,35 +72381,35 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+vwf
+vwf
+vwf
+khZ
+vgZ
+pjw
+pjw
+neZ
+taO
+taO
+cEy
+vwf
+hAb
+cEy
+vwf
+mkQ
+pjw
+pjw
+pjw
+pjw
+aHq
+aHq
+taO
+vwf
+vwf
+vwf
+taO
+aHq
+aHq
 aTW
 azA
 azA
@@ -71166,7 +72444,7 @@ xjs
 xjs
 gbi
 eqJ
-cBf
+aoY
 cBf
 hYR
 nDM
@@ -71299,15 +72577,15 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (16,1,1) = {"
@@ -71405,35 +72683,35 @@ aTW
 aTW
 aTW
 aTW
+taO
+vwf
+taO
+vwf
+taO
+pjw
+pjw
+pjw
+pjw
+pjw
+taO
+vwf
+vwf
+vwf
+taO
+cIa
+jVF
+pjw
+pjw
+pjw
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+aHq
+aHq
+taO
+taO
+taO
+tIn
+iHG
+aHq
 aTW
 azA
 azA
@@ -71602,14 +72880,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (17,1,1) = {"
@@ -71707,35 +72985,35 @@ azA
 aTW
 aTW
 aTW
+neZ
+vwf
+taO
+taO
+taO
+neZ
+pjw
+pjw
+pjw
+pjw
+pjw
+pjw
+taO
+taO
+taO
+vwf
+vwf
+pjw
+pjw
+pjw
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+aHq
+aHq
+aHq
+bDG
+aHq
+aHq
+aHq
 aTW
 azA
 azA
@@ -71904,14 +73182,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (18,1,1) = {"
@@ -72009,33 +73287,33 @@ azA
 aTW
 aTW
 aTW
+pjw
+jVF
+vwf
+taO
+taO
+taO
+taO
+vwf
+tsv
+taO
+pjw
+pjw
+neZ
+vwf
+vwf
+vwf
+taO
+taO
+pjw
+pjw
 aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+aHq
+aHq
+aHq
 aTW
 aTW
 aTW
@@ -72206,14 +73484,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (19,1,1) = {"
@@ -72311,28 +73589,28 @@ azA
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+pjw
+cEy
+taO
+vwf
+vwf
+vwf
+vwf
+vwf
+khZ
+taO
+taO
+taO
+bwE
+vwf
+vwf
+vwf
+vwf
+vwf
+bwE
+neZ
+iPb
+mEB
 aTW
 aTW
 aTW
@@ -72509,13 +73787,13 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (20,1,1) = {"
@@ -72612,30 +73890,30 @@ azA
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+rjL
+taO
+vwf
+taO
+taO
+vwf
+taO
+taO
+taO
+taO
+vwf
+taO
+taO
+vwf
+taO
+taO
+taO
+taO
+taO
+vwf
+taO
+nma
+trA
+wCL
 aTW
 aTW
 aTW
@@ -72812,12 +74090,12 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (21,1,1) = {"
@@ -72914,29 +74192,29 @@ azA
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+taO
+taO
+cje
+aOP
+xDI
+taO
+pjw
+pjw
+jsG
+cIa
+vwf
+taO
+taO
+vwf
+taO
+vwf
+vwf
+taO
+pjw
+taO
+vwf
+vwf
+uHe
 aTW
 aTW
 aTW
@@ -73114,12 +74392,12 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (22,1,1) = {"
@@ -73216,30 +74494,30 @@ azA
 azA
 aTW
 aTW
+taO
+jhX
+qVa
+qVa
+sgb
+taO
+pjw
 aTW
 aTW
 aTW
+neZ
+taO
+taO
+kTq
+taO
+taO
+taO
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+gUl
+fbD
+taO
+vwf
+vwf
 aTW
 aTW
 aTW
@@ -73417,11 +74695,11 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (23,1,1) = {"
@@ -73518,31 +74796,31 @@ azA
 aTW
 aTW
 aTW
+taO
+nxs
+qVa
+ncu
+vwf
+taO
+neZ
 aTW
 aTW
 aTW
 aTW
 aTW
+neZ
+taO
+vwf
+neZ
 aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+oDj
+taO
+taO
+crt
+neZ
 aTW
 aTW
 aTW
@@ -73719,11 +74997,11 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (24,1,1) = {"
@@ -73819,23 +75097,23 @@ azA
 azA
 aTW
 aTW
+neZ
+taO
+oFS
+sfZ
+wRD
+taO
+neZ
 aTW
 aTW
 aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+neZ
+vwf
+taO
+neZ
 aTW
 aTW
 aTW
@@ -74022,10 +75300,10 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
+eyn
 rkv
 "}
 (25,1,1) = {"
@@ -74121,23 +75399,23 @@ uhS
 azA
 aTW
 aTW
+pjw
+lSV
+jYM
+aRK
+aRK
+lSV
 aTW
 aTW
 aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+axL
+taO
+vwf
+taO
+taO
 aTW
 aTW
 aTW
@@ -74325,9 +75603,9 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
 rkv
 "}
 (26,1,1) = {"
@@ -74423,24 +75701,24 @@ nrq
 azA
 aTW
 aTW
+pjw
+lSV
+aRK
+jYM
+jYM
+lSV
 aTW
 aTW
 aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+eqB
+vwf
+vwf
+vwf
+bwE
+hIl
 aTW
 aTW
 aTW
@@ -74627,9 +75905,9 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
 rkv
 "}
 (27,1,1) = {"
@@ -74723,26 +76001,26 @@ sPT
 cBf
 nrq
 azA
-azA
+aTW
+aTW
+pjw
+lSV
+aRK
+aRK
+geR
+lSV
 aTW
 aTW
 aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+dhZ
+taO
+taO
+vwf
+eqB
+xli
 aTW
 aTW
 aTW
@@ -74929,9 +76207,9 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
+eyn
+eyn
+eyn
 rkv
 "}
 (28,1,1) = {"
@@ -75025,14 +76303,14 @@ cBf
 cBf
 nrq
 azA
-azA
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+ydO
+vkP
+vkP
+vkP
+npY
+npY
+npY
+vkP
 aTW
 aTW
 aTW
@@ -75232,8 +76510,8 @@ azA
 azA
 azA
 azA
-azA
-azA
+eyn
+eyn
 rkv
 "}
 (29,1,1) = {"
@@ -75327,10 +76605,14 @@ wTQ
 kyp
 ctN
 azA
-azA
-azA
-azA
-azA
+ner
+vkP
+laX
+olF
+olU
+uYQ
+pGg
+vkP
 aTW
 aTW
 aTW
@@ -75339,11 +76621,7 @@ aTW
 aTW
 aTW
 aTW
-aTW
-aTW
-aTW
-aTW
-aTW
+cDx
 aTW
 aTW
 aTW
@@ -75629,14 +76907,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ner
+vkP
+fiR
+hze
+olU
+uYQ
+rjo
+vkP
 jZQ
 oDd
 qZu
@@ -75931,14 +77209,14 @@ uQH
 uQH
 uQH
 uQH
-uQH
-uQH
-fZR
-azA
-azA
-azA
-azA
-azA
+mUB
+vkP
+jiP
+sEJ
+pGg
+uYQ
+pGg
+bLJ
 fel
 oNc
 qZu
@@ -76235,12 +77513,12 @@ vkP
 vkP
 vkP
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
+jaM
+qLq
+uYQ
+uYQ
+lTG
+gHy
 jZQ
 jZQ
 wYW
@@ -76537,15 +77815,15 @@ vkP
 lCN
 fLH
 vkP
-sLI
+thA
+fkM
+pGg
+uYQ
+olU
+gHy
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-wYW
+eMa
 lri
 xyl
 jZQ
@@ -76839,13 +78117,13 @@ kiK
 lCN
 lCN
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
-azA
+vkP
+vkP
+npY
+wes
+wes
+gHy
+cXl
 azA
 wYW
 dCA
@@ -77141,12 +78419,12 @@ vkP
 uEc
 tOp
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
+nmy
+rhZ
+smK
+smK
+smK
+yky
 azA
 azA
 wYW
@@ -77443,12 +78721,12 @@ vkP
 vkP
 vkP
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
+rhc
+rhZ
+kqU
+smK
+smK
+yky
 azA
 azA
 wYW
@@ -77745,12 +79023,12 @@ vkP
 jIl
 tHr
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
+hwA
+rhZ
+kqU
+smK
+smK
+yky
 mUU
 azA
 wYW
@@ -78047,12 +79325,12 @@ kiK
 oVp
 fze
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
+qwc
+rhZ
+kqU
+kqU
+smK
+yky
 azA
 azA
 wYW
@@ -78349,12 +79627,12 @@ vkP
 cva
 irI
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
+izU
+rhZ
+kqU
+smK
+smK
+uWy
 azA
 azA
 wYW
@@ -78651,12 +79929,12 @@ vkP
 vkP
 vkP
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
+ioi
+rhZ
+smK
+kqU
+smK
+yky
 azA
 azA
 wYW
@@ -78953,12 +80231,12 @@ hxl
 vtH
 bNB
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
+ktI
+weO
+smK
+eLo
+smK
+yky
 lhS
 azA
 wYW
@@ -79255,12 +80533,12 @@ mnX
 vtH
 hxl
 xCz
-sLI
-azA
-azA
-jHW
-azA
-azA
+hwA
+arq
+smK
+kqU
+smK
+yky
 shi
 azA
 wYW
@@ -79557,12 +80835,12 @@ jhP
 ovf
 bNB
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
+hwA
+lcl
+kqU
+eLo
+smK
+yky
 azA
 azA
 wYW
@@ -79859,12 +81137,12 @@ vkP
 vkP
 vkP
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
+aSa
+kUI
+kqU
+smK
+smK
+yky
 azA
 azA
 wYW
@@ -80149,24 +81427,24 @@ ucp
 ucp
 vkP
 vkP
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+sgn
+qMB
+qMB
+qMB
+qMB
+qMB
+qMB
+qMB
+qMB
+qMB
+ydO
+ahs
+aSa
+arq
+smK
+kqU
+smK
+yky
 azA
 azA
 wYW
@@ -80451,6 +81729,7 @@ fpJ
 bjI
 dqC
 vkP
+sLI
 azA
 azA
 azA
@@ -80460,15 +81739,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ner
+ahs
+hwA
+nbU
+smK
+smK
+smK
+yky
 mUU
 azA
 wYW
@@ -80753,7 +82031,7 @@ dtH
 qHt
 dtH
 vkP
-azA
+sLI
 azA
 azA
 azA
@@ -80763,14 +82041,14 @@ azA
 azA
 azA
 ohQ
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ner
+ahs
+hwA
+kPz
+smK
+smK
+kqU
+mae
 azA
 azA
 wYW
@@ -81055,6 +82333,7 @@ vkP
 vkP
 vkP
 vkP
+sLI
 azA
 azA
 azA
@@ -81064,15 +82343,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ner
+ahs
+hwA
+kPz
+smK
+smK
+smK
+mae
 azA
 azA
 wYW
@@ -81348,16 +82626,16 @@ vPQ
 vPQ
 bhz
 vkP
-sLI
-azA
-azA
-azA
-azA
-azA
-ohQ
-azA
-azA
-azA
+sgn
+qMB
+qMB
+qMB
+qMB
+qMB
+uAe
+qMB
+qMB
+nqZ
 azA
 azA
 aUc
@@ -81367,14 +82645,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ner
+ahs
+hwA
+rhZ
+kqU
+smK
+smK
+yky
 azA
 azA
 wYW
@@ -81669,14 +82947,14 @@ azA
 azA
 jXc
 azA
-azA
-qtW
-azA
-azA
-azA
-azA
-azA
-azA
+ner
+cht
+hwA
+rhZ
+kqU
+smK
+smK
+mae
 azA
 azA
 wYW
@@ -81971,14 +83249,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ner
+ahs
+hwA
+rhZ
+kqU
+smK
+kqU
+yky
 mUU
 azA
 wYW
@@ -82273,14 +83551,14 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ner
+ahs
+hwA
+rhZ
+mjp
+aMj
+mjp
+yky
 azA
 azA
 wYW
@@ -82575,14 +83853,14 @@ azA
 azA
 azA
 slm
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ner
+ahs
+hwA
+rhZ
+luk
+nOi
+cNV
+yky
 azA
 azA
 wYW
@@ -82877,14 +84155,14 @@ axO
 vgK
 ijk
 axO
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+mUB
+ahs
+hwA
+rhZ
+gtc
+lxu
+cNV
+yky
 azA
 ohQ
 wYW
@@ -83180,13 +84458,13 @@ mBm
 xom
 eTC
 axO
-uQH
-fZR
-azA
-azA
-azA
-azA
-azA
+ahs
+hwA
+kPz
+gtc
+ybl
+luk
+yky
 azA
 azA
 wYW
@@ -83483,12 +84761,12 @@ rdk
 rPH
 axO
 axO
-sLI
-azA
-azA
-azA
-azA
-azA
+aSa
+rhZ
+luk
+luk
+luk
+yky
 azA
 azA
 wYW
@@ -83785,12 +85063,12 @@ jkv
 rdk
 nvC
 wWn
-sLI
-azA
-azA
-azA
-azA
-azA
+hwA
+rhZ
+hiH
+kFH
+hiH
+yky
 azA
 azA
 wYW
@@ -84087,12 +85365,12 @@ rdk
 rdk
 ybL
 xaK
-sLI
-azA
-azA
-azA
-azA
-azA
+hwA
+rhZ
+smK
+kqU
+smK
+yky
 azA
 azA
 wYW
@@ -84389,12 +85667,12 @@ pyY
 fOT
 axO
 axO
-sLI
-azA
-azA
-azA
-azA
-azA
+hwA
+rhZ
+smK
+kqU
+smK
+yky
 azA
 azA
 wYW
@@ -84691,12 +85969,12 @@ kSD
 axO
 axO
 qOr
-kAJ
-fZR
-azA
-azA
-azA
-azA
+hwA
+kPz
+kqU
+kqU
+smK
+yky
 azA
 azA
 azA
@@ -84993,12 +86271,12 @@ vgK
 axO
 qOr
 cMW
-nQO
-sLI
-azA
-azA
-azA
-azA
+hwA
+rhZ
+kqU
+kqU
+smK
+yky
 azA
 azA
 lhS
@@ -85294,13 +86572,13 @@ wsd
 wsd
 wsd
 wsd
-wsd
-wsd
-wsd
-wsd
-wsd
-wsd
-wsd
+hwA
+hwA
+rhZ
+smK
+kqU
+smK
+bho
 wsd
 wsd
 wsd
@@ -85598,11 +86876,11 @@ eAw
 eAw
 nQB
 eAw
-eAw
-eAw
-eAw
-eAw
-eAw
+qwL
+smK
+smK
+smK
+rzw
 eAw
 eAw
 eAw
@@ -85902,7 +87180,7 @@ smK
 smK
 smK
 smK
-smK
+kqU
 smK
 smK
 smK
@@ -86203,8 +87481,8 @@ smK
 smK
 smK
 smK
-smK
-smK
+kqU
+kqU
 smK
 smK
 smK
@@ -86504,8 +87782,8 @@ smK
 smK
 smK
 smK
-smK
-smK
+kqU
+kqU
 smK
 smK
 smK
@@ -120049,7 +121327,7 @@ cBf
 cBf
 cBf
 cBf
-cBf
+kGJ
 kGJ
 kGJ
 kGJ
@@ -120366,7 +121644,7 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
 cBf
 cBf
 kiP
@@ -120960,7 +122238,6 @@ cBf
 cBf
 xXx
 cBf
-cBf
 kGJ
 kGJ
 kGJ
@@ -120972,7 +122249,8 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
+kGJ
 cBf
 cBf
 cBf
@@ -121611,6 +122889,7 @@ kGJ
 kGJ
 kGJ
 kGJ
+kGJ
 cBf
 cBf
 cBf
@@ -121618,12 +122897,11 @@ cBf
 cBf
 cBf
 cBf
-cBf
-kiP
-rDi
-rDi
-rDi
-rDi
+nrq
+azA
+azA
+azA
+ndZ
 rDi
 rDi
 rDi
@@ -121921,11 +123199,11 @@ kGJ
 kGJ
 kGJ
 cBf
-cBf
-cBf
-cBf
-cBf
-cBf
+kiP
+rDi
+rDi
+rDi
+dPr
 cBf
 cBf
 cBf
@@ -122222,21 +123500,21 @@ kGJ
 kGJ
 kGJ
 kGJ
+kGJ
 cBf
 cBf
 cBf
 cBf
 cBf
 cBf
-cBf
-cBf
-cBf
-cBf
-cBf
-cBf
-cBf
-cBf
-cBf
+kGJ
+kGJ
+kGJ
+kGJ
+kGJ
+kGJ
+kGJ
+kGJ
 cBf
 cBf
 cBf
@@ -123712,7 +124990,7 @@ cBf
 cBf
 cBf
 cBf
-cBf
+kGJ
 kGJ
 kGJ
 kGJ
@@ -124324,7 +125602,7 @@ cBf
 cBf
 cBf
 cBf
-cBf
+kGJ
 kGJ
 kGJ
 kGJ
@@ -124371,7 +125649,7 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
 cBf
 cBf
 cBf
@@ -124874,7 +126152,7 @@ rlV
 rlV
 wuZ
 xXx
-xXx
+cBf
 cBf
 kGJ
 kGJ
@@ -125175,7 +126453,7 @@ nAl
 nAl
 nAl
 oeA
-xXx
+cBf
 cBf
 cBf
 kGJ
@@ -125284,7 +126562,7 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
 kGJ
 kGJ
 cBf
@@ -125476,10 +126754,10 @@ xXx
 xXx
 xXx
 xXx
-xXx
 cBf
 cBf
 cBf
+kGJ
 kGJ
 kGJ
 kGJ
@@ -125545,11 +126823,11 @@ cBf
 cBf
 cBf
 cBf
-cBf
-cBf
-cBf
-cBf
-cBf
+kGJ
+kGJ
+kGJ
+kGJ
+kGJ
 cBf
 cBf
 cBf
@@ -125611,7 +126889,7 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
 cBf
 cBf
 cBf
@@ -125799,7 +127077,7 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
 cBf
 smK
 eUj
@@ -125846,13 +127124,13 @@ wTQ
 wTQ
 wTQ
 wTQ
-wTQ
-wTQ
-wTQ
-wTQ
-wTQ
-wTQ
-wTQ
+jbl
+cBf
+cBf
+cBf
+cBf
+cBf
+nDt
 wTQ
 wTQ
 wTQ
@@ -125876,7 +127154,7 @@ cBf
 cBf
 cBf
 cBf
-cBf
+kGJ
 kGJ
 kGJ
 kGJ
@@ -125921,7 +127199,7 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
 cBf
 cBf
 cBf
@@ -126079,7 +127357,7 @@ xXx
 xXx
 tkN
 xXx
-xXx
+cBf
 cBf
 cBf
 kGJ
@@ -126148,13 +127426,13 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+gAg
+wTQ
+wTQ
+wTQ
+wTQ
+wTQ
+ctN
 azA
 azA
 azA
@@ -126265,7 +127543,7 @@ azA
 azA
 azA
 snR
-cBf
+kGJ
 kGJ
 kGJ
 cBf
@@ -126565,9 +127843,9 @@ azA
 azA
 azA
 azA
-azA
-snR
-cBf
+ndZ
+dPr
+kGJ
 kGJ
 kGJ
 cBf
@@ -126679,7 +127957,7 @@ xXx
 bQt
 tkN
 xXx
-xXx
+cBf
 cBf
 cBf
 kGJ
@@ -126785,7 +128063,7 @@ gAg
 jbl
 cBf
 cBf
-cBf
+kGJ
 kGJ
 kGJ
 kGJ
@@ -126867,9 +128145,9 @@ rDi
 rDi
 rDi
 rDi
-rDi
 dPr
 cBf
+kGJ
 kGJ
 kGJ
 cBf
@@ -126980,11 +128258,11 @@ xXx
 xXx
 xXx
 xXx
-xXx
-xXx
 cBf
 cBf
 cBf
+kGJ
+kGJ
 kGJ
 kGJ
 kGJ
@@ -127141,7 +128419,7 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
 cBf
 cBf
 cBf
@@ -127170,11 +128448,11 @@ cBf
 cBf
 cBf
 cBf
+kGJ
+kGJ
+kGJ
+kGJ
 cBf
-kGJ
-kGJ
-kGJ
-kGJ
 cBf
 cBf
 cBf
@@ -127279,7 +128557,7 @@ tkN
 xXx
 xXx
 xXx
-xXx
+cBf
 cBf
 cBf
 cBf
@@ -127469,16 +128747,16 @@ ahs
 qfO
 cBf
 cBf
+kGJ
+kGJ
+kGJ
+kGJ
+kGJ
+kGJ
 cBf
-kGJ
-kGJ
-kGJ
-kGJ
-kGJ
-kGJ
-kGJ
-kGJ
-kGJ
+cBf
+cBf
+cBf
 cBf
 rkv
 "}
@@ -127775,11 +129053,11 @@ kGJ
 kGJ
 kGJ
 kGJ
-kGJ
-kGJ
-kGJ
-kGJ
-kGJ
+cBf
+cBf
+cBf
+cBf
+cBf
 kGJ
 kGJ
 gXH
@@ -127907,7 +129185,7 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
 cBf
 cBf
 cBf
@@ -128075,12 +129353,12 @@ kGJ
 kGJ
 kGJ
 kGJ
-kGJ
-kGJ
-kGJ
-kGJ
-kGJ
-kGJ
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
 kGJ
 kGJ
 kGJ
@@ -128329,7 +129607,7 @@ cBf
 cBf
 cBf
 cBf
-cBf
+kGJ
 kGJ
 kGJ
 kGJ
@@ -128452,10 +129730,10 @@ rlV
 rlV
 rlV
 rlV
-gqv
-xXx
-pfB
-qRE
+oUL
+aVP
+xKW
+mzS
 juP
 rlV
 rlV
@@ -128752,20 +130030,20 @@ lpG
 juP
 xgT
 rlV
-lpG
-qRE
-jxR
-xXx
-xXx
-jxR
-hrk
+eSY
+rlV
+nju
 rlV
 rlV
-sap
-qRE
-qRE
-qRE
-qRE
+nju
+aNG
+rlV
+rlV
+nFM
+mzS
+mzS
+mzS
+mzS
 qRE
 qRE
 qRE
@@ -129055,20 +130333,20 @@ hrk
 uji
 loM
 gqv
-xXx
-xXx
-tUE
-xXx
-xXx
-xXx
-sap
 qRE
-xXx
-jxR
-xXx
-xXx
-xXx
-xXx
+qRE
+gJX
+fcB
+rlV
+rlV
+sap
+bim
+rlV
+nju
+rlV
+rlV
+rlV
+vHe
 feo
 xXx
 xXx
@@ -129084,7 +130362,7 @@ xXx
 xXx
 xXx
 xXx
-xXx
+cBf
 cBf
 cBf
 kGJ
@@ -129361,17 +130639,17 @@ eZr
 thD
 bYD
 oAl
-oAl
-oAl
-oAl
-oAl
+fgv
+fgv
+fgv
+fgv
 vut
-xXx
-xXx
-pfB
-xXx
-xXx
-xXx
+qRE
+qRE
+asa
+rlV
+rlV
+vHe
 xXx
 xXx
 xXx
@@ -129408,7 +130686,7 @@ vtz
 kGJ
 kGJ
 kGJ
-pFV
+vtz
 cBf
 cBf
 cBf
@@ -129671,10 +130949,10 @@ dUy
 xXx
 xXx
 xXx
-xXx
-xXx
-xXx
-xXx
+fcB
+rlV
+rlV
+vHe
 xXx
 xXx
 xXx
@@ -129974,14 +131252,14 @@ xXx
 nkz
 ilz
 lqz
-xXx
-xXx
-xXx
-xXx
-feo
-xXx
-tkN
-xXx
+fcB
+rlV
+rlV
+vHe
+dJZ
+cBf
+cbW
+cBf
 xXx
 xXx
 cBf
@@ -130011,7 +131289,7 @@ kGJ
 kGJ
 kGJ
 kGJ
-kGJ
+cBf
 cBf
 lbm
 qrC
@@ -130163,8 +131441,8 @@ cBf
 cBf
 cBf
 cBf
-cBf
-cBf
+kGJ
+kGJ
 kGJ
 kGJ
 kGJ
@@ -130277,14 +131555,14 @@ lBz
 uIF
 uIF
 lqz
-xXx
-xXx
-xXx
-xXx
-xXx
-xXx
-xXx
-xXx
+fcB
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
 cBf
 cBf
 cBf
@@ -130467,9 +131745,9 @@ cBf
 cBf
 cBf
 cBf
-cBf
-cBf
-mCE
+kGJ
+kGJ
+pZA
 bho
 wsd
 wsd
@@ -130491,7 +131769,7 @@ wGm
 wGm
 jRp
 pIU
-cBf
+kGJ
 kGJ
 kGJ
 kGJ
@@ -130580,13 +131858,13 @@ hgo
 uIF
 jFC
 pfB
-xXx
-feo
-xXx
-xXx
-xXx
-xXx
-xXx
+cBf
+dJZ
+cBf
+kGJ
+kGJ
+cBf
+rtu
 cBf
 cBf
 kGJ
@@ -130793,14 +132071,14 @@ sii
 wQY
 cFQ
 pIU
-cBf
 kGJ
 kGJ
 kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
+kGJ
 cBf
 rkv
 "}
@@ -130881,14 +132159,14 @@ xXx
 jxR
 iHD
 xXx
-xXx
-xXx
-vLn
-xXx
-xXx
 cBf
-cBf
-cBf
+jjw
+gUt
+kGJ
+kGJ
+kGJ
+kGJ
+uax
 cBf
 kGJ
 kGJ
@@ -131096,12 +132374,12 @@ mQw
 gEA
 pIU
 cBf
-cBf
 kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
+kGJ
 cBf
 rRz
 rkv
@@ -131183,12 +132461,14 @@ xXx
 xXx
 feo
 xXx
-xXx
-xXx
-xXx
-xXx
 cBf
-cBf
+jJJ
+jJJ
+jJJ
+kGJ
+kGJ
+kGJ
+cxe
 kGJ
 kGJ
 kGJ
@@ -131211,8 +132491,6 @@ kGJ
 kGJ
 kGJ
 kGJ
-kGJ
-cBf
 cBf
 cBf
 cBf
@@ -131485,14 +132763,14 @@ tkN
 eSP
 xXx
 jxR
-xXx
-xXx
-xXx
-xXx
 cBf
+awu
+awu
 kGJ
 kGJ
 kGJ
+kGJ
+cxe
 kGJ
 kGJ
 kGJ
@@ -131788,13 +133066,13 @@ xXx
 xXx
 xXx
 xXx
-xXx
-xXx
 cBf
 cBf
+cBf
 kGJ
 kGJ
 kGJ
+cxe
 kGJ
 kGJ
 kGJ
@@ -132093,10 +133371,10 @@ xXx
 cBf
 cBf
 cBf
-kGJ
-kGJ
-kGJ
-kGJ
+daI
+hhh
+iby
+bhQ
 kGJ
 kGJ
 kGJ
@@ -133291,7 +134569,7 @@ crd
 xXx
 xXx
 pfB
-xXx
+cBf
 cBf
 kGJ
 kGJ
@@ -133311,7 +134589,7 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
 cBf
 cBf
 cBf
@@ -134215,7 +135493,7 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
+kGJ
 cBf
 cBf
 cBf
@@ -135399,7 +136677,7 @@ xXx
 xXx
 feo
 xXx
-xXx
+cBf
 cBf
 cBf
 kGJ
@@ -140798,7 +142076,7 @@ xXx
 xXx
 xXx
 xXx
-xXx
+cBf
 cBf
 cBf
 cBf
@@ -141097,7 +142375,7 @@ xXx
 xXx
 xXx
 xXx
-xXx
+cBf
 cBf
 cBf
 cBf
@@ -141993,8 +143271,8 @@ xXx
 cBf
 cBf
 cBf
-xXx
-xXx
+cBf
+cBf
 cBf
 cBf
 cBf
@@ -142287,7 +143565,7 @@ cBf
 cBf
 cBf
 cBf
-xXx
+cBf
 xXx
 cBf
 cBf
@@ -142585,14 +143863,14 @@ rkv
 (252,1,1) = {"
 rkv
 cBf
+pFV
 cBf
 cBf
 cBf
 cBf
 cBf
 cBf
-cBf
-cBf
+pFV
 cBf
 cBf
 kGJ
@@ -142915,7 +144193,7 @@ kGJ
 eZE
 kGJ
 cBf
-cBf
+pFV
 cBf
 cBf
 cBf
@@ -143811,8 +145089,8 @@ kGJ
 kGJ
 kGJ
 kGJ
-cBf
-cBf
+pFV
+pFV
 cBf
 cBf
 cBf
@@ -144110,7 +145388,7 @@ kGJ
 cBf
 cBf
 cBf
-cBf
+pFV
 cBf
 kGJ
 cBf
@@ -145001,9 +146279,9 @@ rkv
 (260,1,1) = {"
 rkv
 cBf
+pFV
 cBf
-cBf
-cBf
+pFV
 cBf
 cBf
 cBf

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
@@ -5,10 +5,23 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker/bunkerfive)
+"aaw" = (
+/obj/structure/junk/locker,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/sewer/powered)
 "aaC" = (
 /obj/item/trash/tray,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"aaE" = (
+/obj/machinery/autolathe/constructionlathe,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/sewer/powered)
 "aaL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light{
@@ -31,6 +44,12 @@
 	icon_state = "redmark"
 	},
 /area/ruin/powered)
+"abh" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "abq" = (
 /obj/structure/simple_door/metal/ventilation,
 /obj/structure/cable{
@@ -295,6 +314,14 @@
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
+"ahH" = (
+/obj/machinery/porta_turret/f13/turret_shotgun/raider{
+	dir = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/sewer/powered)
 "ahX" = (
 /obj/effect/gibspawner/robot,
 /obj/structure/fluff/railing{
@@ -302,6 +329,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/bunker/bunkereight)
+"aib" = (
+/obj/effect/overlay/junk/oldpipes,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "aii" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /obj/effect/decal/cleanable/dirt,
@@ -332,6 +364,20 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"aiz" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 4;
+	icon_state = "f13foldupchair"
+	},
+/obj/effect/decal/cleanable/shreds{
+	pixel_x = 9;
+	pixel_y = -11
+	},
+/mob/living/simple_animal/hostile/renegade/grunt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "aiA" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -381,6 +427,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerfive)
+"aji" = (
+/obj/machinery/porta_turret/f13/turret_9mm/burstfire/raider,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/sewer/powered)
 "ajA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small,
@@ -416,6 +470,17 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"akd" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/sewer/powered)
+"aki" = (
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "akv" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -479,6 +544,15 @@
 /obj/item/clothing/head/helmet/f13/power_armor/t45d,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"ama" = (
+/obj/machinery/autolathe/constructionlathe,
+/obj/structure/decoration/clock{
+	pixel_y = 27
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/sewer/powered)
 "amw" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -729,6 +803,12 @@
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"arZ" = (
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "asn" = (
 /obj/machinery/light{
 	dir = 4;
@@ -840,6 +920,15 @@
 "auJ" = (
 /turf/closed/indestructible/rock,
 /area/f13/bunker/bunkerthree)
+"auS" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "auV" = (
 /obj/structure/disposalpipe/broken{
 	dir = 4
@@ -850,6 +939,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"auY" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/sewer/powered)
 "ava" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1081,6 +1179,11 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"aAt" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/ncr_k_ration,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "aAy" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -1093,6 +1196,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"aBf" = (
+/obj/structure/lattice,
+/obj/structure/junk/small/bed,
+/mob/living/simple_animal/hostile/renegade/guardian,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "aBi" = (
 /obj/structure/rack,
 /obj/item/stack/spacecash/c1000,
@@ -1210,6 +1319,10 @@
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"aEc" = (
+/obj/structure/junk/locker,
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "aEe" = (
 /obj/structure/barricade/train{
 	dir = 4
@@ -1395,6 +1508,14 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/vault/atrium)
+"aIR" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/mre,
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "aIT" = (
 /obj/machinery/light{
 	dir = 8
@@ -1489,6 +1610,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault)
+"aKY" = (
+/obj/structure/table,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/sewer/powered)
 "aLb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/cola,
@@ -1816,6 +1943,12 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/radiation)
+"aSo" = (
+/obj/machinery/door/locked/regular/maybe_trapped,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "aSq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
@@ -1902,6 +2035,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/ruin/powered)
+"aUp" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood/house,
+/area/f13/sewer/powered)
 "aUs" = (
 /obj/machinery/door/password{
 	door_id = "blacice"
@@ -1929,6 +2066,16 @@
 /obj/structure/barricade/concrete,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"aVu" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "aVH" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -1938,6 +2085,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"aVU" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet{
+	pixel_x = 8;
+	pixel_y = 14
+	},
+/obj/structure/filingcabinet{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "aVV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/three_barrels,
@@ -2168,6 +2328,14 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/f13,
 /area/f13/vault)
+"bbq" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/sewer/powered)
 "bbx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepiletwo,
@@ -2421,6 +2589,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
+"biw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "biC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -2534,6 +2707,11 @@
 	icon_state = "mosaic_dark-broken4"
 	},
 /area/f13/building/abandoned/o)
+"bmm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "bmX" = (
 /obj/machinery/bloodbankgen,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -2575,6 +2753,14 @@
 	icon_state = "redmark"
 	},
 /area/f13/enclave)
+"bnL" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
+	},
+/area/f13/sewer/powered)
 "bnU" = (
 /obj/machinery/light/small{
 	light_color = "red"
@@ -2585,6 +2771,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"bnV" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "bod" = (
 /obj/structure/mirror{
 	pixel_y = 29
@@ -2652,6 +2847,11 @@
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/ruins,
 /area/f13/sewer)
+"boT" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "boY" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/machinery/light/small{
@@ -2702,6 +2902,16 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"bqs" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "bqw" = (
 /obj/structure/lattice,
 /obj/machinery/door/airlock/hatch,
@@ -3050,6 +3260,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/sewer)
+"bBz" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bBA" = (
 /obj/structure/table/wood,
 /obj/item/blueprint/research,
@@ -3064,6 +3280,12 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"bBZ" = (
+/obj/structure/wreck/trash/four_barrels{
+	pixel_x = 3
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "bCa" = (
 /obj/structure/decoration/vent/rusty,
 /turf/closed/wall/rust,
@@ -3095,6 +3317,12 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"bCW" = (
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/sewer/powered)
 "bCY" = (
 /obj/effect/gibspawner/human,
 /obj/item/target,
@@ -3212,6 +3440,14 @@
 "bGd" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault/medical/breakroom)
+"bGo" = (
+/obj/machinery/porta_turret/f13/turret_9mm/raider{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "bGp" = (
 /obj/structure/fluff/hedge,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -3258,6 +3494,10 @@
 /mob/living/simple_animal/hostile/ghoul/soldier/armored,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
+"bIa" = (
+/obj/structure/junk/cabinet,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "bIc" = (
 /mob/living/simple_animal/hostile/ghoul/legendary,
 /turf/open/floor/plating/rust,
@@ -3359,6 +3599,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault/diner)
+"bKS" = (
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
+/area/f13/sewer/powered)
 "bKU" = (
 /obj/structure/table,
 /obj/item/book/granter/crafting_recipe/gunsmith_one,
@@ -3369,6 +3613,12 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker/bighornbunker)
+"bKZ" = (
+/obj/machinery/autolathe/ammo/unlocked_basic,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/sewer/powered)
 "bLc" = (
 /mob/living/simple_animal/hostile/handy,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -3414,6 +3664,10 @@
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"bMm" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/f13/ruins,
+/area/f13/sewer/powered)
 "bMp" = (
 /obj/structure/closet/crate/bin/trashbin,
 /obj/machinery/light{
@@ -3740,6 +3994,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"bTt" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "bTV" = (
 /mob/living/simple_animal/hostile/handy/assaultron,
 /turf/open/floor/plasteel/dark,
@@ -3798,6 +4058,13 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
+"bWd" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "bWf" = (
 /obj/structure/table,
 /obj/item/defibrillator/loaded,
@@ -3905,6 +4172,15 @@
 "bYS" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/sewer)
+"bYX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "bZh" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/wreck/trash/five_tires,
@@ -4292,6 +4568,21 @@
 	dir = 8
 	},
 /area/f13/vault/atrium)
+"chS" = (
+/obj/structure/lattice,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
+"cig" = (
+/obj/structure/ore_box,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "cim" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
@@ -4363,6 +4654,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
+"cju" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "cjN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/doorButtons/vaultButton/external,
@@ -4419,6 +4714,18 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/abandoned/o)
+"cln" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/obj/structure/filingcabinet{
+	pixel_x = -10;
+	pixel_y = -6
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "clp" = (
 /obj/structure/vaultdoor{
 	name = "vault 113 door";
@@ -4435,6 +4742,12 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/enclave)
+"clI" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/sewer/powered)
 "clL" = (
 /obj/structure/window/reinforced/fulltile/indestructable{
 	can_be_unanchored = 0
@@ -4469,6 +4782,9 @@
 /obj/machinery/rnd/server/vault,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/science)
+"cma" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "cmM" = (
 /obj/effect/turf_decal/caution/stand_clear/white,
 /obj/effect/decal/cleanable/dirt,
@@ -4746,6 +5062,10 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/ruin/powered)
+"cuy" = (
+/obj/structure/table/wood,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "cuK" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -4802,6 +5122,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"cwi" = (
+/obj/machinery/mech_bay_recharge_port,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "cwv" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib3-old"
@@ -4848,6 +5174,10 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
+"cxn" = (
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "cxu" = (
 /obj/structure/chair/comfy/modern{
 	dir = 4
@@ -4896,6 +5226,13 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"cyf" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "cyq" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -5075,6 +5412,14 @@
 "cCS" = (
 /turf/closed/wall/rust,
 /area/f13/bar/heaven)
+"cCY" = (
+/obj/structure/chair/f13foldupchair,
+/obj/effect/decal/cleanable/cobweb,
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "cDu" = (
 /obj/structure/window/reinforced/fulltile/indestructable{
 	can_be_unanchored = 0
@@ -5261,6 +5606,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/abandoned/o)
+"cJm" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "cJo" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/machinery/light/fo13colored/Aqua{
@@ -5341,6 +5693,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault/reactor)
+"cLC" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
+"cLM" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "cLN" = (
 /obj/machinery/shower{
 	dir = 8
@@ -5480,6 +5840,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"cPM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/concrete,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "cPQ" = (
 /mob/living/simple_animal/hostile/deathclaw/legendary,
 /turf/open/indestructible/ground/inside/subway,
@@ -5507,6 +5872,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/side,
 /area/f13/vault/medical)
+"cQh" = (
+/obj/structure/barricade/wooden,
+/turf/closed/mineral/random/no_caves,
+/area/f13/sewer/powered)
 "cQo" = (
 /obj/structure/shelf_wood,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5522,6 +5891,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/bunker/bunkereight)
+"cQD" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/fun_police{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "cQE" = (
 /obj/effect/landmark/start/f13/raider,
 /obj/effect/overlay/junk/oldpipes,
@@ -5554,6 +5935,13 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/vault/diner)
+"cRd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/concrete,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "cRg" = (
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
@@ -5804,6 +6192,15 @@
 /obj/machinery/vending/wardrobe/chem_wardrobe/free,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/white,
 /area/f13/vault/science)
+"cXV" = (
+/mob/living/simple_animal/hostile/handy/gutsy/flamer{
+	health = 700
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "cYb" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -6555,6 +6952,14 @@
 /obj/effect/decal/cleanable/chem_pile,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"doR" = (
+/obj/structure/wreck/trash/halftire{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "dpa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -6730,6 +7135,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/overseer)
+"dsF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "dtl" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -6818,6 +7229,12 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
+"dwg" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "dwn" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/indestructible/ground/inside/subway,
@@ -6907,6 +7324,12 @@
 	dir = 8
 	},
 /area/f13/radiation)
+"dyg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "dyk" = (
 /obj/structure/rack/shelf_metal{
 	dir = 4
@@ -6995,6 +7418,16 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker/bunkerthree)
+"dAS" = (
+/obj/effect/decal/cleanable/oil,
+/obj/item/stack/sheet/plasteel/five,
+/obj/item/stack/sheet/plasteel/five,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "dBd" = (
 /obj/structure/sink{
 	dir = 8;
@@ -7106,6 +7539,21 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
+"dDu" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/sewer/powered)
+"dDD" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/sewer/powered)
 "dDI" = (
 /obj/machinery/rnd/production/protolathe,
 /obj/structure/sign/poster/prewar/poster94{
@@ -7333,6 +7781,10 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault/science)
+"dIR" = (
+/obj/structure/lattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "dIT" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
@@ -7687,6 +8139,15 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"dRX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
+"dSe" = (
+/obj/structure/flora/rock/pile/largejungle,
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dSs" = (
 /obj/effect/overlay/junk/oldpipes,
 /obj/effect/decal/cleanable/dirt,
@@ -7845,6 +8306,10 @@
 	light_range = 4
 	},
 /area/ruin/powered)
+"dWe" = (
+/obj/structure/sign/poster/ripped,
+/turf/closed/wall/f13/wood,
+/area/f13/sewer/powered)
 "dWx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/no_caves,
@@ -7928,6 +8393,16 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/radiation)
+"dXG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	pixel_y = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "dXO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/red/line{
@@ -7952,6 +8427,14 @@
 	dir = 5
 	},
 /area/f13/vault/atrium)
+"dZh" = (
+/obj/machinery/porta_turret/f13/turret_9mm/burstfire/raider{
+	dir = 9
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "dZm" = (
 /turf/open/floor/f13,
 /area/ruin/powered)
@@ -8140,6 +8623,18 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"ees" = (
+/obj/structure/lattice,
+/obj/structure/barricade/concrete,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
+"eeE" = (
+/obj/effect/overlay/junk/oldpipes{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "eeH" = (
 /obj/structure/chair/stool/retro/backed{
 	dir = 8
@@ -8236,6 +8731,17 @@
 /obj/item/stack/sheet/mineral/gold/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker/bunkerthree)
+"ehK" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/porta_turret/f13/turret_shotgun/raider{
+	dir = 10
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "ehX" = (
 /obj/structure/campfire/barrel{
 	pixel_x = -8;
@@ -8243,6 +8749,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"eie" = (
+/obj/structure/fence/end{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "eit" = (
 /obj/structure/table,
 /obj/item/clothing/under/f13/combat,
@@ -8295,6 +8808,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/sewer)
+"eiT" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/sewer/powered)
 "ejd" = (
 /obj/machinery/shower{
 	dir = 4
@@ -8323,6 +8842,18 @@
 	name = "rusty reinforced wall"
 	},
 /area/f13/tunnel)
+"ejC" = (
+/obj/structure/sign/poster/contraband/donut_corp{
+	pixel_x = 32
+	},
+/obj/structure/barricade/concrete,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/wreck/trash/bus_door{
+	pixel_y = -13;
+	pixel_x = -9
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "ejE" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden,
@@ -8775,6 +9306,13 @@
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/f13,
 /area/ruin/powered)
+"eve" = (
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/renegade/soldier,
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "evf" = (
 /mob/living/simple_animal/hostile/handy/protectron{
 	auto_fire_delay = 2;
@@ -8860,6 +9398,10 @@
 /obj/structure/grille/indestructable,
 /turf/open/floor/f13,
 /area/ruin/powered)
+"exg" = (
+/obj/structure/wreck/trash/four_barrels,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "exi" = (
 /obj/effect/gibspawner/human,
 /obj/machinery/computer/terminal{
@@ -8966,6 +9508,22 @@
 /obj/machinery/mecha_part_fabricator,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"ezX" = (
+/obj/effect/decal/waste{
+	pixel_x = 20;
+	pixel_y = 1
+	},
+/obj/effect/decal/waste{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "ezZ" = (
 /obj/item/papercutter,
 /obj/structure/table{
@@ -9046,6 +9604,13 @@
 /obj/structure/chair/left,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/enclave)
+"eCe" = (
+/obj/structure/timeddoor,
+/obj/structure/decoration/warning{
+	name = "WARNING: LEADER AHEAD"
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/sewer/powered)
 "eCk" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
@@ -9288,6 +9853,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"eGo" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "eGH" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -9381,6 +9954,11 @@
 /obj/structure/lattice,
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
+"eIB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/wreck/trash/autoshaft,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "eIC" = (
 /obj/structure/chair/f13foldupchair,
 /obj/item/restraints/handcuffs/cable/zipties/used,
@@ -9510,6 +10088,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/bunker/bunkereight)
+"eLJ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "eLL" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/hypospray/medipen/medx,
@@ -9972,6 +10555,10 @@
 /obj/item/gun/energy/laser/wattz/magneto,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/ruin/powered)
+"eVl" = (
+/obj/structure/table,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "eVx" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10032,6 +10619,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/carpet,
 /area/f13/shack)
+"eYk" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "eYo" = (
 /obj/structure/stairs/south,
 /turf/open/floor/plasteel/dark,
@@ -10104,6 +10695,13 @@
 /obj/effect/decal/cleanable/flour,
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
+"eZv" = (
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_9";
+	pixel_y = 20
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "eZI" = (
 /obj/structure/window/reinforced/fulltile/indestructable{
 	can_be_unanchored = 0
@@ -10245,6 +10843,14 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"fep" = (
+/obj/effect/decal/waste{
+	pixel_x = 20;
+	pixel_y = 1
+	},
+/obj/structure/light_construct,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "fes" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plasteel/dark,
@@ -10347,6 +10953,11 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
+"fgF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "fgK" = (
 /obj/structure/ore_box,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -10425,6 +11036,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/atrium)
+"fiF" = (
+/obj/structure/decoration/vent,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "fiO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -10482,6 +11099,13 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"fki" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/traitbooks/low,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "fkv" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/camera/autoname{
@@ -10523,6 +11147,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/bunker/bunkerthree)
+"fln" = (
+/obj/machinery/porta_turret/f13/turret_556/burstfire/raider{
+	dir = 9
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/sewer/powered)
 "flU" = (
 /obj/structure/closet/crate{
 	anchored = 1
@@ -10559,6 +11191,10 @@
 	dir = 8
 	},
 /area/f13/vault/security)
+"fmS" = (
+/obj/structure/junk/machinery,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "fnc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10624,6 +11260,21 @@
 	icon_state = "tealwhrusty_chess2"
 	},
 /area/f13/brotherhood/leisure)
+"foK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
+"foN" = (
+/obj/structure/table,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/sewer/powered)
 "foP" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
 	dir = 1
@@ -10783,6 +11434,14 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"fuj" = (
+/obj/effect/decal/cleanable/blood/gibs/human,
+/obj/structure/wreck/trash/four_barrels{
+	pixel_y = 11;
+	pixel_x = -2
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "fuB" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -11014,6 +11673,16 @@
 /obj/machinery/pool/drain,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/dormitory)
+"fzv" = (
+/obj/structure/table,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "fzB" = (
 /obj/structure/table/wood/poker{
 	name = "felt table"
@@ -11327,6 +11996,14 @@
 	icon_state = "yellowdirtysolid"
 	},
 /area/f13/bunker/bunkerfive)
+"fFQ" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/structure/girder,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "fFR" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/structure/rack/large/shelf_rust,
@@ -11519,6 +12196,9 @@
 	},
 /turf/open/water,
 /area/f13/sewer)
+"fLn" = (
+/turf/closed/indestructible/rock,
+/area/f13/sewer/powered)
 "fLM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepiletwo,
@@ -11571,6 +12251,12 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"fMY" = (
+/obj/structure/chair/folding{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "fNa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11746,6 +12432,12 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"fRC" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "fRE" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/bars,
@@ -11886,6 +12578,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"fUt" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "fVc" = (
 /obj/structure/lattice/clockwork,
 /obj/structure/fence/handrail{
@@ -11998,6 +12697,16 @@
 /obj/structure/spacevine,
 /turf/open/water,
 /area/f13/sewer)
+"fYx" = (
+/turf/closed/wall/f13/wood/house,
+/area/f13/sewer/powered)
+"fYD" = (
+/obj/structure/closet/crate/trashcart/moneywish,
+/obj/structure/disposalpipe/broken{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "fYE" = (
 /obj/structure/simple_door/metal/fence,
 /turf/open/floor/plating/tunnel,
@@ -12027,6 +12736,10 @@
 /obj/structure/barricade/wooden/strong,
 /turf/closed/mineral/random/high_chance,
 /area/f13/caves)
+"fZk" = (
+/obj/structure/grille/broken,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "fZp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -12150,6 +12863,13 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/chemistry)
+"gdb" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/sewer/powered)
 "gdn" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -12326,6 +13046,15 @@
 	name = "dirty floor"
 	},
 /area/f13/building/abandoned/o)
+"ghb" = (
+/obj/machinery/light{
+	bulb_colour = "#BC8F8F";
+	dir = 4;
+	light_color = "#BC8F8F";
+	name = "bar light"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "ghn" = (
 /obj/structure/debris/v4,
 /obj/structure/debris/v3,
@@ -12353,6 +13082,15 @@
 /obj/item/clothing/head/helmet/f13/firefighter,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
+"ghy" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/obj/structure/wreck/trash/five_tires{
+	pixel_y = 11
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "ghA" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -12414,6 +13152,10 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
+"gkc" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "gkh" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/crude,
@@ -12478,6 +13220,30 @@
 /obj/structure/loot_pile,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
+"gkZ" = (
+/obj/structure/junk/small/table,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
+"glE" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/guncase,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
+"glF" = (
+/obj/structure/lattice,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/neck/apron/labor,
+/obj/item/clothing/neck/apron/labor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "gmg" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/brews,
 /turf/open/floor/plasteel/floorgrime,
@@ -12598,6 +13364,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/overseer)
+"gpy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/reflector,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/sewer/powered)
 "gpF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -12781,6 +13554,19 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/bunker/bunkerfive)
+"gsY" = (
+/obj/machinery/workbench/forge{
+	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
+	icon_state = "generator_on";
+	name = "superheating forge"
+	},
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "gtd" = (
 /obj/item/reagent_containers/food/snacks/soylentgreen,
 /turf/open/indestructible/ground/inside/subway,
@@ -12928,6 +13714,12 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"gxc" = (
+/obj/structure/fence/end{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "gxe" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/landmark/start/f13/raider,
@@ -12939,6 +13731,12 @@
 	dir = 4
 	},
 /area/f13/vault/garden)
+"gxv" = (
+/obj/structure/wreck/trash/five_tires{
+	pixel_y = 11
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "gxw" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 10
@@ -12967,6 +13765,11 @@
 /obj/machinery/telecomms/server/presets/khans,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"gxX" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/sewer/powered)
 "gya" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/raider/ranged/boss,
@@ -13002,6 +13805,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/ruin/powered)
+"gza" = (
+/obj/structure/table,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "gzg" = (
 /obj/effect/decal/cleanable/blood,
 /mob/living/simple_animal/hostile/raider/junker/creator,
@@ -13093,6 +13904,17 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"gBb" = (
+/obj/structure/table,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/item/stack/sheet/plasteel/five,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "gBk" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13211,6 +14033,10 @@
 /obj/structure/spider/stickyweb,
 /turf/closed/wall/rust,
 /area/f13/sewer)
+"gDu" = (
+/mob/living/simple_animal/hostile/renegade/grunt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "gDy" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -13502,6 +14328,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
+"gLd" = (
+/obj/structure/decoration/rag{
+	layer = 4.3
+	},
+/turf/closed/wall/r_wall,
+/area/f13/sewer/powered)
 "gLe" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	desc = "A deadly close combat robot developed by RobCo in a vaguely feminine, yet ominous chassis. This one seems sleeker and more dangerous, with a slick red paintjob.";
@@ -13516,6 +14348,12 @@
 	},
 /turf/open/floor/f13,
 /area/ruin/powered)
+"gLh" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/sewer/powered)
 "gLi" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 1
@@ -13560,6 +14398,19 @@
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/plasteel/freezer,
 /area/f13/vault/diner)
+"gMl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/obj/structure/ladder/unbreakable{
+	id = "meistrovault1";
+	level = 1;
+	icon_state = "manhole_open";
+	height = 2
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "gMs" = (
 /turf/closed/wall/f13/ruins,
 /area/f13/caves)
@@ -13598,6 +14449,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
+"gNv" = (
+/obj/effect/overlay/junk/oldpipes/end,
+/obj/structure/wreck/trash/three_barrels{
+	pixel_y = 16;
+	pixel_x = 15
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "gNw" = (
 /obj/structure/junk/locker,
 /turf/open/floor/plating/tunnel{
@@ -13611,6 +14470,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker/bunkerfive)
+"gOJ" = (
+/obj/structure/chair/f13chair1,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "gPg" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -13677,6 +14542,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"gRf" = (
+/obj/structure/lattice,
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/stack/ore/blackpowder/fifty,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "gRj" = (
 /obj/machinery/door/password{
 	door_id = "blackstar"
@@ -13846,6 +14720,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/armory)
+"gTS" = (
+/obj/structure/fence/end{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "gUb" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -14198,6 +15078,27 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
+"hby" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/ladder/unbreakable{
+	id = "meistrovault2";
+	level = 1;
+	icon_state = "manhole_open";
+	height = 2
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
+"hbG" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/generic,
+/mob/living/simple_animal/hostile/renegade/engie,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "hbO" = (
 /obj/structure/fermenting_barrel,
 /obj/effect/decal/cleanable/dirt,
@@ -14278,6 +15179,11 @@
 /obj/effect/spawner/bundle/f13/armor/t45d_salvaged,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"hds" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/sewer/powered)
 "hdt" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	desc = "A deadly close combat robot developed by RobCo in a vaguely feminine, yet ominous chassis. This one seems sleeker and more dangerous, with a slick red paintjob.";
@@ -14804,6 +15710,10 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"hov" = (
+/obj/structure/simple_door/repaired,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "hoC" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/armylootbasic,
@@ -14823,6 +15733,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"hpL" = (
+/obj/item/flashlight/lantern{
+	pixel_x = -10;
+	pixel_y = 15
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "hpV" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	desc = "A deadly close combat robot developed by RobCo in a vaguely feminine, yet ominous chassis. This one seems sleeker and more dangerous, with a slick red paintjob.";
@@ -14911,6 +15828,11 @@
 	},
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
+"hrG" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/pile/largejungle,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hrH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_mosaic,
@@ -15013,6 +15935,14 @@
 /obj/item/ammo_box/a556,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
+"huL" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/defender,
+/obj/structure/chair/f13chair1,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "hvg" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/subway,
@@ -15075,6 +16005,10 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"hxC" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/sewer/powered)
 "hyd" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -15099,6 +16033,13 @@
 /obj/structure/lattice,
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
+"hyE" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "hyH" = (
 /obj/structure/bed,
 /obj/item/bedsheet/black,
@@ -15111,6 +16052,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/armory)
+"hzb" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "hzc" = (
 /obj/structure/table,
 /obj/item/ammo_box/shotgun/buck,
@@ -15577,6 +16526,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker/bunkersix)
+"hLQ" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/wall/f13/ruins,
+/area/f13/sewer/powered)
 "hLV" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -15896,6 +16851,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"hUK" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/ruins,
+/area/f13/sewer/powered)
 "hUM" = (
 /obj/structure/sign/poster/prewar/poster68{
 	pixel_y = 32
@@ -16080,6 +17039,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/radiation)
+"iaB" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "iaI" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -16097,6 +17062,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"iaT" = (
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "ibd" = (
 /obj/structure/closet/ammunitionlocker,
 /obj/structure/cable,
@@ -16302,6 +17272,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"ihw" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/sewer/powered)
 "ihU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/toy/plush/mammal/fox/squishfox,
@@ -16395,6 +17371,10 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"ikd" = (
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "ikj" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/enclave)
@@ -16491,6 +17471,9 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operating)
+"imO" = (
+/turf/closed/mineral/random/low_chance,
+/area/f13/sewer/powered)
 "imY" = (
 /mob/living/simple_animal/hostile/megafauna/behemoth{
 	desc = "A super mutant who has grown to an incredible size, it's skin is pulled tight! This one wields two lamposts that have had car doors tied to the ends creating deadly axes, around it's neck hangs a license plate that spells out 'Tiny'.";
@@ -16573,6 +17556,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"ioP" = (
+/obj/structure/barricade/concrete,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "ioV" = (
 /obj/machinery/light{
 	flickering = 1
@@ -16869,6 +17859,14 @@
 /obj/item/crowbar/advanced,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"ivR" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "ivX" = (
 /obj/structure/chair/f13chair1{
 	pixel_x = 7;
@@ -17318,6 +18316,10 @@
 /obj/item/clothing/head/welding/weldingfire,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"iJg" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "iJu" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -17433,6 +18435,17 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"iMn" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/soldier,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "iMq" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/f13{
@@ -17591,6 +18604,13 @@
 /mob/living/simple_animal/hostile/raider/ranged/boss,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"iQt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/vent,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "iQB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -17875,6 +18895,15 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/enclave)
+"iYK" = (
+/obj/structure/barricade/concrete,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/spawner/lootdrop/trash,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "iYQ" = (
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
@@ -17900,6 +18929,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/leisure)
+"iZN" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "iZQ" = (
 /obj/structure/closet/locker,
 /obj/effect/spawner/lootdrop/clothing_middle,
@@ -17929,6 +18964,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault/reactor)
+"jbd" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "jbh" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -18141,6 +19185,12 @@
 	},
 /turf/open/floor/plating/dirt/dark,
 /area/f13/radiation)
+"jfx" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood,
+/area/f13/sewer/powered)
 "jfV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18192,6 +19242,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"jij" = (
+/obj/machinery/mech_bay_recharge_port,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "jip" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden/strong,
@@ -18286,6 +19343,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"jme" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "jmG" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -18309,6 +19376,10 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"jnD" = (
+/obj/structure/barricade/concrete,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "jnI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -18338,6 +19409,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"joz" = (
+/obj/structure/decoration/rag{
+	icon_state = "skulls"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/closed/wall/f13/ruins,
+/area/f13/sewer/powered)
 "joH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
@@ -18374,6 +19452,11 @@
 	dir = 8
 	},
 /area/f13/bunker/bighornbunker)
+"jpq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/renegade/doc,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "jpA" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/dirt,
@@ -18606,6 +19689,12 @@
 /obj/machinery/door/locked/easy/maybe_trapped,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"jtX" = (
+/obj/structure/wreck/trash/five_tires{
+	pixel_y = 11
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "jue" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/inside/subway,
@@ -18692,6 +19781,16 @@
 /obj/structure/table_frame,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"jwm" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/porta_turret/f13/turret_shotgun/raider,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "jwH" = (
 /obj/machinery/workbench/advanced,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18778,6 +19877,14 @@
 	icon_state = "greenfull"
 	},
 /area/f13/sewer)
+"jyU" = (
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "jyV" = (
 /obj/structure/table,
 /obj/item/healthanalyzer,
@@ -18845,6 +19952,13 @@
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
+"jAd" = (
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/blood/gibs/human,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "jAx" = (
 /obj/structure/lattice,
 /obj/structure/chair/sofa/right,
@@ -18952,6 +20066,11 @@
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
+"jEG" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/sewer/powered)
 "jEI" = (
 /obj/machinery/vending/cola/space_up,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -19203,6 +20322,11 @@
 	dir = 4
 	},
 /area/f13/vault/science)
+"jLg" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "jLp" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -19407,6 +20531,11 @@
 /obj/machinery/telecomms/server/presets/bos,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"jPX" = (
+/obj/structure/junk/cabinet,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "jQh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs/down,
@@ -19423,6 +20552,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
+"jQm" = (
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_y = 11;
+	pixel_x = 3
+	},
+/obj/structure/table,
+/obj/item/reagent_containers/blood/radaway,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/sewer/powered)
 "jQz" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19493,6 +20631,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"jTu" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "jTw" = (
 /mob/living/simple_animal/hostile/supermutant/legendary,
 /obj/effect/decal/cleanable/dirt,
@@ -19757,6 +20902,20 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"jZm" = (
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "jZq" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /obj/effect/decal/cleanable/dirt,
@@ -19992,6 +21151,14 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"kfa" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "kfc" = (
 /obj/machinery/power/terminal,
 /turf/open/floor/plasteel,
@@ -20438,6 +21605,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/bunker/bunkereight)
+"koa" = (
+/obj/structure/decoration/warning{
+	name = "WARNING: LEADER AHEAD"
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/sewer/powered)
 "kod" = (
 /turf/open/floor/plasteel/vault/side{
 	dir = 1
@@ -20480,6 +21653,13 @@
 	icon_state = "yellowsidingcorner"
 	},
 /area/ruin/powered)
+"kpP" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "kpU" = (
 /obj/machinery/light{
 	dir = 8
@@ -20549,6 +21729,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"krf" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "kry" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/terminal{
@@ -20640,6 +21828,18 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
+"ksO" = (
+/obj/machinery/workbench/forge{
+	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
+	icon_state = "generator_on";
+	name = "superheating forge"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "ktv" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/subway,
@@ -20755,6 +21955,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
+"kwI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "kwJ" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /obj/structure/lattice/catwalk,
@@ -20851,6 +22060,10 @@
 /obj/item/bedsheet/hos,
 /turf/open/floor/carpet/orange,
 /area/f13/vault/security)
+"kzM" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "kzN" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/f13{
@@ -21108,6 +22321,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker/bunkerthree)
+"kGH" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
+"kHz" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "kHS" = (
 /obj/structure/mecha_wreckage/durand,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -21137,6 +22361,11 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/water,
 /area/f13/sewer)
+"kIU" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/sewer/powered)
 "kJd" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -21519,6 +22748,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/dormitory)
+"kQK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/wreck/car/bike{
+	pixel_x = -12
+	},
+/obj/structure/wreck/trash/autoshaft{
+	pixel_x = -6
+	},
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "kQL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -21705,6 +22945,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/enclave)
+"kUK" = (
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/sewer/powered)
 "kUN" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/randomraiderchest,
@@ -21805,6 +23050,18 @@
 	dir = 8
 	},
 /area/ruin/powered)
+"kWB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/car/rubbish3{
+	pixel_x = 16;
+	pixel_y = 8
+	},
+/obj/structure/wreck/trash/bus_door{
+	pixel_x = 9;
+	pixel_y = -11
+	},
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "kWE" = (
 /obj/machinery/vending/tool,
 /turf/open/floor/f13{
@@ -22054,6 +23311,13 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/sewer)
+"lcg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "lcq" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -22103,6 +23367,14 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"ldk" = (
+/obj/machinery/porta_turret/f13/turret_556/raider{
+	dir = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "lds" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/cleanable/dirt,
@@ -22195,6 +23467,21 @@
 /obj/structure/rack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"lfN" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
+"lfV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "lgm" = (
 /obj/effect/decal/remains/human,
 /turf/open/water,
@@ -22211,6 +23498,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
+"lgC" = (
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall,
+/area/f13/sewer/powered)
 "lgD" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple/side,
 /area/f13/vault/science)
@@ -22262,6 +23553,11 @@
 	dir = 8
 	},
 /area/f13/vault/security)
+"lhL" = (
+/obj/structure/barricade/wooden,
+/obj/structure/timeddoor,
+/turf/closed/wall/r_wall/rust,
+/area/f13/sewer/powered)
 "lhV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
@@ -22336,6 +23632,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
+"ljL" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "ljO" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
@@ -22349,6 +23649,20 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkereight)
+"ljV" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
+"ljW" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "ljZ" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -22387,6 +23701,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/bunker/bunkereight)
+"lks" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "lkv" = (
 /obj/structure/simple_door/metal/barred,
 /turf/open/indestructible/ground/inside/subway,
@@ -22477,6 +23797,12 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"lmL" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/wood/house,
+/area/f13/sewer/powered)
 "lmU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -22840,6 +24166,11 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault/atrium)
+"lvZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "lwa" = (
 /obj/structure/sign/warning{
 	layer = 5
@@ -23096,6 +24427,19 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/overseer)
+"lBK" = (
+/obj/item/flashlight/lantern{
+	pixel_x = -10;
+	pixel_y = 15
+	},
+/obj/structure/wreck/trash/five_tires{
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "lBQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/ghoul/scorched{
@@ -23251,6 +24595,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/abandoned/o)
+"lFl" = (
+/obj/structure/sign/poster/contraband/hacking_guide{
+	pixel_x = -32
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/sewer/powered)
 "lFm" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -23401,6 +24753,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
+"lJe" = (
+/obj/structure/sign/poster/contraband/tools{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "lJi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -23635,6 +24993,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"lNt" = (
+/obj/structure/lattice,
+/obj/structure/sign/poster/contraband/atmosia_independence{
+	pixel_y = 32
+	},
+/mob/living/simple_animal/hostile/renegade/grunt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "lNx" = (
 /obj/structure/table/reinforced,
 /obj/structure/barricade/bars,
@@ -23643,6 +25009,14 @@
 "lNB" = (
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
+"lNL" = (
+/obj/structure/wreck/car/bike{
+	dir = 5;
+	pixel_y = 19
+	},
+/obj/structure/wreck/trash/engine,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "lOB" = (
 /obj/effect/decal/marking,
 /obj/effect/decal/cleanable/dirt,
@@ -23841,6 +25215,12 @@
 /obj/effect/spawner/lootdrop/armylootelite,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"lSQ" = (
+/obj/structure/barricade/concrete,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/sewer/powered)
 "lSU" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /obj/effect/decal/cleanable/dirt,
@@ -23943,6 +25323,19 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/water,
 /area/f13/sewer)
+"lVq" = (
+/obj/structure/fence/cut/large{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
+"lVQ" = (
+/obj/structure/chair/f13chair1,
+/mob/living/simple_animal/hostile/renegade/engie,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "lVR" = (
 /obj/machinery/blackbox_recorder,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -23999,6 +25392,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/radiation)
+"lXb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "lXo" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/cleanable/dirt,
@@ -24126,6 +25524,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bighornbunker)
+"lZt" = (
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "lZy" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side,
 /area/f13/brotherhood/reactor)
@@ -24396,6 +25798,15 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"mgb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/f13/turret_556/burstfire/raider{
+	dir = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "mgl" = (
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -24473,6 +25884,15 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
+"miY" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "mji" = (
 /obj/structure/junk/small/bed,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24660,6 +26080,12 @@
 /obj/effect/landmark/start/f13/vaultsecurityofficer,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security)
+"mpO" = (
+/obj/structure/barricade/concrete,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "mpS" = (
 /obj/structure/lattice{
 	layer = 3
@@ -24731,6 +26157,10 @@
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
+"mrF" = (
+/obj/effect/overlay/junk/oldpipes,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "mrL" = (
 /obj/structure/chair/stool/retro/black,
 /obj/effect/decal/cleanable/dirt,
@@ -24813,6 +26243,13 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/vault/reactor)
+"mtm" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/renegade/guardian,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "mtw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -24988,6 +26425,10 @@
 	icon_state = "greenfull"
 	},
 /area/f13/sewer)
+"mwH" = (
+/obj/item/pickaxe,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "mwI" = (
 /obj/structure/chair/right{
 	dir = 1
@@ -25012,6 +26453,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/dormitory)
+"mwU" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plasteel/five,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/sewer/powered)
 "mxn" = (
 /obj/structure/closet/locker,
 /obj/item/clothing/shoes/cowboyboots/black,
@@ -25394,6 +26840,12 @@
 /obj/structure/nest/assaultron,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"mEq" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "mEN" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -25415,6 +26867,13 @@
 	icon_state = "engine"
 	},
 /area/ruin/powered)
+"mFw" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/guardian,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "mFK" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -25451,6 +26910,13 @@
 	},
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/leisure)
+"mGj" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "mGk" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/sewer)
@@ -25606,6 +27072,12 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/vault/atrium)
+"mKG" = (
+/obj/structure/railing/corner,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "mKY" = (
 /obj/item/flashlight/seclite,
 /obj/structure/table/wood,
@@ -25759,6 +27231,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"mNJ" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
+"mNS" = (
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/wood,
+/area/f13/sewer/powered)
 "mOE" = (
 /obj/effect/decal/cleanable/blood/innards,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -25767,6 +27249,10 @@
 /obj/structure/wreck/trash/halftire,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/tunnel)
+"mOK" = (
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "mOR" = (
 /obj/structure/barricade/train{
 	dir = 1
@@ -25823,6 +27309,13 @@
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"mQJ" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/f13/turret_shotgun/raider,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "mQO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/start/f13/vaultscientist,
@@ -25927,6 +27420,9 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/radiation)
+"mTF" = (
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/sewer/powered)
 "mTI" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -25973,6 +27469,11 @@
 	},
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker/bunkerthree)
+"mUL" = (
+/obj/structure/lattice,
+/obj/structure/table,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "mUQ" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
@@ -26055,6 +27556,20 @@
 	smooth = 1
 	},
 /area/f13/caves)
+"mWi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/car/rubbish2{
+	pixel_x = 1;
+	pixel_y = 18
+	},
+/obj/structure/wreck/trash/halftire{
+	pixel_x = 1;
+	pixel_y = 16
+	},
+/obj/structure/wreck/trash/one_tire,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "mWr" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Base Lockdown"
@@ -26064,6 +27579,10 @@
 /mob/living/simple_animal/hostile/giantant,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"mWA" = (
+/obj/structure/junk/arcade,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "mWT" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "bcircuit1";
@@ -26171,6 +27690,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"mZN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "mZS" = (
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
@@ -26191,6 +27718,13 @@
 /mob/living/simple_animal/hostile/handy/gutsy,
 /turf/open/floor/plating,
 /area/f13/bunker/bunkereight)
+"nbc" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/soldier,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "nbf" = (
 /obj/structure/closet/locker/oldstyle,
 /turf/open/floor/f13,
@@ -26446,6 +27980,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
+"nhp" = (
+/obj/structure/ladder/unbreakable{
+	id = "meistrovault1"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "nhs" = (
 /obj/structure/bed/old,
 /obj/item/bedsheet/brown,
@@ -26680,6 +28222,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"nlA" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "nlB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -26775,6 +28324,15 @@
 /obj/machinery/computer/card/bos,
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
+"nnM" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/porta_turret/f13/turret_shotgun/raider,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "nnQ" = (
 /obj/structure/floodlight_frame,
 /turf/open/indestructible/ground/inside/subway,
@@ -26846,6 +28404,11 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"nrC" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "nrO" = (
 /obj/machinery/light{
 	dir = 1;
@@ -26943,6 +28506,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"ntS" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/renegade/defender,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "nuh" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/dark,
@@ -26997,6 +28567,17 @@
 "nuO" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security)
+"nuQ" = (
+/obj/structure/wreck/trash/one_tire{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/structure/wreck/trash/one_barrel{
+	pixel_y = 11;
+	pixel_x = 5
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "nuW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/wreck/trash/four_barrels,
@@ -27015,6 +28596,13 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/ruin/powered)
+"nvj" = (
+/obj/structure/tires,
+/obj/structure/tires/half{
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "nvr" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /turf/open/floor/plasteel/dark,
@@ -27056,6 +28644,11 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plating,
 /area/f13/bunker/bunkereight)
+"nwg" = (
+/obj/structure/lattice,
+/obj/structure/chair/f13foldupchair,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "nwl" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -27220,6 +28813,13 @@
 "nzg" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
+"nzp" = (
+/obj/structure/simple_door/bunker,
+/obj/structure/timeddoor,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "nzu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
@@ -27387,6 +28987,16 @@
 	dir = 1
 	},
 /area/f13/vault/medical/breakroom)
+"nDE" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "nDK" = (
 /obj/structure/table/wood/fancy,
 /obj/item/trash/plate,
@@ -27698,6 +29308,13 @@
 "nLG" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/corner,
 /area/ruin/powered)
+"nLH" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/sewer/powered)
 "nLM" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/wooden/strong,
@@ -27856,6 +29473,13 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault/diner)
+"nPk" = (
+/mob/living/simple_animal/hostile/renegade/defender,
+/obj/structure/chair/f13chair1,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "nPu" = (
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/indestructible/ground/inside/subway,
@@ -27891,6 +29515,12 @@
 	},
 /turf/closed/wall/f13/ruins,
 /area/f13/sewer)
+"nQw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "nQC" = (
 /obj/structure/barricade/bars,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -27938,12 +29568,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bighornbunker)
+"nSD" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "nSP" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"nSS" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "nSV" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28134,6 +29776,11 @@
 	icon_state = "greenfull"
 	},
 /area/f13/sewer)
+"nWM" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/sewer/powered)
 "nXj" = (
 /obj/effect/decal/waste{
 	pixel_x = 18;
@@ -28207,6 +29854,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
+"nYW" = (
+/obj/structure/barricade/concrete,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/sewer/powered)
 "nYY" = (
 /obj/structure/table/wood,
 /turf/open/floor/f13{
@@ -28250,6 +29903,13 @@
 	icon_state = "purplechess"
 	},
 /area/f13/bunker/bunkerthree)
+"oac" = (
+/obj/structure/decoration/rag{
+	icon_state = "flag_ncr";
+	name = "NCR banner"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/sewer/powered)
 "oaC" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
@@ -28412,6 +30072,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"oeM" = (
+/obj/structure/wreck/trash/autoshaft{
+	pixel_x = 17
+	},
+/obj/effect/decal/cleanable/vomit/old,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "ofd" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
@@ -28525,6 +30193,12 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
+"ohQ" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/remains/human,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "oih" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -28921,6 +30595,14 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/sewer)
+"oqG" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/decoration/rag{
+	layer = 2.5;
+	pixel_y = 5
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "oqN" = (
 /obj/machinery/workbench/advanced,
 /turf/open/floor/f13{
@@ -29029,6 +30711,15 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"osu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "osF" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/inside/subway,
@@ -29043,6 +30734,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/ruin/powered)
+"ota" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/sewer/powered)
 "otb" = (
 /obj/machinery/seed_extractor,
 /obj/effect/decal/cleanable/dirt,
@@ -29074,6 +30771,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security)
+"ouq" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/filingcabinet{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "ouw" = (
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/dark,
@@ -29093,6 +30800,10 @@
 "ouS" = (
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/building/abandoned/o)
+"ovd" = (
+/obj/structure/barricade/wooden,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/sewer/powered)
 "ove" = (
 /obj/machinery/computer/telecomms/server{
 	dir = 4;
@@ -29149,6 +30860,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/abandoned/o)
+"owt" = (
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "owx" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -29167,6 +30884,14 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operating)
+"oxg" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "oxo" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -29209,6 +30934,10 @@
 /obj/item/reagent_containers/food/snacks/f13/mre,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/shack)
+"oxZ" = (
+/obj/structure/table_frame/wood,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "oyg" = (
 /obj/structure/lattice{
 	layer = 3
@@ -29462,6 +31191,13 @@
 "oED" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker/bunkereight)
+"oEK" = (
+/obj/structure/barricade/concrete,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "oEU" = (
 /turf/open/floor/plating/asteroid,
 /area/f13/caves)
@@ -29744,6 +31480,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker/bunkerfive)
+"oMW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/grill,
+/obj/item/reagent_containers/food/snacks/meat/rawcutlet/chicken{
+	pixel_y = 8
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "oNa" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/table/wood,
@@ -29908,6 +31652,17 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
+"oRw" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	pixel_y = -3;
+	pixel_x = 4;
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "oRx" = (
 /obj/item/surgicaldrill/advanced,
 /obj/structure/table,
@@ -29960,6 +31715,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
+"oSF" = (
+/obj/structure/sign/poster/contraband/scum{
+	pixel_x = 32
+	},
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubblepillar"
+	},
+/area/f13/sewer/powered)
 "oSH" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/f13{
@@ -29978,6 +31742,13 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
 /area/f13/caves)
+"oSY" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/obj/structure/table/wood,
+/turf/closed/wall/f13/wood,
+/area/f13/sewer/powered)
 "oTo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -29992,6 +31763,12 @@
 	icon_state = "rampdowntop"
 	},
 /area/f13/brotherhood/operations)
+"oTG" = (
+/obj/structure/wreck/trash/five_tires{
+	pixel_y = 11
+	},
+/turf/closed/wall/f13/ruins,
+/area/f13/sewer/powered)
 "oTZ" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
 /obj/structure/chair/office,
@@ -30035,6 +31812,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"oVb" = (
+/obj/structure/lattice,
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "oVl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -30143,6 +31925,12 @@
 	},
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/security)
+"oYe" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/bomb/tier1,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "oYH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -30211,6 +31999,11 @@
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/dorms)
+"paQ" = (
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "paR" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 10
@@ -30405,6 +32198,13 @@
 /obj/item/reagent_containers/glass/beaker/glass_dish,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/white,
 /area/f13/vault/medical/chemistry)
+"phl" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/barricade/concrete,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/sewer/powered)
 "phx" = (
 /mob/living/simple_animal/hostile/handy,
 /obj/structure/shelf_wood,
@@ -30495,6 +32295,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker/bunkerfive)
+"pjk" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "pjo" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -30544,6 +32350,12 @@
 /obj/structure/disposalpipe/broken,
 /turf/open/water,
 /area/f13/radiation)
+"pmd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "pmg" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/snacks/f13/mre,
@@ -30657,6 +32469,13 @@
 	icon_state = "floordirty"
 	},
 /area/f13/bunker/bunkerthree)
+"ppk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "ppm" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -30782,6 +32601,12 @@
 /obj/structure/junk/small/bed,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"psA" = (
+/obj/structure/lattice,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "psP" = (
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -30862,11 +32687,23 @@
 /obj/effect/decal/cleanable/robot_debris,
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
+"puF" = (
+/obj/structure/barricade/concrete,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "puJ" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"puW" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "puX" = (
 /obj/structure/table/booth,
 /obj/machinery/chem_dispenser/drinks{
@@ -30951,6 +32788,12 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
+"pwY" = (
+/obj/effect/overlay/junk/oldpipes{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "pxh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -30985,6 +32828,13 @@
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/radiation)
+"pxF" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "pxG" = (
 /obj/machinery/chem_master,
 /obj/structure/cable{
@@ -31016,6 +32866,11 @@
 /obj/structure/barricade/train,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
+"pyw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "pyJ" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/machinery/light,
@@ -31028,6 +32883,21 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/dorms)
+"pza" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
+"pzg" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/heavy/salvaged_pa/t45d,
+/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d/raider,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/sewer/powered)
 "pzo" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/f13{
@@ -31057,6 +32927,15 @@
 	light_range = 4
 	},
 /area/ruin/powered)
+"pzV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "pAp" = (
 /obj/structure/railing{
 	dir = 9
@@ -31112,6 +32991,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"pBK" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "pBM" = (
 /obj/structure/fence/wooden{
 	density = 0;
@@ -31176,6 +33061,9 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"pCR" = (
+/turf/closed/wall/r_wall,
+/area/f13/sewer/powered)
 "pDi" = (
 /obj/structure/table/abductor,
 /obj/item/stack/sheet/metal/fifty,
@@ -31189,6 +33077,10 @@
 	light_range = 4
 	},
 /area/ruin/powered)
+"pDj" = (
+/obj/structure/closet/cabinet,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "pDA" = (
 /obj/structure/kitchenspike,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31216,10 +33108,21 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/building/abandoned/o)
+"pEk" = (
+/obj/structure/barricade/wooden/planks,
+/turf/closed/wall/f13/wood,
+/area/f13/sewer/powered)
 "pEl" = (
 /obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/medical)
+"pEE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/bountyhunters{
+	pixel_y = 32
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "pEO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/showcase/cyborg/old{
@@ -31230,6 +33133,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"pER" = (
+/obj/structure/wreck/trash/halftire{
+	pixel_x = 3;
+	pixel_y = -10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "pFb" = (
 /obj/structure/junk/small,
 /obj/effect/spawner/lootdrop/trash,
@@ -31252,10 +33163,41 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"pFI" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/sewer/powered)
+"pFQ" = (
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
+	},
+/area/f13/sewer/powered)
 "pFU" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
+"pFW" = (
+/obj/machinery/porta_turret/f13/turret_shotgun/raider{
+	dir = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
+"pGf" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "pGA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin{
@@ -31378,6 +33320,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"pIl" = (
+/obj/structure/timeddoor,
+/obj/structure/decoration/warning{
+	name = "WARNING: LEADER AHEAD"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/sewer/powered)
 "pIq" = (
 /obj/item/crowbar{
 	pixel_x = 31
@@ -31454,6 +33403,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
+"pLm" = (
+/obj/effect/decal/remains/human,
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "pLq" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/guncase/shotgun,
@@ -31521,6 +33474,12 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
+"pMk" = (
+/obj/structure/lattice,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/mre,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "pMI" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -31572,6 +33531,9 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
+"pOi" = (
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/sewer/powered)
 "pOu" = (
 /obj/item/trash/chips,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -31823,6 +33785,20 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
+"pTq" = (
+/obj/effect/overlay/junk/oldpipes/vent{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
+"pTz" = (
+/obj/structure/chair/f13foldupchair,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "pTM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -31894,6 +33870,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"pWi" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/item/pickaxe{
+	pixel_y = -11
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "pWn" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -31911,6 +33899,11 @@
 /obj/structure/bookcase/manuals/engineering,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
+"pWF" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
+/area/f13/sewer/powered)
 "pWN" = (
 /turf/open/floor/f13{
 	color = "#f7e8e1";
@@ -32043,6 +34036,12 @@
 /obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/f13/brotherhood/leisure)
+"pZC" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "pZD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -32079,6 +34078,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/f13/bunker/bunkersix)
+"qar" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess"
+	},
+/area/f13/sewer/powered)
 "qaD" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/decal/cleanable/cobweb,
@@ -32086,6 +34093,11 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
+"qaK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "qaR" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/hydroponics/constructable,
@@ -32256,6 +34268,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"qej" = (
+/obj/structure/wreck/trash/five_tires{
+	pixel_y = 14
+	},
+/obj/structure/wreck/trash/bus_door{
+	pixel_y = -5;
+	pixel_x = -6
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "qes" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32271,6 +34294,13 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
+"qex" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "qeA" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/wreck/trash/four_barrels,
@@ -32366,6 +34396,12 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"qfJ" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "qfR" = (
 /obj/structure/curtain,
 /obj/machinery/shower{
@@ -32486,6 +34522,12 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
+"qiz" = (
+/obj/structure/barricade/concrete,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "qiF" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
@@ -32657,6 +34699,12 @@
 	},
 /turf/open/water,
 /area/f13/sewer)
+"qlO" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/sewer/powered)
 "qmd" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/hud/health/prescription,
@@ -32851,6 +34899,18 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/medical)
+"qqL" = (
+/obj/machinery/light{
+	bulb_colour = "#BC8F8F";
+	dir = 4;
+	light_color = "#BC8F8F";
+	name = "bar light"
+	},
+/obj/structure/wreck/trash/five_tires{
+	pixel_y = 11
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "qqQ" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/f13,
@@ -32945,6 +35005,15 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker/bunkerfive)
+"qth" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "qtk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -33017,6 +35086,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
+"qus" = (
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "quu" = (
 /obj/effect/spawner/lootdrop/weapons/unique,
 /turf/open/floor/plasteel/f13,
@@ -33325,6 +35401,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/dorms)
+"qzx" = (
+/mob/living/simple_animal/hostile/renegade/meister,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "qzE" = (
 /obj/structure/rack,
 /turf/open/floor/f13/wood,
@@ -33490,6 +35572,10 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
+"qDQ" = (
+/mob/living/simple_animal/hostile/renegade/defender,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "qDR" = (
 /obj/structure/chair/wood,
 /mob/living/simple_animal/hostile/raider/legendary,
@@ -33596,6 +35682,20 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
+"qGr" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/item/pen{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "qGs" = (
 /obj/effect/decal/cleanable/crayon,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -33844,6 +35944,14 @@
 	dir = 4
 	},
 /area/f13/vault/diner)
+"qLT" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "qLX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
@@ -33926,6 +36034,15 @@
 	},
 /turf/open/water,
 /area/f13/caves)
+"qNt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "qNy" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
@@ -34029,16 +36146,36 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"qQq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/wreck/trash/halftire{
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "qQy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bighornbunker)
+"qQE" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/sewer/powered)
 "qQI" = (
 /obj/structure/mecha_wreckage/mauler,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mech_bay_recharge_floor,
 /area/f13/bunker/bunkerthree)
+"qQJ" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "qQY" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -34119,6 +36256,10 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"qSx" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/r_wall/rust,
+/area/f13/sewer/powered)
 "qSA" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
@@ -34201,6 +36342,12 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
+"qUV" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "qUW" = (
 /turf/open/floor/plating/dirt/dark,
 /area/f13/radiation)
@@ -34259,6 +36406,9 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operating)
+"qWw" = (
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/sewer/powered)
 "qWE" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical/old,
@@ -34593,10 +36743,19 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"rez" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/r_wall/rust,
+/area/f13/sewer/powered)
 "reB" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
+"reL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/decoration/hatch,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "reM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/glowstick,
@@ -34845,6 +37004,12 @@
 "rmB" = (
 /turf/closed/mineral/ash_rock,
 /area/f13/caves)
+"rmD" = (
+/obj/structure/chair/folding{
+	pixel_y = 11
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "rmP" = (
 /obj/structure/chopping_block,
 /obj/effect/decal/waste,
@@ -34940,6 +37105,15 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
+"roN" = (
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "roW" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/effect/decal/cleanable/dirt,
@@ -35002,6 +37176,12 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"rqw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "rqC" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden,
@@ -35187,6 +37367,17 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"ruy" = (
+/mob/living/simple_animal/hostile/renegade/defender,
+/obj/machinery/light,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/structure/filingcabinet{
+	pixel_x = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/sewer/powered)
 "rvj" = (
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/inside/subway,
@@ -35704,6 +37895,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/operations)
+"rIj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "rIk" = (
 /obj/structure/wreck/trash/two_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -35730,6 +37925,24 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/leisure)
+"rIJ" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/sewer/powered)
+"rIM" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
+"rIR" = (
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "rIX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -35759,12 +37972,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
+"rJX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "rJZ" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"rKt" = (
+/obj/structure/table,
+/obj/machinery/recharger,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "rKI" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -35802,6 +38026,14 @@
 /obj/machinery/porta_turret/f13/turret_556/hostile,
 /turf/open/floor/plasteel/f13/vault_floor/red/corner,
 /area/ruin/powered)
+"rMu" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "rMA" = (
 /obj/item/reagent_containers/glass/bucket/wood,
 /obj/structure/decoration/hatch{
@@ -35826,6 +38058,11 @@
 "rNg" = (
 /turf/closed/wall/rust,
 /area/f13/bunker/bunkersix)
+"rNm" = (
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "rNo" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -35917,6 +38154,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"rOl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/sewer/powered)
 "rOr" = (
 /obj/structure/campfire/barrel,
 /turf/open/floor/f13{
@@ -35961,6 +38202,12 @@
 "rPs" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/vault/science)
+"rPu" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "rPx" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -36025,6 +38272,14 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
+"rQV" = (
+/obj/machinery/mech_bay_recharge_port{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "rQX" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -36088,6 +38343,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"rRW" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/obj/machinery/light,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "rSa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -36246,6 +38509,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
+"rVS" = (
+/obj/effect/overlay/junk/oldpipes,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "rWa" = (
 /obj/structure/table,
 /obj/item/modular_computer/laptop/preset{
@@ -36455,6 +38722,15 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"sbs" = (
+/obj/structure/simple_door/bunker,
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "sbz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe/ammo/unlocked,
@@ -36592,12 +38868,27 @@
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
 /area/f13/enclave)
+"sfb" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "sfe" = (
 /obj/structure/bed/oldalt,
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker/bighornbunker)
+"sfm" = (
+/obj/effect/overlay/junk/oldpipes,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "sft" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /mob/living/simple_animal/hostile/ghoul{
@@ -36880,6 +39171,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/vault/security)
+"smg" = (
+/obj/structure/chair/f13foldupchair{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
+"smo" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "smp" = (
 /obj/machinery/processor/chopping_block,
 /obj/structure/table/wood,
@@ -36960,6 +39261,14 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker/bunkersix)
+"snY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/folding{
+	dir = 4
+	},
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "soj" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/corner{
@@ -37032,6 +39341,18 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
+"spY" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/obj/item/paper/construction{
+	desc = "All hands we need to dig the boss out, someone needs to pick up the enxt shift were getting pretty far"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "sqf" = (
 /obj/structure/table,
 /obj/item/folder/blue,
@@ -37059,6 +39380,13 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
+"sqG" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "sqK" = (
 /obj/structure/barricade/train{
 	dir = 9
@@ -37266,6 +39594,13 @@
 /obj/machinery/porta_turret/syndicate/pod,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"svO" = (
+/obj/structure/lattice,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "swG" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -37414,6 +39749,12 @@
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"szW" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "sAj" = (
 /obj/machinery/door/window/right/directional/east,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -37497,6 +39838,13 @@
 /obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"sCO" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/sewer/powered)
 "sCP" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/f13/wood{
@@ -37654,6 +40002,12 @@
 "sGE" = (
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
+"sGG" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/mob/living/simple_animal/hostile/deathclaw,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sGJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37685,6 +40039,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/rnd)
+"sGX" = (
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/sewer/powered)
 "sGY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/terminal{
@@ -37737,6 +40094,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault/reactor)
+"sHI" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/clothing_low,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "sHZ" = (
 /obj/structure/loot_pile,
 /turf/open/indestructible/ground/inside/mountain,
@@ -37764,6 +40126,10 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
+"sJg" = (
+/obj/structure/girder,
+/turf/closed/mineral/random/low_chance,
+/area/f13/sewer/powered)
 "sJq" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
@@ -37825,6 +40191,12 @@
 	dir = 1
 	},
 /area/f13/radiation)
+"sKI" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/f13/turret_shotgun/raider,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "sKS" = (
 /obj/structure/bed,
 /turf/open/floor/f13/wood{
@@ -37860,6 +40232,15 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"sMf" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/bundle/f13/armor/combat,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "sMi" = (
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -37892,6 +40273,11 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
+"sNr" = (
+/obj/structure/guncase/shotgun,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "sNN" = (
 /obj/machinery/doppler_array,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -37941,6 +40327,12 @@
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
+"sOF" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/plasteel/five,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "sOJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks,
@@ -38028,6 +40420,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/bunker/bunkersix)
+"sQz" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/sewer/powered)
 "sQA" = (
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
@@ -38281,6 +40680,16 @@
 /obj/structure/showcase/mecha/ripley,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/bunker/bunkereight)
+"sYJ" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/obj/structure/wreck/trash/five_tires{
+	pixel_y = 11
+	},
+/obj/structure/girder,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "sZa" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/fluff/ruins/listeningstation/reports,
@@ -38462,6 +40871,14 @@
 /mob/living/simple_animal/hostile/securitron/sentrybot,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"tdq" = (
+/obj/structure/lattice,
+/obj/structure/chair/f13foldupchair{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "tdw" = (
 /obj/structure/fluff/hedge,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
@@ -38555,6 +40972,19 @@
 	},
 /turf/open/floor/carpet/black,
 /area/f13/brotherhood/dorms)
+"tfY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
+"tga" = (
+/turf/open/floor/plasteel/f13{
+	icon_state = "rampdowntop"
+	},
+/area/f13/sewer/powered)
 "tgj" = (
 /obj/structure/barricade/tentclothedge,
 /obj/structure/table/wood,
@@ -38569,6 +40999,14 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker/bunkerthree)
+"tgE" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "tgL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/dirt,
@@ -38650,6 +41088,10 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/enclave)
+"tiJ" = (
+/obj/structure/simple_door/metal,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "tjq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -38716,6 +41158,19 @@
 	icon_state = "greenfull"
 	},
 /area/f13/sewer)
+"tkG" = (
+/obj/structure/wreck/trash/five_tires{
+	pixel_y = 9;
+	pixel_x = 9
+	},
+/obj/structure/wreck/trash/bus_door{
+	pixel_y = -7
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "tkH" = (
 /obj/structure/rack,
 /obj/item/book/granter/crafting_recipe/gunsmith_two,
@@ -38795,6 +41250,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/dormitory)
+"tmf" = (
+/mob/living/simple_animal/hostile/renegade,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "tmm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/mattress{
@@ -39240,6 +41699,15 @@
 	},
 /turf/open/floor/f13,
 /area/f13/vault)
+"tuQ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "tuT" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
@@ -39417,6 +41885,13 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"tzT" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "tzW" = (
 /obj/effect/gibspawner/human,
 /turf/open/indestructible/ground/outside/ruins,
@@ -39838,6 +42313,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"tKk" = (
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "tKr" = (
 /obj/structure/rack/shelf_metal,
 /obj/structure/window{
@@ -39927,6 +42408,12 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
+"tMd" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/remains/human,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tMQ" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/water,
@@ -39980,6 +42467,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"tOl" = (
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibup1"
+	},
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "tOn" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/lights/bulbs,
@@ -40023,6 +42517,11 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker/bighornbunker)
+"tPx" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/sewer/powered)
 "tPS" = (
 /mob/living/simple_animal/hostile/supermutant/legendary,
 /obj/structure/lattice,
@@ -40166,6 +42665,14 @@
 	dir = 9
 	},
 /area/f13/vault/atrium)
+"tTk" = (
+/mob/living/simple_animal/hostile/handy/gutsy/flamer{
+	health = 700
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "tTv" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/wooden/strong,
@@ -40204,6 +42711,13 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"tUw" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "tUC" = (
 /obj/structure/window/reinforced/fulltile/indestructable{
 	can_be_unanchored = 0
@@ -40217,6 +42731,10 @@
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"tUV" = (
+/obj/effect/overlay/junk,
+/turf/closed/wall/f13/ruins,
+/area/f13/sewer/powered)
 "tVc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
@@ -40303,6 +42821,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
+"tWz" = (
+/obj/structure/table/optable,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/sewer/powered)
 "tWD" = (
 /obj/structure/spacevine,
 /turf/open/indestructible/ground/inside/subway,
@@ -40328,10 +42851,30 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
+"tXw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "tXL" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/radiation)
+"tXS" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/obj/structure/guncase,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "tYE" = (
 /obj/item/paper_bin,
 /obj/structure/table{
@@ -40488,6 +43031,12 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/purple/side,
 /area/f13/vault/science)
+"udV" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/sewer/powered)
 "udY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40621,6 +43170,17 @@
 	dir = 1
 	},
 /area/ruin/powered)
+"uge" = (
+/turf/closed/mineral/random/no_caves,
+/area/f13/sewer/powered)
+"ugs" = (
+/obj/machinery/porta_turret/f13/turret_9mm/raider{
+	dir = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "ugB" = (
 /obj/structure/fence{
 	dir = 8
@@ -40672,6 +43232,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"uiI" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/f13/ruins,
+/area/f13/sewer/powered)
 "uiM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -40764,6 +43330,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/white,
 /area/f13/vault/medical/chemistry)
+"ulp" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "ulw" = (
 /obj/structure/fans/tiny,
 /turf/closed/wall/r_wall,
@@ -41201,6 +43776,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"uue" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/sewer/powered)
 "uug" = (
 /obj/structure/easel,
 /turf/open/indestructible/ground/inside/dirt,
@@ -41376,6 +43957,20 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"uza" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_x = -32
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "uze" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -41465,6 +44060,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
+"uAC" = (
+/obj/effect/spawner/lootdrop/glowstick,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "uAD" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -41546,15 +44147,44 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
+"uBZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "uCe" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"uCi" = (
+/obj/structure/rack/shelf_metal,
+/obj/machinery/light,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhighcargo,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "uCp" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkerthree)
+"uCw" = (
+/obj/machinery/porta_turret/f13/turret_shotgun/raider{
+	dir = 10
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/sewer/powered)
+"uCV" = (
+/obj/machinery/light{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "uCZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -41614,6 +44244,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"uFq" = (
+/obj/item/trash/waffles,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "uFv" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -41637,6 +44271,19 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"uGv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
+"uGW" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin";
+	pixel_y = 0;
+	pixel_x = -5
+	},
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/sewer/powered)
 "uHf" = (
 /obj/structure/lattice,
 /obj/structure/rack,
@@ -41713,6 +44360,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/vault/medical/breakroom)
+"uIP" = (
+/obj/effect/spawner/lootdrop/glowstick,
+/obj/effect/decal/cleanable/blood/gibs{
+	icon_state = "gibtorso"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "uJf" = (
 /mob/living/simple_animal/hostile/handy/nsb,
 /obj/machinery/light{
@@ -41745,6 +44399,14 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/brotherhood/leisure)
+"uJU" = (
+/obj/machinery/porta_turret/f13/turret_shotgun/raider{
+	dir = 9
+	},
+/turf/open/floor/f13{
+	icon_state = "redrustyfull"
+	},
+/area/f13/sewer/powered)
 "uJW" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/vault/dormitory)
@@ -41830,6 +44492,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"uLq" = (
+/obj/structure/decoration/rag,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/sewer/powered)
 "uLM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/settler,
@@ -41870,6 +44536,12 @@
 	light_range = 4
 	},
 /area/ruin/powered)
+"uMC" = (
+/mob/living/simple_animal/hostile/renegade/guardian,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "uME" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -42026,6 +44698,11 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
+"uPk" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "uPx" = (
 /obj/structure/table,
 /turf/open/floor/f13,
@@ -42198,6 +44875,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
+"uTG" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "uTV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -42287,6 +44970,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/dormitory)
+"uVJ" = (
+/obj/structure/lattice,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/girder,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "uVW" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate{
@@ -42419,6 +45109,14 @@
 /obj/structure/debris/v4,
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker/bunkerthree)
+"uZX" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "vaj" = (
 /obj/item/trash/f13/dog{
 	pixel_x = 10;
@@ -42655,6 +45353,10 @@
 /obj/structure/bookcase/manuals/medical,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"vgp" = (
+/obj/structure/simple_door/room,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/sewer/powered)
 "vgx" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -42802,6 +45504,11 @@
 /obj/structure/table/abductor,
 /turf/open/floor/carpet/red,
 /area/f13/enclave)
+"vjs" = (
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "vjz" = (
 /obj/structure/bed/double,
 /obj/item/bedsheet/captain{
@@ -42976,10 +45683,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"vmy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/concrete,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "vmE" = (
 /mob/living/simple_animal/hostile/raider/junker/boss,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
+"vmN" = (
+/obj/machinery/button/door{
+	id = "renegadeshutters1";
+	name = "Shutter"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/sewer/powered)
 "vnc" = (
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -43019,6 +45738,14 @@
 /obj/item/reagent_containers/medspray/silver_sulf,
 /turf/open/floor/f13,
 /area/f13/bunker)
+"vov" = (
+/obj/machinery/porta_turret/f13/turret_9mm/raider{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/sewer/powered)
 "voH" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -43047,6 +45774,10 @@
 	},
 /turf/open/floor/circuit/f13_red,
 /area/f13/enclave)
+"vpe" = (
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "vpg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/black,
@@ -43125,6 +45856,18 @@
 /obj/item/locked_box/armor/any_random,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker/bunkerthree)
+"vrI" = (
+/obj/structure/frame/computer{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
+"vrX" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "renegadeshutters2"
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "vrZ" = (
 /obj/structure/simple_door/blast,
 /obj/structure/cable{
@@ -43197,6 +45940,10 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
+"vtB" = (
+/obj/structure/simple_door/room,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "vtG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/fluff/railing{
@@ -43315,6 +46062,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"vvy" = (
+/obj/effect/spawner/lootdrop/trash,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/sewer/powered)
 "vvL" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
@@ -43440,6 +46193,22 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"vyQ" = (
+/obj/structure/table,
+/obj/structure/sign/poster/contraband/pinup_topless{
+	pixel_y = 31
+	},
+/obj/item/paper_bin{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 6
+	},
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "vzb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -43532,6 +46301,9 @@
 	},
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
+"vBd" = (
+/turf/closed/wall/f13/wood,
+/area/f13/sewer/powered)
 "vBl" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -43737,6 +46509,10 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
+"vIc" = (
+/obj/structure/girder,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "vIk" = (
 /obj/structure/lattice,
 /turf/open/water,
@@ -43921,6 +46697,12 @@
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /turf/open/floor/f13,
 /area/ruin/powered)
+"vLw" = (
+/obj/structure/wreck/trash/machinepiletwo{
+	pixel_y = 6
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "vLQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -43929,6 +46711,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"vMf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/sewer/powered)
 "vMn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -43993,6 +46781,15 @@
 	},
 /turf/open/floor/wood_fancy,
 /area/f13/vault/security)
+"vNx" = (
+/obj/machinery/porta_turret/f13/turret_556/burstfire/raider{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/sewer/powered)
 "vNB" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/stack/sheet/mineral/uranium/fifty,
@@ -44187,6 +46984,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/abandoned/o)
+"vSy" = (
+/obj/effect/decal/cleanable/oil,
+/obj/structure/girder,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "vSB" = (
 /obj/structure/rack,
 /obj/structure/rack,
@@ -44216,6 +47020,10 @@
 /obj/structure/disposalpipe/broken,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
+"vSN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/sewer/powered)
 "vSU" = (
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/operations)
@@ -44246,6 +47054,10 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
+"vUs" = (
+/obj/effect/decal/cleanable/blood/gibs/human,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "vUN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark/side{
@@ -44468,6 +47280,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"wcw" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/mob/living/simple_animal/hostile/renegade/grunt,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "wcC" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light/fo13colored/Aqua{
@@ -44870,6 +47688,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
+"wmf" = (
+/obj/machinery/light,
+/mob/living/simple_animal/hostile/renegade/defender,
+/obj/structure/chair/f13chair1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/sewer/powered)
 "wmi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/crate/hydroponics,
@@ -45252,6 +48078,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/tunnel)
+"wtY" = (
+/obj/structure/ladder/unbreakable{
+	id = "meistrovault2"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "wuf" = (
 /obj/structure/barricade/train{
 	dir = 1
@@ -45443,6 +48277,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/enclave)
+"wyy" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/sewer/powered)
+"wyD" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/r_wall,
+/area/f13/sewer/powered)
+"wyU" = (
+/obj/structure/barricade/concrete,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "wyY" = (
 /obj/structure/table/glass,
 /obj/item/storage/bag/chemistry{
@@ -45479,6 +48330,9 @@
 /obj/structure/grille,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
+"wAb" = (
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "wAd" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -45655,6 +48509,20 @@
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"wEg" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/bomb/tier1,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
+"wEp" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/junk/small/bed,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "wEE" = (
 /turf/open/floor/f13,
 /area/f13/vault)
@@ -45839,6 +48707,12 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/ruin/powered)
+"wJl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubblepillar"
+	},
+/area/f13/sewer/powered)
 "wJw" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -46053,6 +48927,12 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"wNv" = (
+/obj/machinery/light,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/sewer/powered)
 "wNz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/meat/slab/molerat{
@@ -46380,6 +49260,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/sewer)
+"wTv" = (
+/obj/effect/decal/remains/human,
+/obj/item/clothing/suit/armor/heavy/salvaged_pa/recycled,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wUl" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -46473,6 +49359,10 @@
 /obj/structure/firelock_frame,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"wXj" = (
+/obj/structure/reagent_dispensers/barrel/two,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "wXk" = (
 /obj/structure/table,
 /obj/item/bodypart/head/robot,
@@ -46566,6 +49456,11 @@
 "wYU" = (
 /turf/open/floor/carpet/royalblue,
 /area/f13/vault/security)
+"wZd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "wZr" = (
 /obj/item/stack/sheet/mineral/uranium,
 /obj/effect/decal/cleanable/greenglow,
@@ -46729,6 +49624,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/sewer)
+"xcN" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/human,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
+	},
+/area/f13/sewer/powered)
 "xcY" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -46803,6 +49706,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_wide,
 /area/f13/vault/diner)
+"xep" = (
+/obj/item/stack/sheet/plasteel/five,
+/obj/item/stack/sheet/plasteel/five,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "xey" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib6-old"
@@ -46869,6 +49781,11 @@
 	},
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
+"xfM" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/crafting,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "xfN" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/storage/belt/army/security/full,
@@ -46929,6 +49846,17 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"xhd" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
+"xhi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "xht" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13{
@@ -47018,6 +49946,11 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"xiZ" = (
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/sewer/powered)
 "xji" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -47189,6 +50122,21 @@
 /obj/machinery/door/poddoor/shutters/radiation,
 /turf/open/water,
 /area/f13/sewer)
+"xnL" = (
+/obj/structure/barricade/concrete,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
+"xnT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "xod" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -47201,6 +50149,22 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
+"xoF" = (
+/obj/structure/junk/locker,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/sewer/powered)
+"xoM" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/sewer/powered)
 "xoQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -47456,6 +50420,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"xvD" = (
+/obj/structure/grille,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "xwc" = (
 /obj/structure/rack,
 /obj/item/ammo_box/magazine/m556/rifle/assault/empty,
@@ -47610,6 +50579,9 @@
 "xyW" = (
 /turf/open/floor/plating/dirt,
 /area/f13/bunker/bunkersix)
+"xyX" = (
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "xzq" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -47665,6 +50637,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/white,
 /area/f13/vault/science)
+"xAd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
 "xAg" = (
 /obj/structure/debris/v2{
 	pixel_x = -12;
@@ -47825,6 +50802,17 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
+"xCI" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/low_tools,
+/obj/effect/spawner/lootdrop/low_tools,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "xCL" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -47879,6 +50867,10 @@
 /obj/structure/lattice,
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
+"xEh" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "xEu" = (
 /obj/structure/closet/fridge/cannibal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -47900,6 +50892,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/chemistry)
+"xFj" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "xFr" = (
 /turf/open/floor/f13{
 	icon_state = "greenfull"
@@ -48013,6 +51009,16 @@
 /obj/structure/chair/sofa,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
+"xIF" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "xII" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cooking,
 /turf/open/floor/plasteel/floorgrime,
@@ -48149,6 +51155,11 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker/bighornbunker)
+"xMl" = (
+/obj/structure/guncase/shotgun,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
+/turf/open/floor/plating/dirt,
+/area/f13/sewer/powered)
 "xMP" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/cell/ammo/ecp,
@@ -48175,6 +51186,28 @@
 	icon_state = "floordirty"
 	},
 /area/f13/bunker/bunkerthree)
+"xNl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
+"xNp" = (
+/obj/item/trash/f13/blamco_large{
+	pixel_y = 16;
+	pixel_x = 8
+	},
+/obj/item/trash/f13/borscht{
+	pixel_x = -9;
+	pixel_y = 18
+	},
+/obj/item/trash/f13/blamco{
+	pixel_y = 5;
+	pixel_x = 3
+	},
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/sewer/powered)
 "xNB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -48361,6 +51394,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
+"xRz" = (
+/obj/structure/fence{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
+"xRC" = (
+/obj/structure/sign/warning,
+/turf/closed/wall/f13/wood,
+/area/f13/sewer/powered)
 "xRH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -48423,6 +51466,14 @@
 	dir = 1
 	},
 /area/f13/vault/science)
+"xSI" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelchess2"
+	},
+/area/f13/sewer/powered)
 "xSK" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker/bunkerthree)
@@ -48518,6 +51569,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"xUq" = (
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/sewer/powered)
 "xUw" = (
 /obj/machinery/jukebox,
 /obj/structure/railing{
@@ -48687,6 +51746,31 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"yao" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "darkdirtysolid"
+	},
+/area/f13/sewer/powered)
+"yaB" = (
+/obj/structure/table,
+/obj/item/cigbutt{
+	pixel_y = 5;
+	pixel_x = -10
+	},
+/obj/item/cigbutt{
+	pixel_y = 2;
+	pixel_x = -4
+	},
+/obj/item/cigbutt{
+	pixel_y = 9;
+	pixel_x = -2
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer/powered)
 "yaK" = (
 /obj/structure/chair/sofa/right{
 	dir = 8
@@ -48797,6 +51881,10 @@
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plating,
 /area/f13/bunker/bunkernine)
+"ydV" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/sewer/powered)
 "ydY" = (
 /obj/structure/frame/machine,
 /obj/item/circuitboard/machine/ore_silo,
@@ -48871,6 +51959,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker/bighornbunker)
+"yfF" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer/powered)
+"yfG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/decoration/hatch,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/sewer/powered)
 "yfP" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper_bin{
@@ -49072,6 +52172,9 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/sewer)
+"ylB" = (
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/sewer/powered)
 "ylE" = (
 /obj/structure/closet/crate{
 	anchored = 1
@@ -51764,30 +54867,30 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
 qBv
 cJF
 cJF
@@ -52065,6 +55168,8 @@ yhR
 yhR
 yhR
 yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -52074,22 +55179,20 @@ yhR
 yhR
 yhR
 yhR
+xRC
+bgK
+bgK
+bPs
+bPs
 yhR
 yhR
 yhR
 yhR
+bgK
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
 qBv
 cJF
 cJF
@@ -52366,6 +55469,8 @@ yhR
 yhR
 yhR
 yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -52375,23 +55480,21 @@ yhR
 yhR
 yhR
 yhR
+fFQ
+lBK
+jXz
+jXz
+jXz
+sYJ
+bPs
+bPs
+yhR
+yhR
+bgK
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
 qBv
 cJF
 cJF
@@ -52668,6 +55771,7 @@ yhR
 yhR
 yhR
 yhR
+bgK
 yhR
 yhR
 yhR
@@ -52676,24 +55780,23 @@ yhR
 yhR
 yhR
 yhR
+jZm
+spY
+pZC
+jXz
+jXz
+jXz
+jXz
+jXz
+fLn
+fLn
+bPs
+yhR
+bgK
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
 qBv
 cJF
 cJF
@@ -52969,6 +56072,8 @@ yhR
 yhR
 yhR
 yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -52978,24 +56083,22 @@ yhR
 yhR
 yhR
 yhR
+tOl
+mwH
+ghb
+jXz
+jXz
+jXz
+jXz
+jXz
+jXz
+bPs
+bPs
+yhR
+bgK
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
 qBv
 cJF
 cJF
@@ -53266,6 +56369,12 @@ yhR
 yhR
 yhR
 yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -53276,32 +56385,26 @@ yhR
 yhR
 yhR
 yhR
+vBd
+yhR
+xRC
+yhR
+bPs
+bPs
+uCV
+jXz
+jXz
+jXz
+bPs
+bgK
+bgK
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-yhR
-yhR
-qBv
+bgK
+egd
+jXz
+jXz
+egd
 yhR
 yhR
 yhR
@@ -53568,46 +56671,46 @@ yhR
 yhR
 yhR
 yhR
+bgK
+rIJ
+rIJ
+rIJ
+rIJ
+mTF
 yhR
 yhR
 yhR
 yhR
+wAb
+wAb
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bKS
+pCR
+pCR
+mTF
+mTF
+mTF
+fLn
+bPs
+jXz
+jXz
+jXz
+jXz
+vIc
+bgK
+bgK
+lWI
+bPs
+bPs
+bPs
+vtB
+vgp
+bPs
+bPs
+bPs
+bPs
+uge
 yhR
 yhR
 yhR
@@ -53870,55 +56973,55 @@ yhR
 yhR
 yhR
 yhR
+bgK
+rIJ
+eVl
+dDD
+aAt
+mTF
 yhR
 yhR
 yhR
+sJg
+wAb
+cxn
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+lhL
+uMC
+cRd
+mgb
+ldk
+mTF
+fLn
+bPs
+jXz
+jXz
+jXz
+jXz
+vIc
+bgK
+bgK
+bPs
+bPs
+iJg
+ljV
+cju
+jXz
+vUs
+jXz
+jXz
+yfF
+vBd
+vBd
+bPs
+bPs
+bPs
+bPs
+bPs
+lWI
+lWI
+lWI
 yhR
 qBv
 cJF
@@ -54143,84 +57246,84 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+yhR
+yhR
+yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+bgK
+bgK
+bgK
+yhR
+yhR
+yhR
+yhR
+rIJ
+dDu
+rIj
+paQ
+mTF
+pCR
+pCR
+mTF
+mTF
+wAb
+wAb
+wAb
+yhR
+bKS
+mpO
+paQ
+paQ
+fRC
+mTF
+fLn
+bPs
+jXz
+jXz
+jXz
+uTG
+bPs
+bgK
+bgK
+bPs
+eIB
+kWB
+xAd
+cju
+cju
+cju
+cju
+cju
+cju
+gxc
+vUs
+bPs
+vIc
+xfM
+ylB
+bPs
+bPs
+lWI
+lWI
 yhR
 qBv
 cJF
@@ -54467,62 +57570,62 @@ yhR
 yhR
 yhR
 yhR
+bgK
+bgK
+wTv
+bgK
+bgK
+bgK
+bgK
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+rIJ
+hyE
+foK
+cma
+cma
+cma
+lFl
+cma
+mTF
+mTF
+hpL
+wAb
+sJg
+lgC
+paQ
+paQ
+paQ
+gMl
+mTF
+fLn
+vIc
+jXz
+jXz
+jXz
+jXz
+vIc
+bgK
+bgK
+bPs
+xhi
+xcN
+mWi
+xyX
+jXz
+exg
+qQq
+xAd
+jXz
+jXz
+jXz
+jXz
+cju
+uGv
+bmm
+gDu
+bPs
+bPs
+bPs
 yhR
 qBv
 cJF
@@ -54769,63 +57872,63 @@ yhR
 yhR
 yhR
 yhR
+bgK
+iaB
+kiG
+tMd
+dSe
+dCA
+bgK
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+rIJ
+jAd
+foK
+iMn
+aVu
+fRC
+biw
+fRC
+vov
+mTF
+gxv
+wAb
+pza
+bKS
+paQ
+paQ
+paQ
+hby
+mTF
+fLn
+jtX
+jXz
+jXz
+jXz
+jXz
+vIc
+bgK
+bgK
+bPs
+uBZ
+qaK
+wJl
+kQK
+qaK
+xAd
+xAd
+xAd
+jXz
+gTS
+vrI
+bPs
+wXj
+cju
+cju
+cju
+cju
+lZt
+bPs
+bPs
 qBv
 cJF
 tAh
@@ -55070,64 +58173,64 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+dCA
+ohv
+hrG
+kiG
+fTS
+bgK
+bgK
+rIJ
+sCO
+yaB
+oRw
+ulp
+rIj
+iQt
+ivR
+xhd
+pWF
+xCI
+pWi
+paQ
+bKS
+paQ
+paQ
+paQ
+fRC
+mTF
+fLn
+bPs
+jXz
+jXz
+gkc
+uTG
+bPs
+bgK
+bgK
+bPs
+bPs
+bPs
+bPs
+bPs
+bPs
+bPs
+bPs
+bPs
+bPs
+bPs
+bPs
+bPs
+bPs
+vLw
+cju
+cju
+jXz
+cju
+cju
+bPs
 qBv
 cJF
 qBv
@@ -55372,64 +58475,64 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+pLm
+ohQ
+sGG
+dCA
+ohv
+aUW
+ohv
+kiG
+bgK
+rez
+hds
+lcg
+fRC
+fRC
+fRC
+fRC
+rIj
+lfV
+rOl
+fki
+paQ
+paQ
+bKS
+fRC
+fRC
+foK
+foK
+ovd
+fLn
+bPs
+jXz
+jXz
+jXz
+jXz
+oTG
+bgK
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+vBd
+pEE
+cju
+cju
+bPs
 qBv
 cJF
 qBv
@@ -55639,11 +58742,11 @@ cJF
 qBv
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+bgK
+bgK
 bgK
 bgK
 bgK
@@ -55674,64 +58777,64 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+dCA
+ohv
+fTS
+bBz
+ohv
+ohv
+ohv
+ohv
+sbs
+cma
+tzT
+rIj
+ota
+cma
+nrC
+fRC
+bGo
+uGW
+wEg
+paQ
+cig
+lgC
+kwI
+fRC
+foK
+fRC
+mTF
+fLn
+jXz
+jXz
+vBd
+ghy
+qfJ
+oTG
+bgK
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+vBd
+vBd
+ljL
+jXz
+bPs
 qBv
 cJF
 qBv
@@ -55941,7 +59044,7 @@ cJF
 qBv
 yhR
 yhR
-yhR
+bgK
 cNy
 cNy
 cNy
@@ -55976,64 +59079,64 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+ohv
+hrG
+aUW
+kiG
+bgK
+bgK
+bgK
+rez
+ejC
+iYK
+cma
+kUK
+dIR
+lfN
+gkZ
+mTF
+mTF
+mTF
+iZN
+pCR
+lgC
+eCe
+nzp
+nzp
+pIl
+mTF
+fLn
+uIP
+jXz
+xRz
+gNv
+aib
+rVS
+rIJ
+rIJ
+rIJ
+pCR
+pCR
+pCR
+bPs
+bPs
+bPs
+bPs
+bPs
+bPs
+lWI
+lWI
+lWI
+lWI
+lWI
+lWI
+bPs
+bPs
+jXz
+jXz
+bPs
 qBv
 cJF
 qBv
@@ -56243,7 +59346,7 @@ cJF
 qBv
 yhR
 yhR
-yhR
+bgK
 cNy
 iBL
 iFO
@@ -56287,55 +59390,55 @@ bgK
 bgK
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+rIJ
+rIJ
+qSx
+iZN
+iZN
+oac
+pCR
+mTF
+mTF
+cCY
+aIR
+fRC
+krf
+pCR
+cyf
+fRC
+rIj
+sHI
+mTF
+fLn
+nSS
+jXz
+pBK
+nuQ
+rJX
+dRX
+qSx
+xMl
+wAb
+wAb
+uza
+pCR
+phl
+ioP
+jnD
+jnD
+vIc
+bPs
+bPs
+bPs
+bPs
+lWI
+lWI
+lWI
+bPs
+clI
+jXz
+jXz
+bPs
 qBv
 cJF
 qBv
@@ -56545,7 +59648,7 @@ cJF
 qBv
 yhR
 yhR
-yhR
+bgK
 cNy
 jna
 dZm
@@ -56587,57 +59690,57 @@ bgK
 bgK
 bgK
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+mTF
+ees
+fiF
+paQ
+oEK
+wyD
+nSD
+paQ
+nwg
+aKY
+fRC
+yfG
+rIJ
+lJe
+vMf
+rIj
+sMf
+mTF
+fLn
+jXz
+jXz
+pBK
+jPX
+lvZ
+pER
+rIJ
+sNr
+wAb
+qUV
+rRW
+rIJ
+jnD
+xyX
+jXz
+jXz
+jXz
+bPs
+bIa
+bIa
+bPs
+bPs
+bPs
+lWI
+bPs
+fmS
+jXz
+jXz
+bPs
 qBv
 cJF
 qBv
@@ -56889,57 +59992,57 @@ bgK
 bgK
 bgK
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+ihw
+dIR
+cma
+fRC
+fRC
+iZN
+fRC
+hds
+cma
+fRC
+fRC
+paQ
+iZN
+paQ
+kIU
+foK
+tgE
+ovd
+fLn
+bPs
+uCV
+gxc
+jXz
+fgF
+lXb
+pCR
+gza
+mtm
+hds
+aaE
+qSx
+xyX
+cju
+cju
+bPs
+reL
+hLQ
+eZv
+ylB
+ylB
+lks
+bPs
+bPs
+bPs
+jXz
+jXz
+jXz
+bPs
 qBv
 cJF
 qBv
@@ -57193,55 +60296,55 @@ bgK
 bgK
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+mTF
+ota
+boT
+uAC
+fRC
+iZN
+paQ
+paQ
+fRC
+fRC
+miY
+tdq
+rIJ
+fRC
+jTu
+nrC
+psA
+mTF
+fLn
+jXz
+jXz
+jXz
+smo
+kGH
+lXb
+pCR
+vyQ
+smg
+kUK
+vpe
+vrX
+qDQ
+jXz
+jXz
+jpq
+cju
+jXz
+jXz
+cju
+cju
+xFj
+ylB
+jfx
+jXz
+jXz
+jXz
+jXz
+bPs
 qBv
 cJF
 qBv
@@ -57495,55 +60598,55 @@ bgK
 bgK
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+mTF
+aji
+ota
+nrC
+vSy
+gLd
+abh
+aiz
+iQt
+rIj
+mUL
+pMk
+rIJ
+wEp
+svO
+aBf
+mTF
+mTF
+fLn
+jXz
+jXz
+jXz
+puF
+smo
+xnT
+rIJ
+qar
+rKt
+cma
+nYW
+vmN
+jXz
+bPs
+uiI
+pyw
+cPM
+jXz
+cju
+cju
+jXz
+ppk
+cju
+pEk
+cju
+cju
+jXz
+jXz
+bPs
 qBv
 cJF
 qBv
@@ -57797,55 +60900,55 @@ bgK
 bgK
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+mTF
+mTF
+mTF
+mTF
+mTF
+pCR
+pTz
+fUt
+gpy
+xSI
+jbd
+auY
+mTF
+mTF
+mTF
+mTF
+mTF
+fLn
+fLn
+imO
+jtX
+puF
+vmy
+smo
+xnT
+rIJ
+rIJ
+bKZ
+ikd
+wNv
+gLh
+xyX
+uFq
+jXz
+cju
+reL
+bPs
+jXz
+jXz
+pDj
+vBd
+vBd
+vBd
+vBd
+hov
+bPs
+bPs
+bPs
 qBv
 cJF
 qBv
@@ -58099,55 +61202,55 @@ bgK
 bgK
 yhR
 yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+mTF
+mTF
+mTF
+mTF
+rIJ
+iZN
+rIJ
+mTF
+mTF
+mTF
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+imO
+fLn
+jXz
+jXz
+jXz
+smo
+smo
+jXz
+bgK
+rIJ
+rIJ
+cQD
+xIF
+rIJ
+xNp
+jXz
+jXz
+cju
+cju
+hUK
+mWA
+jXz
+bPs
+vBd
+fuj
+ezX
+cJm
+cju
+jXz
+jXz
+bgK
 qBv
 cJF
 qBv
@@ -58405,51 +61508,51 @@ yhR
 yhR
 yhR
 yhR
+bgK
+bgK
+bgK
+mTF
+chS
+uZX
+fRC
+fRC
+mTF
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+imO
+fLn
+jXz
+jXz
+gTS
+smo
+jXz
+iJg
+bgK
+bgK
+rIJ
+pCR
+rIJ
+rIJ
+iaT
+oSF
+pjk
+jXz
+jXz
+fYx
+fYx
+hUK
+bPs
+jXz
+cju
+cju
+cju
+cju
+jXz
+jXz
+bgK
 qBv
 cJF
 qBv
@@ -58709,49 +61812,49 @@ yhR
 yhR
 yhR
 yhR
+bgK
+mTF
+lNt
+nrC
+foK
+lfV
+uLq
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+fLn
+bPs
+jXz
+pBK
+lvZ
+oxg
+vIc
+lWI
+bgK
+bgK
+bgK
+bgK
+bPs
+bPs
+bPs
+bPs
+tiJ
+aUp
+fYx
+mOK
+jXz
+cJm
+cju
+cju
+cju
+cju
+eLJ
+jXz
+bgK
+bgK
 qBv
 cJF
 qBv
@@ -59011,49 +62114,49 @@ yhR
 yhR
 yhR
 yhR
+bgK
+mTF
+gdb
+glF
+biw
+fRC
+mTF
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+fLn
+bPs
+qqL
+lVq
+jXz
+jXz
+bPs
+lWI
+lWI
+lWI
+lWI
+bgK
+bgK
+wni
+rVS
+sfm
+pTq
+mrF
+lmL
+lNL
+cju
+cju
+oeM
+pjk
+jXz
+jXz
+cju
+jXz
+vBd
+bgK
 qBv
 cJF
 qBv
@@ -59313,49 +62416,49 @@ yhR
 yhR
 yhR
 yhR
+bgK
+mTF
+mTF
+ama
+ota
+fRC
+mTF
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+fLn
+bPs
+bPs
+pBK
+qej
+fYD
+bPs
+lWI
+lWI
+lWI
+lWI
+bgK
+vBd
+tKk
+ylB
+xFj
+cju
+jXz
+lmL
+doR
+cju
+cuy
+oSY
+vBd
+vBd
+jLg
+cju
+jXz
+vBd
+bgK
 qBv
 cJF
 qBv
@@ -59615,6 +62718,13 @@ yhR
 yhR
 yhR
 yhR
+bgK
+bgK
+mTF
+qQJ
+hbG
+nLH
+mTF
 yhR
 yhR
 yhR
@@ -59622,41 +62732,34 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bPs
+bPs
+jXz
+jXz
+bPs
+lWI
+lWI
+lWI
+bgK
+bgK
+cQh
+jXz
+joz
+jXz
+jXz
+cju
+eie
+jXz
+eLJ
+mEq
+vBd
+mNS
+dWe
+tmf
+jXz
+jXz
+bgK
 yhR
 qBv
 cJF
@@ -59782,7 +62885,7 @@ lQD
 lQD
 lQD
 lQD
-lQD
+oht
 juN
 cJF
 cJF
@@ -59918,6 +63021,12 @@ yhR
 yhR
 yhR
 yhR
+bgK
+mTF
+ljW
+gRf
+oVb
+mTF
 yhR
 yhR
 yhR
@@ -59925,40 +63034,34 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+fMY
+jXz
+jXz
+jXz
+bPs
+lWI
+lWI
+lWI
+bgK
+oYe
+bTt
+cju
+dsF
+pyw
+xAd
+xAd
+cju
+cju
+cju
+dwg
+wAb
+nQw
+nDE
+cju
+cju
+jXz
+bgK
 yhR
 qBv
 cJF
@@ -60220,6 +63323,12 @@ yhR
 yhR
 yhR
 yhR
+bgK
+mTF
+mTF
+mTF
+mTF
+mTF
 yhR
 yhR
 yhR
@@ -60227,40 +63336,34 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+uPk
+rmD
+jXz
+jXz
+kzM
+bgK
+bgK
+bgK
+bgK
+cuy
+cju
+cju
+wcw
+pyw
+cju
+jXz
+gTS
+jXz
+sqG
+wAb
+cLC
+wZd
+sfb
+jXz
+nvj
+vBd
+bgK
 yhR
 qBv
 cJF
@@ -60522,7 +63625,6 @@ yhR
 yhR
 yhR
 yhR
-yhR
 bgK
 bgK
 bgK
@@ -60530,39 +63632,40 @@ bgK
 bgK
 bgK
 bgK
+bgK
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+kzM
+kzM
+jXz
+jXz
+pwY
+vBd
+vBd
+cLM
+ljL
+xAd
+cju
+cju
+cju
+jXz
+jXz
+tUV
+oqG
+cLC
+snY
+cLC
+bWd
+jXz
+bBZ
+vBd
+bgK
+bgK
 yhR
 qBv
 cJF
@@ -60642,40 +63745,40 @@ mPm
 vNN
 cJF
 mPm
-lQD
-qBv
-qBv
-oEb
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
+kBY
+aEc
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+bgK
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+bgK
+bgK
+bgK
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+bgK
 bPs
 dgA
 qjQ
@@ -60838,32 +63941,32 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+jXz
+jXz
+jXz
+jXz
+fZk
+cju
+cju
+cju
+cju
+pjk
+cju
+ylB
+ylB
+arZ
+bMm
+dwg
+wAb
+oMW
+bWd
+oxZ
+bPs
+bPs
+bPs
+bgK
 yhR
 yhR
 qBv
@@ -60944,40 +64047,40 @@ mPm
 cJF
 cJF
 mPm
-bgK
-qBv
-qBv
-oEb
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
-lWI
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+nrC
+kfa
+nrC
+nrC
+pFW
+mTF
+mTF
+mTF
+jij
+puW
+rNm
+cwi
+mTF
+mTF
+mTF
+mTF
+mTF
+sOF
+kfa
+gBb
+tUw
+mTF
+mTF
 bPs
 wIN
 qjQ
@@ -61141,31 +64244,31 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+fLn
+jXz
+jXz
+eeE
+xvD
+jXz
+jXz
+jXz
+uiI
+bMm
+xEh
+ylB
+eYk
+bgK
+bPs
+tkG
+cLC
+eve
+nlA
+fep
+bPs
+bgK
+bgK
+bgK
 yhR
 yhR
 qBv
@@ -61246,40 +64349,40 @@ mPm
 cJF
 cJF
 mPm
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+udV
+kfa
+nrC
+xiZ
+lSQ
+xiZ
+xiZ
+xiZ
+uue
+yao
+rIJ
+nrC
+nrC
+nrC
+nrC
+nrC
+ugs
+rIJ
+rMu
+tTk
+pmd
+pmd
+tTk
+rQV
+koa
+nnM
+mTF
+mQJ
+nrC
+qLT
+rIM
+vjs
+ksO
+mTF
 bPs
 wIN
 nfh
@@ -61444,28 +64547,28 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+vBd
+vBd
+bgK
+bgK
+bgK
+bgK
+bgK
+vBd
+vBd
+bgK
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -61548,40 +64651,40 @@ mPm
 dWH
 mDZ
 mPm
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+nWM
+nrC
+fRC
+mFw
+wyU
+fRC
+fRC
+fRC
+fRC
+paQ
+tga
+qus
+tfY
+tfY
+tfY
+qus
+qus
+rIJ
+qus
+tfY
+tfY
+qus
+tfY
+qus
+jyU
+xnL
+pzV
+xoM
+xoM
+eGo
+qus
+vjs
+dAS
+mTF
 bPs
 wIN
 lgm
@@ -61749,23 +64852,23 @@ yhR
 yhR
 yhR
 yhR
+bgK
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -61850,40 +64953,40 @@ mPm
 cJF
 eYF
 mPm
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+paQ
+paQ
+cRd
+paQ
+fRC
+cRd
+fRC
+fRC
+paQ
+tga
+rqw
+vjs
+vjs
+rqw
+mZN
+xNl
+aSo
+vjs
+rqw
+vjs
+rqw
+xNl
+vjs
+owt
+qiz
+rqw
+rqw
+rqw
+qzx
+vjs
+vjs
+uCi
+mTF
 bPs
 wIN
 qjQ
@@ -62063,10 +65166,10 @@ cNy
 cNy
 cNy
 cNy
+mIB
 cNy
 cNy
-cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -62152,40 +65255,40 @@ mPm
 cJF
 kVu
 mPm
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+paQ
+fRC
+fRC
+fRC
+ntS
+wyU
+fRC
+fRC
+fRC
+tga
+qus
+tfY
+qNt
+tfY
+qus
+qus
+rIJ
+qus
+tfY
+tfY
+qNt
+tfY
+qus
+jyU
+xnL
+mKG
+jme
+tXw
+osu
+qus
+vjs
+gsY
+mTF
 bPs
 wIN
 qsK
@@ -62368,7 +65471,7 @@ mbw
 tfz
 mbw
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -62454,40 +65557,40 @@ mPm
 cJF
 kVu
 mPm
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+mTF
+rOl
+mTF
+mTF
+mTF
+mTF
+mTF
+iZN
+mTF
+mTF
+nrC
+nrC
+nrC
+nrC
+nrC
+dZh
+rIJ
+rMu
+tTk
+pmd
+pmd
+cXV
+rQV
+koa
+jwm
+mTF
+sKI
+nrC
+xUq
+bqs
+vjs
+xep
+mTF
 bPs
 aGX
 qjQ
@@ -62670,7 +65773,7 @@ mbw
 mbw
 mbw
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -62756,40 +65859,40 @@ mPm
 rQg
 wJw
 mPm
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+mTF
+mTF
+mTF
+kHz
+pGf
+kpP
+xiZ
+paQ
+sQz
+mTF
+nrC
+lfN
+nrC
+nrC
+uJU
+mTF
+mTF
+mTF
+hzb
+bYX
+rNm
+hzb
+mTF
+mTF
+mTF
+mTF
+mTF
+nrC
+auS
+fzv
+qex
+mTF
+mTF
 bPs
 qjQ
 lgm
@@ -62972,7 +66075,7 @@ cNy
 mbw
 mbw
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -63061,37 +66164,37 @@ mPm
 bgK
 yhR
 yhR
+mTF
+rIR
+lVQ
+dXG
+qQE
+fRC
+uue
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+yhR
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+mTF
+mTF
+mTF
+aSo
+mTF
+mTF
 bPs
 njC
 qjQ
@@ -63274,7 +66377,7 @@ cNy
 mbw
 mbw
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -63363,6 +66466,14 @@ mPm
 bgK
 yhR
 yhR
+mTF
+roN
+rIR
+kHz
+xiZ
+jTu
+xiZ
+mTF
 yhR
 yhR
 yhR
@@ -63372,28 +66483,20 @@ yhR
 yhR
 yhR
 yhR
+mTF
+mTF
+mTF
+mTF
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+jEG
+rqw
+wmf
+mTF
 bPs
 bPs
 bPs
@@ -63576,7 +66679,7 @@ cNy
 mbw
 mbw
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -63665,6 +66768,14 @@ mPm
 bgK
 yhR
 yhR
+mTF
+dyg
+gOJ
+dXG
+uue
+fRC
+xiZ
+mTF
 yhR
 yhR
 yhR
@@ -63674,28 +66785,20 @@ yhR
 yhR
 yhR
 yhR
+mTF
+nhp
+wtY
+mTF
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+glE
+nPk
+qth
+mTF
 yhR
 yhR
 yhR
@@ -63878,7 +66981,7 @@ cNy
 mbw
 mbw
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -63967,37 +67070,37 @@ mPm
 bgK
 yhR
 yhR
+mTF
+tuQ
+qGr
+kHz
+uue
+paQ
+xiZ
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+vjs
+vjs
+mTF
+mTF
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+pzg
+rqw
+mwU
+mTF
 yhR
 yhR
 yhR
@@ -64180,7 +67283,7 @@ cNy
 fBL
 mbw
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -64269,37 +67372,37 @@ mPm
 bgK
 yhR
 yhR
+mTF
+dyg
+rIR
+rPu
+uue
+fRC
+xiZ
+mTF
+vNx
+hxC
+qlO
+sGX
+sGX
+qlO
+ahH
+mTF
+gxX
+foN
+aki
+vjs
+jQm
+mTF
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+tXS
+huL
+bnV
+mTF
 yhR
 yhR
 yhR
@@ -64482,9 +67585,9 @@ cNy
 mbw
 mbw
 cNy
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -64571,37 +67674,37 @@ mPm
 bgK
 yhR
 yhR
+mTF
+uVJ
+vvy
+rIR
+eiT
+fRC
+qQE
+mTF
+vjs
+rqw
+rqw
+vjs
+vjs
+mGj
+rqw
+mTF
+tPx
+pOi
+rqw
+rqw
+tWz
+mTF
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+bbq
+rqw
+ruy
+mTF
 yhR
 yhR
 yhR
@@ -64786,7 +67889,7 @@ mbw
 cNy
 cNy
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -64873,37 +67976,37 @@ mPm
 bgK
 yhR
 yhR
+mTF
+ouq
+szW
+rIR
+xiZ
+fRC
+xiZ
+pFI
+sGX
+vSN
+vSN
+vSN
+sGX
+vSN
+vSN
+vjs
+vjs
+rqw
+rqw
+vjs
+bCW
+mTF
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+rIJ
+mTF
+rIJ
+mTF
 yhR
 yhR
 yhR
@@ -65088,7 +68191,7 @@ mbw
 mbw
 mbw
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -65175,28 +68278,28 @@ mPm
 bgK
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+cln
+nbc
+pxF
+aaw
+nSD
+xiZ
+mTF
+vjs
+rqw
+rqw
+rqw
+rqw
+rqw
+rqw
+mTF
+qWw
+ydV
+pOi
+akd
+mTF
+mTF
 yhR
 yhR
 yhR
@@ -65477,28 +68580,28 @@ bgK
 bgK
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+mTF
+mTF
+aVU
+mNJ
+xoF
+ehK
+mTF
+mTF
+uCw
+wyy
+vSN
+sGX
+hxC
+wyy
+fln
+mTF
+mTF
+pFQ
+bnL
+mTF
+mTF
+mTF
 yhR
 yhR
 yhR
@@ -65779,26 +68882,26 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+fLn
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
+mTF
 yhR
 yhR
 yhR
@@ -66096,7 +69199,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+uvH
 yhR
 yhR
 yhR
@@ -69930,7 +73033,7 @@ bgK
 bgK
 bgK
 bgK
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -70232,7 +73335,7 @@ cNy
 cNy
 cNy
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -70534,7 +73637,7 @@ wCz
 qkm
 aFR
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -70836,7 +73939,7 @@ iFO
 dxU
 wdw
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -71138,7 +74241,7 @@ dZm
 uBc
 yfn
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -71440,7 +74543,7 @@ dZm
 lwy
 vsn
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -71742,7 +74845,7 @@ dZm
 lwy
 kqr
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -72044,7 +75147,7 @@ dZm
 lcW
 qkm
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -72346,7 +75449,7 @@ dZm
 lcW
 aug
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -72648,7 +75751,7 @@ dZm
 lwy
 xmL
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -72950,7 +76053,7 @@ dZm
 lwy
 fbb
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -73252,7 +76355,7 @@ dZm
 hZx
 wdw
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -73554,7 +76657,7 @@ hED
 nlJ
 yfn
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -73856,7 +76959,7 @@ wCz
 spL
 qkm
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -74158,7 +77261,7 @@ cNy
 cNy
 cNy
 cNy
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -74358,9 +77461,9 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
 bgK
 bgK
 bgK
@@ -74460,7 +77563,7 @@ bgK
 bgK
 bgK
 bgK
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -74660,7 +77763,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+bgK
 cNy
 cNy
 cNy
@@ -74730,39 +77833,39 @@ cNy
 bgK
 bgK
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -74962,7 +78065,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+bgK
 cNy
 cNG
 fbb
@@ -75032,8 +78135,8 @@ cNy
 bgK
 bgK
 bgK
-yhR
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -75264,7 +78367,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+bgK
 cNy
 qvO
 pzo
@@ -75334,8 +78437,8 @@ cNy
 cNy
 cNy
 cNy
-yhR
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -75566,7 +78669,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+bgK
 cNy
 aMV
 syE
@@ -75636,8 +78739,8 @@ mfH
 mfH
 voI
 cNy
-yhR
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -75868,7 +78971,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+bgK
 cNy
 aMV
 fbb
@@ -75938,8 +79041,8 @@ dZm
 dZm
 vuA
 cNy
-yhR
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -76170,7 +79273,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+bgK
 cNy
 lqy
 pzo
@@ -76240,8 +79343,8 @@ cke
 dZm
 vuA
 cNy
-yhR
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -76472,7 +79575,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+bgK
 cNy
 lJw
 nFf
@@ -76542,8 +79645,8 @@ pJo
 dZm
 sRT
 cNy
-yhR
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -76774,7 +79877,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+bgK
 cNy
 cNy
 cNy
@@ -76844,8 +79947,8 @@ pJo
 dZm
 rdG
 cNy
-yhR
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -77076,9 +80179,9 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
 bgK
 bgK
 bgK
@@ -77146,8 +80249,8 @@ cke
 dZm
 rdG
 cNy
-yhR
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -77448,8 +80551,8 @@ dZm
 dZm
 rdG
 cNy
-yhR
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -77750,8 +80853,8 @@ oAh
 oAh
 cjl
 cNy
-yhR
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -78052,8 +81155,8 @@ cNy
 cNy
 cNy
 cNy
-yhR
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -78342,20 +81445,20 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -78644,20 +81747,20 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
 yhR
 yhR
 yhR


### PR DESCRIPTION
Changes Include Addition of the meister bunker from tipton, slightly redone layout, w of chew and w of trainyard in 2 parts, 2nd part is sealed and accessible via the 1st part of the dungeon via ladder. Adds radioactive waste dump N of the NCR on the surface level. Added a rockface in the SW corner so its not a 90 degree corner of rock. Tiny TEENY changes to the rivers layout.

## About The Pull Request
<!-- Write here -->

## Pre-Merge Checklist
- [V] You tested this on a local server.
- [V] This code did not runtime during testing.
- [V] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
add: Added new things
add: Added more things
Add: 2 Dungeons, 1 new, 1 old.
Add: Slight mapping changes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
