### PR TITLE
medical weapons

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -685,8 +685,7 @@ Senior Scribe
 	backpack_contents = list(
 		/obj/item/book/granter/crafting_recipe/blueprint/aer9 = 1,
 		/obj/item/book/granter/crafting_recipe/blueprint/aep7 = 1,
-		/obj/item/gun/energy/laser/pistol=1,
-		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/melee/powered/ripper = 1,
 		)
 
 /datum/outfit/loadout/sshield

--- a/code/modules/jobs/job_types/enclave.dm
+++ b/code/modules/jobs/job_types/enclave.dm
@@ -391,8 +391,8 @@
 							/obj/item/clothing/suit/bio_suit/enclave = 1,
 							/obj/item/storage/belt/medical = 1,
 							/obj/item/clothing/gloves/color/latex/nitrile = 1,
-							/obj/item/stock_parts/cell/ammo/mfc = 2,
-							/obj/item/gun/energy/gammagun = 1,
+							/obj/item/gun/ballistic/revolver/needler = 1,
+							/obj/item/ammo_box/needle = 2,
 							)
 
 //NON-COMBATANTS

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -107,6 +107,8 @@ Administrator
 		/obj/item/book/granter/trait/techno = 1,
 		/obj/item/healthanalyzer/advanced = 1,
 		/obj/item/storage/bag/money/small/settler = 1,
+		/obj/item/gun/ballistic/revolver/needler = 1,
+		/obj/item/ammo_box/needle = 2,
 		/obj/item/hypospray/mkii/CMO = 1
 	)
 
@@ -300,6 +302,7 @@ Practitioner
 	backpack_contents = list(
 		/obj/item/clothing/suit/hooded/surgical = 1,
 		/obj/item/reagent_containers/medspray/synthflesh = 1,
+		/obj/item/melee/powered/ripper = 1,
 		/obj/item/healthanalyzer/advanced = 1,
 	)
 
@@ -311,6 +314,8 @@ Practitioner
 	backpack_contents = list(
 		/obj/item/flashlight/pen = 1,
 		/obj/item/pda/chemist = 1,
+		/obj/item/gun/ballistic/revolver/needler = 1,
+		/obj/item/ammo_box/needle = 2,
 	)
 
 /datum/outfit/loadout/paramedic

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -270,9 +270,9 @@ Raider
 	name = "Quack Doctor"
 	suit = /obj/item/clothing/suit/toggle/labcoat
 	l_hand = /obj/item/storage/backpack/duffelbag/med/surgery
-	suit_store = /obj/item/gun/energy/laser/wattz
+	suit_store = /obj/item/gun/ballistic/revolver/needler = 1,
 	backpack_contents = list(
-		/obj/item/stock_parts/cell/ammo/ec = 1,
+				/obj/item/ammo_box/needle = 2,
 		/obj/item/reagent_containers/pill/patch/jet = 3,
 		/obj/item/storage/firstaid/ancient = 1,
 		/obj/item/storage/pill_bottle/aranesp = 1,

--- a/code/modules/projectiles/ammunition/caseless/_caseless.dm
+++ b/code/modules/projectiles/ammunition/caseless/_caseless.dm
@@ -23,7 +23,12 @@
 	icon_state = "needler-casing"
 	caliber = CALIBER_NEEDLE
 	projectile_type = /obj/item/projectile/bullet/needle
-	var/reagent_amount = 15
+
+/obj/item/ammo_casing/caseless/needle/pierce
+	name = "An AP needler round."
+	desc = "A dart for use in needler pistols."
+	projectile_type = /obj/item/projectile/bullet/needle/pierce
+
 
 /obj/item/ammo_casing/caseless/musketball
 	name = "Musketball"

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -808,15 +808,19 @@
 
 //Needler
 /obj/item/ammo_box/needle
-	name = "needler stripper clip (needle darts)"
+	name = "HN AP needler stripper clip (needle darts)"
 	icon_state = "needler"
 	caliber = "needle"
-	ammo_type = /obj/item/ammo_casing/caseless/needle
+	ammo_type = /obj/item/ammo_casing/caseless/needle/pierce
 	caliber = list(CALIBER_NEEDLE)
 	max_ammo = 5
 	multiple_sprites = 1
 	w_class = WEIGHT_CLASS_TINY
 	custom_materials = list(/datum/material/iron = MATS_STRIPPER)
+
+/obj/item/ammo_box/needle/handload
+	name = "HN needler stripper clip (needle darts)"
+	ammo_type = /obj/item/ammo_casing/caseless/needle
 
 //.50 BMG
 /obj/item/ammo_box/a50MG

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -1660,7 +1660,7 @@
 
 /obj/item/gun/ballistic/automatic/type93
 	name = "type 93 assault rifle"
-	desc = "The standard issue rifle for the PLA at the time of the great war.. Thousands were stockpiled in the US for infiltrators before the bombs fell ."
+	desc = "The standard issue rifle for the PLA at the time of the great war. Thousands were stockpiled in the US for infiltrators before the bombs fell ."
 	icon_state = "type93"
 	item_state = "handmade_rifle"
 	icon_prefix = "handmade_rifle"

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -747,7 +747,7 @@
 
 /* * * * * * * * * * *
  * Needler 'revolver'
- * Wounding revolver
+ * Armor Piercing, low damage
  * Needles
  * Uncommon
  * * * * * * * * * * */
@@ -767,10 +767,10 @@
 	burst_shot_delay = GUN_BURSTFIRE_DELAY_NORMAL
 	burst_size = 1
 	damage_multiplier = GUN_EXTRA_DAMAGE_0
-	init_recoil = HANDGUN_RECOIL(0.8)
+	init_recoil = HANDGUN_RECOIL(0.6)
 	gun_accuracy_zone_type = ZONE_WEIGHT_PRECISION
 	init_firemodes = list(
-		/datum/firemode/semi_auto/faster
+		/datum/firemode/semi_auto/fast
 	)
 	silenced = TRUE
 	fire_sound = 'sound/weapons/gunshot_silenced.ogg'
@@ -778,7 +778,7 @@
 
 /obj/item/gun/ballistic/revolver/needler/ultra
 	name = "Ultracite needler"
-	desc = "An ultracite enhanced needler pistol." //Sounds like lame bethesda stuff to me
+	desc = "An ultracite enhanced needler pistol."
 	icon_state = "ultraneedler"
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/revneedler
 

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -26,7 +26,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_22
 	bare_wound_bonus = BULLET_WOUND_PISTOL_22_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_22
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -47,10 +47,10 @@
 	wound_bonus = RUBBERY_WOUND_PISTOL_22
 	bare_wound_bonus = BULLET_WOUND_PISTOL_22_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_22
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
-	
+
 	sharpness = SHARP_NONE
 	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
@@ -71,7 +71,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_22 * BULLET_WOUND_SHOCK
 	bare_wound_bonus = BULLET_WOUND_PISTOL_22_NAKED_MULT * BULLET_NAKED_WOUND_SHOCK
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_22
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -110,7 +110,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_9MM
 	bare_wound_bonus = BULLET_WOUND_PISTOL_9MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_9MM
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -132,7 +132,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_9MM_HANDLOAD
 	bare_wound_bonus = BULLET_WOUND_PISTOL_9MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_9MM_HANDLOAD
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -153,7 +153,7 @@
 	wound_bonus = RUBBERY_WOUND_PISTOL_9MM
 	bare_wound_bonus = BULLET_WOUND_PISTOL_9MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_9MM
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 	sharpness = SHARP_NONE
@@ -177,7 +177,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_9MM * BULLET_WOUND_ACID
 	bare_wound_bonus = BULLET_WOUND_PISTOL_9MM_NAKED_MULT * BULLET_NAKED_WOUND_ACID
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_9MM
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -215,7 +215,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_9MM * BULLET_WOUND_FIRE
 	bare_wound_bonus = BULLET_WOUND_PISTOL_9MM_NAKED_MULT * BULLET_NAKED_WOUND_FIRE
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_9MM
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -257,7 +257,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_9MM
 	bare_wound_bonus = BULLET_WOUND_PISTOL_9MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_9MM * 0.5
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -266,17 +266,16 @@
 /////////////
 
 /* * * * * * * *
- * TBD Light Pistol Bullet
- * Needle that... I guess does a fuckload of wounding?
- * TBD for sure
+ * Light Pistol Bullet
+ * DT piercing round
  * * * * * * * */
 
 /* needle
  * DAMAGE: 10
  * STAMIN: 5
  * RECOIL: 0
- * WOUNDS: 50
- * WNAKED: 58
+ * WOUNDS: 5
+ * WNAKED: 3.75
  */
 /obj/item/projectile/bullet/needle
 	name = "needle"
@@ -285,30 +284,18 @@
 	stamina = BULLET_STAMINA_PISTOL_NEEDLE
 	spread = BULLET_SPREAD_SURPLUS
 	recoil = BULLET_RECOIL_PISTOL_NEEDLE
+	damage_threshold_penetration = 10
 
-	wound_bonus = BULLET_WOUND_PISTOL_NEEDLE
-	bare_wound_bonus = BULLET_WOUND_PISTOL_NEEDLE_NAKED_MULT
+	wound_bonus = BULLET_WOUND_PISTOL_9MM
+	bare_wound_bonus = BULLET_WOUND_PISTOL_9MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_NEEDLE
-	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
-	
-	var/piercing = FALSE // not sure what this does
+	damage_falloff = BULLET_FALLOFF_START_PISTOL_HEAVY //slightly more range
 
-/obj/item/projectile/bullet/needle/improvised
-	name = "nail flechette"
-	icon_state = "cbbolt"
-	damage = BULLET_DAMAGE_PISTOL_NEEDLE_HANDLOAD
-	stamina = BULLET_STAMINA_PISTOL_NEEDLE
-	spread = BULLET_SPREAD_SURPLUS
-	recoil = BULLET_RECOIL_PISTOL_NEEDLE
 
-	wound_bonus = BULLET_WOUND_PISTOL_NEEDLE_HANDLOAD
-	bare_wound_bonus = BULLET_WOUND_PISTOL_NEEDLE_NAKED_MULT
-	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
-	pixels_per_second = BULLET_SPEED_PISTOL_NEEDLE_HANDLOAD
-	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
+/obj/item/projectile/bullet/needle/piercing
+	damage_threshold_penetration = 20
 
 ///////////
 // 10 MM //
@@ -339,7 +326,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_10MM
 	bare_wound_bonus = BULLET_WOUND_PISTOL_10MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_10MM
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -360,7 +347,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_10MM_HANDLOAD
 	bare_wound_bonus = BULLET_WOUND_PISTOL_10MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_10MM_HANDLOAD
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -381,7 +368,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_10MM_HANDLOAD
 	bare_wound_bonus = BULLET_WOUND_PISTOL_10MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_10MM_HANDLOAD * 0.5
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -402,10 +389,10 @@
 	wound_bonus = RUBBERY_WOUND_PISTOL_10MM
 	bare_wound_bonus = BULLET_WOUND_PISTOL_10MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_10MM
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
-	
+
 	sharpness = SHARP_NONE
 	zone_accuracy_type = ZONE_WEIGHT_PRECISION // Rubbers go where you want
 
@@ -426,7 +413,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_10MM * BULLET_WOUND_FIRE
 	bare_wound_bonus = BULLET_WOUND_PISTOL_10MM_NAKED_MULT * BULLET_NAKED_WOUND_FIRE
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_10MM
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -471,7 +458,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_45ACP
 	bare_wound_bonus = BULLET_WOUND_PISTOL_45ACP_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_45ACP
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -492,7 +479,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_45ACP_HANDLOAD
 	bare_wound_bonus = BULLET_WOUND_PISTOL_45ACP_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_45ACP_HANDLOAD
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -506,7 +493,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_45ACP_HANDLOAD
 	bare_wound_bonus = BULLET_WOUND_PISTOL_45ACP_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_45ACP_HANDLOAD * 0.65
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -530,7 +517,7 @@
 	wound_bonus = RUBBERY_WOUND_PISTOL_45ACP
 	bare_wound_bonus = BULLET_WOUND_PISTOL_45ACP_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_45ACP
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -554,7 +541,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_45ACP * BULLET_WOUND_FIRE
 	bare_wound_bonus = BULLET_WOUND_PISTOL_45ACP_NAKED_MULT * BULLET_NAKED_WOUND_FIRE
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_45ACP
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -601,7 +588,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_38_MATCH
 	bare_wound_bonus = BULLET_WOUND_PISTOL_38_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_38_MATCH
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -622,7 +609,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_38
 	bare_wound_bonus = BULLET_WOUND_PISTOL_38_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_38
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -643,7 +630,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_38
 	bare_wound_bonus = BULLET_WOUND_PISTOL_38_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_38
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -670,7 +657,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_38_MATCH * BULLET_WOUND_ACID
 	bare_wound_bonus = BULLET_WOUND_PISTOL_38_NAKED_MULT * BULLET_NAKED_WOUND_ACID
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_38_MATCH
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -706,7 +693,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_38_MATCH * BULLET_WOUND_FIRE
 	bare_wound_bonus = BULLET_WOUND_PISTOL_38_NAKED_MULT * BULLET_NAKED_WOUND_FIRE
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_38_MATCH
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -748,7 +735,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_44
 	bare_wound_bonus = BULLET_WOUND_PISTOL_44_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_44
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -769,7 +756,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_44_HANDLOAD
 	bare_wound_bonus = BULLET_WOUND_PISTOL_44_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_44_HANDLOAD
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -790,7 +777,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_44_HANDLOAD
 	bare_wound_bonus = BULLET_WOUND_PISTOL_44_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_44_HANDLOAD
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -812,7 +799,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_44 * BULLET_WOUND_FIRE
 	bare_wound_bonus = BULLET_WOUND_PISTOL_44_NAKED_MULT * BULLET_NAKED_WOUND_FIRE
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_44
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -854,7 +841,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_14MM
 	bare_wound_bonus = BULLET_WOUND_PISTOL_14MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_14MM
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -875,7 +862,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_14MM_HANDLOAD
 	bare_wound_bonus = BULLET_WOUND_PISTOL_14MM_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_14MM_HANDLOAD
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -896,7 +883,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_14MM * BULLET_WOUND_POISON
 	bare_wound_bonus = BULLET_WOUND_PISTOL_14MM_NAKED_MULT * BULLET_NAKED_WOUND_POISON
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_14MM
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 	var/smoke_radius = 1
@@ -950,7 +937,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_45ACP
 	bare_wound_bonus = BULLET_WOUND_PISTOL_45ACP_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_45ACP
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -978,7 +965,7 @@
 	wound_bonus = BULLET_WOUND_PISTOL_45ACP_HANDLOAD
 	bare_wound_bonus = BULLET_WOUND_PISTOL_45ACP_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_PISTOL_45ACP_HANDLOAD
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 
@@ -1001,7 +988,7 @@
 	wound_bonus = BULLET_WOUND_GHOUL_ROCK
 	bare_wound_bonus = BULLET_WOUND_GHOUL_ROCK_NAKED_MULT
 	wound_falloff_tile = BULLET_WOUND_FALLOFF_PISTOL_LIGHT
-	
+
 	pixels_per_second = BULLET_SPEED_GHOUL_ROCK
 	damage_falloff = BULLET_FALLOFF_DEFAULT_PISTOL_LIGHT
 


### PR DESCRIPTION
## About The Pull Request
<!-- Write here -->
reworks the needler to be more in line with how it was used in FO2: high DT pen, long range
certain enclave, BOS, follower, and wasteland roles with more of a medical theme get the needler as a sidearm as per FO2
needler has reduced fire rate to compensate for the -20 DT on its standard round
needler starts falloff at 5 tiles instead of 2 tiles

ripper now spawns on a few medical-themed roles, BOS scribe and FOA doctors
its both a self-defense weapon and a replacement for a circular saw


## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
change: needler now has -20DT on standard rounds, allowing it to cause scratch damage on even the heaviest targets, still affected by regular armor, so you can annoy PA users but not really kill them
buff: a few scribe, FOA, and enclave roles now get the needler instead of the wattz as well as a ripper
fix: removed a redundant period in the type 93

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
