### PR TITLE
New Brotherhood base. 

### DIFF
--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Sky.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Sky.dmm
@@ -78,6 +78,17 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"ak" = (
+/obj/structure/sign/flag_america,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood)
 "al" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common/wood_common_dark{
@@ -137,12 +148,25 @@
 	icon_state = "floordirty"
 	},
 /area/f13/followers)
-"au" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+"at" = (
+/obj/structure/junk/small/table,
+/obj/structure/junk/small/tv,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
+"au" = (
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "av" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -315,6 +339,10 @@
 	},
 /turf/open/floor/plating/f13/outside/roof/wood/old,
 /area/f13/wasteland)
+"bb" = (
+/obj/structure/debris/v3,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/building/powered)
 "bc" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -552,6 +580,10 @@
 	dir = 4
 	},
 /area/f13/building/powered)
+"bN" = (
+/obj/structure/window/fulltile/house/broken,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "bO" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants/random,
@@ -621,6 +653,15 @@
 /obj/structure/sign/poster/prewar/poster68,
 /turf/closed/wall/f13/wood,
 /area/f13/building/abandoned/z)
+"bY" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "bZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -628,6 +669,17 @@
 /obj/machinery/light,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/z)
+"ca" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "cb" = (
 /obj/structure/table,
 /turf/open/floor/holofloor/carpet,
@@ -703,9 +755,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/cyan,
 /area/f13/building/abandoned/w)
+"cm" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "cn" = (
-/turf/open/indestructible/ground/outside/roof,
-/area/f13/brotherhood/surface)
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/building/powered)
 "cp" = (
 /turf/open/transparent/openspace,
 /area/f13/building/abandoned/z)
@@ -726,6 +788,18 @@
 /obj/structure/sign/legion/veteran,
 /turf/closed/wall/f13/wood/house,
 /area/f13/legioncamp)
+"ct" = (
+/obj/structure/debris/v4,
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "cu" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood{
@@ -736,6 +810,14 @@
 /obj/structure/fluff/railing,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"cx" = (
+/obj/structure/junk/small/table,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/building/powered)
 "cz" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowbottom"
@@ -786,6 +868,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"cG" = (
+/obj/structure/table_frame,
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "cH" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plating/rust,
@@ -833,6 +927,10 @@
 /obj/structure/simple_door/house/clean,
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/building/abandoned/v)
+"cS" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "cU" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -974,6 +1072,11 @@
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
+"dj" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/campfire/barrel,
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "dk" = (
 /obj/machinery/light,
 /turf/open/transparent/openspace{
@@ -1027,6 +1130,18 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"ds" = (
+/obj/structure/junk/small/table,
+/obj/structure/junk/small/tv,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "dv" = (
 /obj/structure/toilet{
 	dir = 8;
@@ -1129,10 +1244,13 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "dM" = (
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "dN" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -1279,6 +1397,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"ej" = (
+/obj/item/stack/cable_coil,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "ek" = (
 /obj/effect/decal/cleanable/oil/streak,
 /obj/effect/decal/cleanable/dirt,
@@ -1300,6 +1422,14 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/p)
+"eo" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "eq" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -1432,14 +1562,8 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "eL" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "eM" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light/fo13colored/Red{
@@ -1484,12 +1608,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
 "eT" = (
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 12
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "eU" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/f13/wood,
@@ -1635,6 +1762,17 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/ncr)
+"fr" = (
+/obj/item/clothing/head/welding/weldingjapan,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "fs" = (
 /obj/machinery/shower{
 	dir = 4
@@ -1670,6 +1808,10 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/wood_wide,
 /area/f13/legioncamp)
+"fx" = (
+/obj/structure/debris/v4,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/building/powered)
 "fy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/wood{
@@ -1705,9 +1847,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"fG" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "fH" = (
-/turf/closed/wall/f13/store,
-/area/f13/brotherhood/surface)
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "fI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -1750,10 +1896,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/concrete,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/turf/closed/wall/rust,
+/area/f13/brotherhood)
 "fO" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/f13{
@@ -1900,6 +2044,17 @@
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/f13/wood/house/broken,
 /area/f13/building/abandoned/w)
+"gl" = (
+/obj/structure/debris/v2,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "gm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -1990,6 +2145,17 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar)
+"gD" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "gE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/raider/tribal{
@@ -2458,6 +2624,27 @@
 /obj/item/restraints/handcuffs,
 /turf/open/floor/wood_fancy,
 /area/f13/building/abandoned/j)
+"hZ" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
+"ib" = (
+/obj/structure/campfire/barrel,
+/obj/item/stack/sheet/mineral/wood{
+	amount = 5
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "ic" = (
 /obj/structure/table/wood,
 /obj/item/binoculars,
@@ -2592,10 +2779,13 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "iB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "iC" = (
 /obj/effect/turf_decal/big/energy{
 	alpha = 200;
@@ -2670,6 +2860,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/abandoned/l)
+"iP" = (
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "iQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -2761,12 +2956,10 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/ncr)
 "je" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses{
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/barricade/bars,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "jf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
@@ -2866,6 +3059,12 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"ju" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/transparent/openspace,
+/area/f13/brotherhood)
 "jv" = (
 /obj/structure/statue/bos/ladyright{
 	desc = "A statue of the Mary Magdalene, arm outstretched beseechingly... For being a biblical figure, she seems to have quite the bust in this rendition.'"
@@ -3060,6 +3259,10 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/followers)
+"kb" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "kd" = (
 /obj/machinery/porta_turret/f13/turret_shotgun/burstfire/robot,
 /obj/structure/lattice,
@@ -3159,6 +3362,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/building/powered)
+"kz" = (
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "kA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal,
@@ -3184,6 +3395,14 @@
 	},
 /turf/open/floor/wood_fancy,
 /area/f13/building/abandoned/y)
+"kF" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/building/powered)
 "kG" = (
 /obj/structure/simple_door/bunker,
 /obj/machinery/door/poddoor/shutters,
@@ -3193,6 +3412,18 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"kH" = (
+/obj/structure/junk/small/table,
+/obj/item/radio/old,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "kJ" = (
 /obj/machinery/door/airlock/medical{
 	name = "Clinic";
@@ -3249,9 +3480,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/p)
 "kQ" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "kS" = (
 /obj/structure/fluff/railing,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -3260,6 +3496,15 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"kV" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "kW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/toolbox/ammo{
@@ -3577,6 +3822,18 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/outside/snow,
 /area/f13/wasteland)
+"lR" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/transparent/openspace,
+/area/f13/brotherhood)
+"lT" = (
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/brotherhood)
 "lU" = (
 /obj/effect/gibspawner/human,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -3759,7 +4016,21 @@
 /area/f13/wasteland)
 "mt" = (
 /turf/open/transparent/openspace,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
+"mu" = (
+/obj/item/gun/ballistic/automatic/m1garand,
+/obj/item/gun/ballistic/automatic/m1carbine/compact,
+/obj/item/gun/ballistic/automatic/m1carbine/compact,
+/obj/structure/guncase,
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/building/powered)
 "mv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -3775,6 +4046,17 @@
 /obj/structure/junk/drawer,
 /turf/open/floor/carpet/purple,
 /area/f13/ambientlighting/building/g)
+"my" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "mz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/sovietsoda,
@@ -3839,10 +4121,22 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/ambientlighting/building/g)
+"mI" = (
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "mJ" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "mK" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -3863,8 +4157,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/p)
 "mO" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/surface)
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood)
 "mP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/ncrranger,
@@ -3880,11 +4177,35 @@
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
 "mT" = (
-/obj/structure/cargocrate,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	name = "old hologram";
+	pixel_x = 16;
+	pixel_y = -16
 	},
-/area/f13/brotherhood/surface)
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	icon_state = "hologram_on";
+	name = "old hologram";
+	pixel_x = 16;
+	pixel_y = 1
+	},
+/obj/machinery/shuttle_manipulator{
+	desc = "You have no idea what this shows.";
+	icon_state = "hologram_ship";
+	name = "old hologram";
+	pixel_x = 14;
+	pixel_y = 9
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "mU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/wood,
@@ -3979,6 +4300,20 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ambientlighting/building/g)
+"nm" = (
+/obj/structure/junk/machinery,
+/obj/machinery/light/small/broken{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "nn" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
@@ -4169,6 +4504,12 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/ncr)
+"nZ" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/simple_door/metal/dirtystore,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "oa" = (
 /turf/open/floor/plating/wooden{
 	icon_state = "housebase4-broken"
@@ -4285,8 +4626,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/m)
 "ot" = (
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/item/trash/f13/mechanist,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "ov" = (
 /obj/machinery/shower{
 	pixel_y = 18
@@ -4300,10 +4646,13 @@
 /turf/open/floor/mineral/titanium/white,
 /area/f13/followers)
 "ow" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/structure/nest/ghoul,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/building/powered)
 "ox" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/decal/cleanable/dirt,
@@ -4347,6 +4696,14 @@
 	dir = 1
 	},
 /area/f13/building/powered)
+"oH" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "oI" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -4510,6 +4867,13 @@
 	dir = 1
 	},
 /area/f13/building/powered)
+"pe" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "pg" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -4673,13 +5037,16 @@
 	},
 /area/f13/building/powered)
 "pK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/machinery,
 /obj/machinery/light{
-	dir = 4
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "pL" = (
 /obj/structure/curtain{
 	color = "#363636";
@@ -4737,6 +5104,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"pU" = (
+/obj/item/stack/cable_coil/cut,
+/obj/structure/chair/stool/retro/black,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "pV" = (
 /obj/structure/table,
 /obj/item/clothing/suit/armor/medium/combat/enclave,
@@ -4807,14 +5182,18 @@
 	icon_state = "floordirty"
 	},
 /area/f13/followers)
+"qf" = (
+/obj/structure/lattice/catwalk,
+/turf/closed/wall/rust,
+/area/f13/brotherhood)
 "qh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "qi" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -5035,6 +5414,20 @@
 /obj/item/storage/book/bible,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/m)
+"qW" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = 16
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "qX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/drip,
@@ -5067,12 +5460,16 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/building/powered)
 "rc" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/barricade/wooden,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/building/powered)
 "rd" = (
 /obj/machinery/shower{
 	dir = 1;
@@ -5129,9 +5526,11 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
 "rm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/store,
-/area/f13/brotherhood/surface)
+/obj/structure/sign/poster/official/ion_rifle{
+	pixel_x = -32
+	},
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "rn" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/terminal{
@@ -5255,10 +5654,24 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/abandoned/l)
 "rG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/hydroseeds,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood)
+"rH" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/f13/brotherhood)
 "rJ" = (
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/f13/wood,
@@ -5342,6 +5755,15 @@
 	dir = 4
 	},
 /area/f13/building/powered)
+"rZ" = (
+/obj/structure/junk/small/table,
+/obj/structure/junk/micro,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "sa" = (
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/underground/mountain)
@@ -5416,6 +5838,18 @@
 /obj/structure/bed,
 /turf/open/floor/wood_fancy,
 /area/f13/building/abandoned/y)
+"sn" = (
+/obj/structure/closet/crate/footlocker{
+	anchored = 1
+	},
+/obj/item/clothing/head/f13/army,
+/obj/item/clothing/under/f13/combat,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "so" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
@@ -5471,6 +5905,18 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"sy" = (
+/obj/structure/debris/v1,
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "sz" = (
 /obj/structure/table_frame,
 /obj/item/stack/sheet/metal,
@@ -5487,6 +5933,15 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"sB" = (
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/barricade/wooden/planks,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "sD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/debris/v3,
@@ -5527,6 +5982,18 @@
 	},
 /turf/open/floor/wood_mosaic,
 /area/f13/ambientlighting/building/c)
+"sM" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/item/weldingtool/basic,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "sN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe,
@@ -5788,15 +6255,31 @@
 	},
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"tF" = (
+/obj/machinery/light/broken,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "tG" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ambientlighting/building/e)
 "tH" = (
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/junk/machinery,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/building/powered)
 "tI" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -5804,15 +6287,27 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"tJ" = (
+/obj/machinery/light/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "tK" = (
-/obj/structure/railing{
-	dir = 1
+/obj/structure/debris/v4,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/building/powered)
 "tL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
@@ -5822,6 +6317,28 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"tM" = (
+/obj/structure/junk/locker,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
+"tN" = (
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "tO" = (
 /obj/structure/fence/wooden,
 /turf/open/transparent/openspace,
@@ -5830,14 +6347,12 @@
 /turf/open/floor/carpet/vault,
 /area/f13/building/abandoned/w)
 "tQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/surface)
+/area/f13/building/powered)
 "tR" = (
 /mob/living/simple_animal/bot/mulebot,
 /obj/effect/turf_decal/bot_white,
@@ -5991,6 +6506,12 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"up" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/open/transparent/openspace,
+/area/f13/brotherhood)
 "uq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -6034,6 +6555,16 @@
 	},
 /turf/open/floor/carpet/vault,
 /area/f13/building/abandoned/w)
+"uw" = (
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "ux" = (
 /obj/machinery/door/unpowered/securedoor/legion,
 /obj/effect/decal/cleanable/dirt,
@@ -6079,6 +6610,12 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
+"uD" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "uF" = (
 /obj/item/stack/sheet/metal,
 /obj/structure/table_frame,
@@ -6141,15 +6678,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/g)
 "uR" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/marker_beacon,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "uS" = (
 /obj/item/storage/toolbox/mechanical/old,
 /obj/effect/decal/cleanable/dirt,
@@ -6178,6 +6715,22 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"uV" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/bottle/instacoffee,
+/obj/item/reagent_containers/food/drinks/bottle/instatea{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "uW" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -6526,11 +7079,9 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building/powered)
 "vT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/sign/flag_america,
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "vV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
@@ -6551,6 +7102,25 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"vX" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/building/powered)
+"vY" = (
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "vZ" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/dirt,
@@ -6620,17 +7190,21 @@
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/engine/workshop)
 "wj" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/surface)
+/area/f13/building/powered)
 "wk" = (
 /obj/structure/window/fulltile/wood_window,
 /turf/open/floor/mineral/titanium,
 /area/f13/building/abandoned/w)
+"wl" = (
+/obj/structure/debris/v1,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "wm" = (
 /obj/effect/turf_decal,
 /obj/structure/barricade/sandbags,
@@ -6690,12 +7264,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/powered)
 "ww" = (
-/obj/machinery/light{
-	dir = 8;
-	flickering = 1
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/cig_packs,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "wy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/firstaid/radbgone,
@@ -6704,6 +7280,12 @@
 "wz" = (
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
+"wA" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/table,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "wB" = (
 /obj/structure/chair/comfy/black,
 /obj/effect/decal/cleanable/dirt,
@@ -6896,6 +7478,18 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/wood_common,
 /area/f13/ncr)
+"xg" = (
+/obj/structure/table,
+/obj/structure/frame/machine,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "xh" = (
 /obj/structure/railing{
 	dir = 5
@@ -6910,6 +7504,16 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/wasteland)
+"xj" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "xk" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/fridge/cannibal,
@@ -6985,6 +7589,17 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"xv" = (
+/obj/structure/closet/crate/footlocker{
+	anchored = 1
+	},
+/obj/item/clothing/head/f13/army/beret,
+/obj/item/clothing/under/f13/combat,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "xw" = (
 /turf/open/transparent/openspace,
 /area/f13/building/powered)
@@ -7268,6 +7883,14 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"yr" = (
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/building/powered)
 "yt" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -7347,6 +7970,14 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/f13/building/powered)
+"yD" = (
+/obj/structure/junk/small/bed2,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "yE" = (
 /obj/structure/junk/drawer,
 /obj/machinery/light/small{
@@ -7479,6 +8110,13 @@
 	},
 /turf/open/floor/plating/f13/outside/roof/metal,
 /area/f13/wasteland)
+"yZ" = (
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "zb" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/f13{
@@ -7524,10 +8162,16 @@
 /turf/open/floor/wood_common,
 /area/f13/followers)
 "zm" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/barricade/sandbags,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "zn" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -7594,6 +8238,10 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"zB" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "zC" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/wood_wide,
@@ -7608,10 +8256,16 @@
 	},
 /area/f13/ambientlighting/building/e)
 "zE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/debris/v4,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building/powered)
 "zF" = (
 /obj/structure/table/wood,
 /obj/item/twohanded/required/kirbyplants/random,
@@ -7746,6 +8400,14 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"zZ" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/building/powered)
 "Aa" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/decal/cleanable/dirt,
@@ -7754,10 +8416,15 @@
 	},
 /area/f13/building/powered)
 "Ab" = (
-/obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Ac" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/f13/building/abandoned/y)
@@ -7819,6 +8486,17 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/ambientlighting/building/p)
+"Am" = (
+/obj/item/paper/crumpled/bloody,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Ao" = (
 /turf/closed/wall/f13/store,
 /area/f13/ambientlighting/building/p)
@@ -7921,6 +8599,17 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"AC" = (
+/obj/structure/debris/v2,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building/powered)
 "AD" = (
 /obj/structure/table/wood/bar,
 /obj/item/binoculars,
@@ -7928,6 +8617,14 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/den)
+"AE" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "AF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood/settler,
@@ -8095,6 +8792,18 @@
 /obj/structure/simple_door/glass,
 /turf/open/floor/wood_fancy,
 /area/f13/building/abandoned/j)
+"Bl" = (
+/obj/structure/junk/small/table,
+/obj/effect/spawner/lootdrop/cigars_cases,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Bm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -8156,6 +8865,19 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"Bw" = (
+/obj/structure/closet/crate/footlocker{
+	anchored = 1
+	},
+/obj/item/clothing/head/f13/army,
+/obj/item/clothing/under/f13/combat,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "BA" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 4
@@ -8166,6 +8888,12 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"BC" = (
+/obj/structure/fluff/railing{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "BD" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -8177,6 +8905,18 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"BE" = (
+/obj/structure/table,
+/obj/item/paper/crumpled/awaymissions,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "BF" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -8253,9 +8993,15 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/c)
 "BS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/surface)
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building/powered)
 "BT" = (
 /obj/item/storage/firstaid/toxin,
 /obj/effect/decal/cleanable/dirt,
@@ -8286,6 +9032,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ambientlighting/building/c)
+"BY" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "BZ" = (
 /obj/item/newspaper{
 	pixel_x = -6;
@@ -8294,6 +9051,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
 /area/f13/ncr)
+"Ca" = (
+/obj/structure/railing,
+/turf/open/transparent/openspace,
+/area/f13/brotherhood)
 "Cb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -8346,6 +9107,12 @@
 	},
 /turf/open/floor/wood_mosaic,
 /area/engine/workshop)
+"Ci" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/transparent/openspace,
+/area/f13/brotherhood)
 "Cj" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/automatic/m1garand,
@@ -8535,6 +9302,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"CG" = (
+/obj/structure/wreck/trash/brokenvendor,
+/obj/machinery/light/small/broken{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "CH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8552,11 +9333,14 @@
 	},
 /area/f13/followers)
 "CJ" = (
-/obj/structure/table/wood,
-/obj/item/stack/sheet/mineral/plasma/fifty,
-/obj/item/stack/sheet/mineral/plasma/fifty,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "CL" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/white/line{
@@ -8926,11 +9710,16 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/building/powered)
 "DW" = (
-/obj/structure/chair/folding{
-	dir = 1
+/obj/structure/debris/v1,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "DX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common{
@@ -8964,15 +9753,16 @@
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
 "Ee" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 10
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/marker_beacon,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "Ef" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
@@ -9216,14 +10006,15 @@
 /turf/open/transparent/openspace,
 /area/f13/bar)
 "EU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "EV" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/royalblack,
@@ -9263,16 +10054,8 @@
 	},
 /area/f13/building/powered)
 "Fc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 6
-	},
-/obj/structure/marker_beacon,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/surface)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "Fd" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -9304,14 +10087,14 @@
 	},
 /area/f13/wasteland)
 "Fh" = (
-/obj/structure/railing{
-	dir = 1
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/junk/locker,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "Fi" = (
 /obj/machinery/light/fo13colored/Red{
 	desc = "A lighting fixture.";
@@ -9349,12 +10132,17 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/z)
 "Fn" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+/obj/structure/table,
+/obj/item/megaphone,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Fo" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -9404,6 +10192,17 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"Fw" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Fx" = (
 /obj/structure/closet/secure/loot,
 /obj/effect/decal/cleanable/dirt,
@@ -9449,13 +10248,16 @@
 /turf/open/floor/carpet/purple,
 /area/f13/building/powered)
 "FE" = (
-/obj/structure/closet/secure_closet/hydroponics{
-	desc = "A locker that smells of soil.";
-	name = "gardening locker";
-	req_access = list(120)
+/obj/structure/simple_door/bunker,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "FF" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
 /obj/effect/decal/cleanable/dirt,
@@ -9605,9 +10407,21 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bar)
+"Ge" = (
+/obj/structure/junk/small/table,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Gf" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/g)
+"Gg" = (
+/obj/structure/junk/small/bed2,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "Gh" = (
 /obj/structure/fluff/hedge,
 /obj/effect/decal/cleanable/dirt,
@@ -9740,14 +10554,9 @@
 /turf/open/floor/carpet/red,
 /area/f13/legioncamp)
 "Gy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/surface)
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "Gz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -9906,11 +10715,13 @@
 	},
 /area/f13/building/powered)
 "GX" = (
-/obj/structure/chair/stool{
-	pixel_y = 6
+/obj/structure/chair/stool/retro/tan,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "GY" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/customizable/bread,
@@ -9967,11 +10778,16 @@
 	},
 /area/f13/ncr)
 "Hj" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/debris/v4,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Hk" = (
 /obj/structure/table,
 /obj/item/clothing/head/crown/fancy,
@@ -10065,6 +10881,14 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"HD" = (
+/obj/structure/nest/ghoul,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "HE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10076,12 +10900,26 @@
 	},
 /area/f13/building/powered)
 "HF" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 4
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
+/area/f13/brotherhood)
+"HG" = (
+/obj/structure/junk/small/table,
+/obj/item/radio/old,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "HH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -10379,10 +11217,11 @@
 /turf/open/floor/carpet/red,
 /area/f13/ambientlighting/building/c)
 "IC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/store,
-/area/f13/brotherhood/surface)
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "ID" = (
 /obj/structure/fence/end/wooden{
 	dir = 8
@@ -10462,6 +11301,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"IR" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/turf/open/transparent/openspace,
+/area/f13/brotherhood)
 "IS" = (
 /obj/item/clothing/under/rank/civilian/janitor,
 /obj/item/storage/belt/janitor,
@@ -10494,6 +11340,17 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"IX" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "IY" = (
 /obj/machinery/light{
 	dir = 8;
@@ -10758,6 +11615,12 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/building/powered)
+"JN" = (
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/table,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "JO" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt{
@@ -10783,6 +11646,17 @@
 /obj/structure/chair/sofa/corner,
 /turf/open/floor/carpet/red,
 /area/f13/building/abandoned/w)
+"JT" = (
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "JU" = (
 /obj/structure/debris/v4,
 /turf/open/floor/f13{
@@ -10928,9 +11802,14 @@
 	},
 /area/f13/wasteland)
 "Kv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/junk/machinery,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/building/powered)
 "Kx" = (
 /obj/item/stack/cable_coil/cut,
 /obj/effect/decal/cleanable/dirt,
@@ -11245,6 +12124,10 @@
 /obj/item/weldingtool/largetank,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"Lv" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "Lw" = (
 /obj/structure/table,
 /obj/effect/turf_decal/stripes/red/line,
@@ -11597,12 +12480,11 @@
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/engine/workshop)
 "MH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/railing{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/turf/open/transparent/openspace,
+/area/f13/brotherhood)
 "MI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/nukacolavendfull{
@@ -11669,9 +12551,11 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "MV" = (
-/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 5
+	},
 /turf/open/transparent/openspace,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "MW" = (
 /obj/structure/reagent_dispensers/barrel/two,
 /obj/effect/decal/cleanable/dirt,
@@ -11735,6 +12619,14 @@
 	icon_state = "floordirty"
 	},
 /area/f13/followers)
+"Ne" = (
+/obj/structure/closet/crate/footlocker{
+	anchored = 1
+	},
+/obj/item/clothing/head/f13/army/beret,
+/obj/item/clothing/under/f13/combat,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "Nf" = (
 /turf/open/transparent/openspace,
 /area/f13/ncr)
@@ -11742,6 +12634,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/low_chance,
 /area/f13/building/powered)
+"Ni" = (
+/obj/structure/chair/stool/retro/tan,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Nk" = (
 /obj/item/clothing/suit/hazardvest,
 /obj/effect/decal/cleanable/dirt,
@@ -11856,6 +12756,15 @@
 	icon_state = "bar"
 	},
 /area/f13/ambientlighting/building/g)
+"Nz" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "NA" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/dirt,
@@ -11904,6 +12813,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/ncr)
+"NJ" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood)
 "NK" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/royalblue,
@@ -11940,6 +12863,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 1
 	},
+/area/f13/building/powered)
+"NT" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "NU" = (
 /obj/structure/simple_door/interior,
@@ -12085,9 +13012,9 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "Or" = (
-/obj/structure/barricade/concrete,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/lattice,
+/turf/open/floor/plating/f13/outside/roof/metal/verdigris,
+/area/f13/wasteland)
 "Os" = (
 /obj/machinery/light/fo13colored/Red,
 /obj/effect/decal/cleanable/dirt,
@@ -12120,6 +13047,18 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"Ox" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/item/paper/crumpled/bloody,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Oy" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/f13/ranger/trail,
@@ -12183,6 +13122,20 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/g)
+"OG" = (
+/obj/structure/table,
+/obj/item/radio/old{
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "OH" = (
 /obj/structure/railing{
 	dir = 9
@@ -12190,13 +13143,11 @@
 /turf/open/transparent/openspace,
 /area/f13/building/abandoned/w)
 "OI" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	layer = 4.1;
-	dir = 4
-	},
-/turf/open/transparent/openspace,
-/area/f13/wasteland)
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/bars,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "OJ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -12405,14 +13356,26 @@
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
 "Pq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+/obj/structure/window/fulltile/house/broken,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
+"Pr" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Ps" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/small/tv,
@@ -12427,6 +13390,22 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"Pu" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light{
+	bulb_colour = "#BC8F8F";
+	dir = 4;
+	light_color = "#BC8F8F";
+	name = "bar light"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Pv" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
@@ -12435,6 +13414,17 @@
 /obj/effect/landmark/poster_spawner/pinup,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/building/powered)
+"Px" = (
+/obj/structure/junk/small/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Py" = (
 /obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
@@ -12484,10 +13474,11 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/z)
 "PF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "PH" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/ambientlighting/building/g)
@@ -12584,11 +13575,11 @@
 	},
 /area/f13/building/powered)
 "PW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
+/obj/structure/railing{
+	dir = 1
 	},
-/area/f13/brotherhood/surface)
+/turf/open/transparent/openspace,
+/area/f13/brotherhood)
 "PX" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -12909,29 +13900,13 @@
 	},
 /area/f13/building/powered)
 "QS" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = 2;
-	pixel_y = 7
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/mug{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "QT" = (
 /obj/machinery/light/small/broken{
 	dir = 8
@@ -12959,6 +13934,14 @@
 /obj/structure/sign/flag_america,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/building/powered)
+"QY" = (
+/obj/structure/junk/locker,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "QZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -13034,6 +14017,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/abandoned/l)
+"Ri" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/building/powered)
 "Rj" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 4
@@ -13079,6 +14072,16 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/m)
+"Rq" = (
+/obj/machinery/light/small/broken{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Rr" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -13107,6 +14110,20 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/g)
+"Ru" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/flashlight/lamp{
+	light_color = "#00FFFF";
+	pixel_x = -14;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "Rv" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/carpet/royalblue,
@@ -13335,6 +14352,17 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"Sc" = (
+/obj/structure/junk/cabinet,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Sd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
@@ -13421,6 +14449,15 @@
 /obj/structure/marker_beacon,
 /turf/open/floor/plasteel/f13,
 /area/f13/wasteland)
+"Sr" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Ss" = (
 /obj/structure/target_stake,
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
@@ -13543,6 +14580,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/g)
+"SR" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "SS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack{
@@ -13600,9 +14642,13 @@
 /turf/open/floor/wood_wide,
 /area/f13/followers)
 "Tb" = (
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Tc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/wood{
@@ -13764,6 +14810,19 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"TC" = (
+/obj/machinery/light{
+	bulb_colour = "#BC8F8F";
+	dir = 4;
+	light_color = "#BC8F8F";
+	name = "bar light"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "TF" = (
 /obj/structure/table_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -13844,11 +14903,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building/abandoned/l)
 "TP" = (
-/obj/structure/closet/crate/bin{
-	anchorable = 0
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "TQ" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
@@ -13865,11 +14925,16 @@
 /turf/open/floor/carpet,
 /area/f13/ncr)
 "TR" = (
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/obj/item/flag/bos,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "TS" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -13888,16 +14953,9 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "TV" = (
-/obj/machinery/light{
-	bulb_colour = "#BC8F8F";
-	dir = 4;
-	light_color = "#BC8F8F";
-	name = "bar light"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/brotherhood/surface)
+/obj/structure/barricade/wooden,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/building/powered)
 "TW" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/dirt,
@@ -13947,6 +15005,10 @@
 	icon_state = "darkrusty";
 	name = "dirty floor"
 	},
+/area/f13/building/powered)
+"Ud" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "Ue" = (
 /obj/structure/simple_door/interior,
@@ -14095,6 +15157,14 @@
 /obj/machinery/porta_turret/f13/turret_shotgun/burstfire/robot,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"UG" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "UH" = (
 /obj/machinery/door/unpowered/secure_legion,
 /obj/effect/decal/cleanable/dirt,
@@ -14293,6 +15363,27 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/building/powered)
+"Vr" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/computer/camera_advanced/abductor{
+	desc = "One day, we'll get that dish working. Not today.";
+	name = "Inactive Radar Console";
+	pixel_y = 17
+	},
+/obj/machinery/computer/terminal{
+	icon = 'icons/obj/machines/particle_accelerator.dmi';
+	icon_keyboard = "generic_key";
+	icon_screen = "generic";
+	icon_state = "control_boxp"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Vs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -14438,12 +15529,25 @@
 /turf/open/floor/wood_common,
 /area/f13/followers)
 "VU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/obj/item/clothing/head/f13/army/general,
+/obj/structure/junk/small/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
+"VV" = (
+/obj/structure/junk/small/bed,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "VW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small,
@@ -14530,6 +15634,17 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"Wo" = (
+/obj/structure/table_frame,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Wp" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -14541,6 +15656,17 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/ncr)
+"Wq" = (
+/obj/structure/campfire/barrel,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Wv" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -14619,6 +15745,18 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"WH" = (
+/obj/structure/table,
+/obj/item/crafting/coffee_pot,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "WI" = (
 /obj/machinery/light{
 	dir = 4
@@ -14638,6 +15776,14 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"WK" = (
+/obj/machinery/workbench,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "WL" = (
 /obj/item/ammo_box/magazine/m10mm/smg/empty,
 /turf/open/floor/plating/rust,
@@ -14705,6 +15851,17 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
+/area/f13/building/powered)
+"WX" = (
+/obj/structure/debris/v1,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
 /area/f13/building/powered)
 "WY" = (
 /obj/effect/decal/remains/human,
@@ -14794,6 +15951,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"Xk" = (
+/obj/structure/barricade/wooden,
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "Xm" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor1-old"
@@ -15004,16 +16165,37 @@
 	},
 /area/f13/building/powered)
 "XV" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5
+/obj/effect/decal/cleanable/oil/streak,
+/obj/item/stack/cable_coil/cut,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/marker_beacon,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
+"XX" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = -8;
+	pixel_y = 4
 	},
-/area/f13/brotherhood/surface)
+/obj/item/reagent_containers/food/drinks/mug,
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/food/drinks/mug{
+	pixel_x = 9;
+	pixel_y = 11
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "XY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -15078,6 +16260,10 @@
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
+/area/f13/building/powered)
+"Yg" = (
+/mob/living/simple_animal/hostile/ghoul/glowing/strong/legendary,
+/turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "Yh" = (
 /turf/open/indestructible/ground/inside/mountain,
@@ -15185,6 +16371,17 @@
 /obj/structure/window/fulltile/store,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/p)
+"YB" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "YC" = (
 /obj/structure/railing{
 	dir = 1
@@ -15301,6 +16498,18 @@
 /obj/item/paper_bin,
 /turf/open/floor/carpet/royalblack,
 /area/f13/ambientlighting/building/c)
+"YZ" = (
+/obj/structure/table,
+/obj/structure/junk/micro,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Za" = (
 /turf/open/transparent/openspace,
 /area/f13/legioncamp)
@@ -15331,6 +16540,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/ambientlighting/building/c)
+"Zg" = (
+/obj/machinery/light/small/broken,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "Zi" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/rust,
@@ -15494,9 +16711,20 @@
 /turf/open/indestructible/ground/outside/snow,
 /area/f13/wasteland)
 "ZN" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plasteel/f13,
-/area/f13/brotherhood/surface)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood)
 "ZO" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /obj/effect/gibspawner/human,
@@ -15509,6 +16737,19 @@
 /mob/living/simple_animal/hostile/raider/ranged/boss,
 /turf/open/floor/carpet/blue,
 /area/f13/ambientlighting/building/g)
+"ZR" = (
+/obj/structure/chalkboard{
+	icon_state = "board_text1"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "ZS" = (
 /obj/structure/railing/corner{
 	color = "#A47449"
@@ -15516,13 +16757,16 @@
 /turf/open/transparent/openspace,
 /area/f13/ncr)
 "ZU" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/obj/structure/barricade/wooden,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "yellowrustysolid"
-	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "ZW" = (
 /obj/structure/closet/wardrobe/cargotech,
 /turf/open/floor/f13{
@@ -47413,24 +48657,24 @@ xm
 xm
 xm
 xm
+Zt
+xm
+xm
+xm
+xm
+Zt
 xm
 xm
 xm
 xm
 xm
 xm
+Zt
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
 xm
 xm
 xm
@@ -47713,36 +48957,36 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
 xm
 xm
 xm
+Zt
+Zt
+Zt
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+xm
+Zt
+xm
+Zt
+Zt
+Zt
+xm
+Zt
+Zt
 xm
 xm
+Zt
+Zt
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
 xm
 xm
 xm
@@ -48012,41 +49256,41 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -48312,44 +49556,44 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -48614,43 +49858,43 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+xm
+Zt
+Zt
+Zt
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -48915,41 +50159,41 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+xm
+Zt
+Zt
 xm
 xm
 xm
+Zt
+xm
+Zt
 xm
 xm
 xm
+Zt
+Zt
 xm
+Zt
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
 xm
 xm
 xm
@@ -49216,26 +50460,26 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+xm
+Zt
+Zt
+Zt
+Zt
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
 xm
 xm
 xm
@@ -49517,24 +50761,24 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
 xm
+Zt
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
 xm
 xm
 xm
@@ -49818,17 +51062,17 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -50119,17 +51363,17 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -50420,17 +51664,17 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -50721,17 +51965,17 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -51022,17 +52266,17 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -51323,6 +52567,16 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -51345,23 +52599,13 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Bs
+Bs
+Bs
+kO
+Bs
+Bs
+Bs
 xm
 xm
 xm
@@ -51625,6 +52869,15 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -51642,28 +52895,19 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
 xm
 xm
 xm
+Bs
+Bs
+kO
 xm
 xm
 xm
-xm
+Bs
 xm
 xm
 xm
@@ -51926,6 +53170,16 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -51944,28 +53198,18 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
 xm
 xm
-xm
-xm
-xm
+kO
+Bs
 xm
 xm
 xm
@@ -52227,6 +53471,16 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -52246,28 +53500,18 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
 xm
 xm
 xm
-xm
-xm
+kO
 xm
 xm
 xm
@@ -52532,6 +53776,12 @@ Zt
 Zt
 Zt
 Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -52548,28 +53798,22 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+Bs
+Bs
+Bs
+xm
+Bs
+Bs
+Bs
+Bs
+xm
+Bs
+Bs
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Bs
+Bs
 xm
 xm
 xm
@@ -52835,6 +54079,10 @@ Zt
 Zt
 Zt
 Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -52850,28 +54098,24 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+xm
+xm
+Bs
+Bs
+Bs
+xm
+xm
+Bs
 xm
 xm
 xm
+Bs
 xm
 xm
 xm
-xm
-xm
-xm
-xm
+kO
+kO
+Bs
 xm
 xm
 xm
@@ -53138,6 +54382,8 @@ Zt
 Zt
 Zt
 Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -53152,26 +54398,24 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
 xm
 xm
 xm
+Bs
 xm
 xm
+Bs
+kO
+xm
+xm
+xm
+xm
+xm
+xm
+Bs
 xm
 xm
 xm
@@ -53440,6 +54684,8 @@ Zt
 Zt
 Zt
 Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -53454,27 +54700,25 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
+Bs
+Bs
+Bs
+xm
+kO
+Bs
+kO
+Bs
+Bs
+kO
 xm
 xm
+Bs
+Bs
 xm
-xm
-xm
-xm
-xm
+Bs
+Bs
 xm
 xm
 xm
@@ -53756,28 +55000,28 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
 xm
+Bs
+xm
+Bs
+Bs
+Bs
+xm
+kO
+xm
+Bs
+Bs
+xm
+Bs
+Bs
 xm
 xm
 xm
-xm
-xm
-xm
+Bs
+Bs
 xm
 xm
 xm
@@ -54058,33 +55302,33 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+xm
+xm
+xm
+xm
+kO
+xm
+kO
+Bs
+Bs
+Bs
+Bs
+xm
+Bs
+Bs
+xm
+Bs
+Bs
+xm
+xm
+Bs
+Bs
+Bs
 xm
 xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
@@ -54360,33 +55604,33 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+xm
+xm
+xm
+xm
+Bs
+kO
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
 xm
 xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
 xm
 xm
 xm
@@ -54662,33 +55906,33 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
 xm
 xm
 xm
@@ -54964,33 +56208,33 @@ xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+cn
+fx
+BS
+BS
+AC
 xm
 xm
 xm
@@ -55265,34 +56509,34 @@ xm
 xm
 xm
 xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+pm
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+Yj
+eK
 xm
 xm
 xm
 xm
 xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+BS
+tQ
+sP
+bb
+cn
 xm
 xm
 xm
@@ -55558,43 +56802,43 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
+xm
+xm
+xm
+pm
+rT
+wT
+wT
+wT
+wT
+wT
+wT
+wT
+wT
+QC
+fH
+eT
+CJ
+Pq
+CJ
+eT
+fH
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+TV
+sP
+cn
+tQ
+bb
 xm
 xm
 xm
@@ -55860,43 +57104,43 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
+xm
+xm
+xm
+Ce
+wT
+wT
+fN
+fN
+Nz
+fN
+fN
+fN
+wT
+wT
+FE
+Ab
+uR
+uR
+uR
+tJ
+eT
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+BS
+tK
+wj
+sP
+fx
 xm
 xm
 xm
@@ -56162,43 +57406,43 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
+xm
+xm
+xm
+Ce
+wT
+qf
+mO
+eL
+eL
+BY
+Ab
+dM
+wT
+wT
+FE
+mJ
+mJ
+Ab
+Ab
+Ab
+eT
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+BS
+rc
+cn
+BS
+BS
 xm
 xm
 xm
@@ -56464,6 +57708,32 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
+xm
+xm
+xm
+Ce
+wT
+qf
+eL
+mt
+eL
+fr
+XV
+fN
+wT
+IC
+eT
+lT
+lR
+pU
+Ab
+TP
+CJ
 xm
 xm
 xm
@@ -56472,35 +57742,9 @@ xm
 xm
 xm
 xm
+wT
+dj
 xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
@@ -56766,6 +58010,32 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
+xm
+xm
+xm
+Ce
+wT
+qf
+mO
+eL
+ej
+sM
+gD
+fN
+wT
+YC
+eT
+IR
+Ca
+Fw
+Ab
+TP
+CJ
 xm
 xm
 xm
@@ -56774,35 +58044,9 @@ xm
 xm
 xm
 xm
+kO
+wT
 xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
@@ -57049,7 +58293,6 @@ xm
 xm
 xm
 xm
-xm
 Zt
 Zt
 Zt
@@ -57057,6 +58300,8 @@ Zt
 Zt
 Zt
 Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -57067,6 +58312,32 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
+xm
+xm
+xm
+Ce
+wT
+wT
+fN
+fN
+fN
+fN
+fN
+fN
+BC
+sU
+eT
+mt
+Ca
+Ab
+Ab
+TP
+CJ
 xm
 xm
 xm
@@ -57076,35 +58347,8 @@ xm
 xm
 xm
 xm
+kO
 xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
@@ -57347,16 +58591,55 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 Zt
 Zt
 xm
-Zt
-Zt
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+Bs
+Bs
+Bs
+Bs
+Bs
+xm
+xm
+xm
+ZF
+qU
+wT
+wT
+wT
+wT
+wT
+YC
+xm
+xm
+eT
+HF
+Ab
+Ab
+Ab
+Ab
+Ab
+ZU
 xm
 xm
 xm
@@ -57368,45 +58651,6 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
@@ -57648,6 +58892,20 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -57658,6 +58916,32 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
+xm
+xm
+xm
+xm
+ZF
+BC
+BC
+BC
+BC
+BC
+sU
+eT
+HF
+ZU
+eo
+qh
+zm
+zm
+zm
+Ab
+eT
 xm
 xm
 xm
@@ -57666,49 +58950,9 @@ xm
 xm
 xm
 xm
+kO
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
 xm
 xm
 xm
@@ -57948,6 +59192,21 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -57959,6 +59218,11 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
 xm
 xm
 xm
@@ -57970,47 +59234,27 @@ xm
 xm
 xm
 xm
+eT
+Hj
+gl
+Ab
+kQ
+Wq
+Ab
+Ab
+tF
+eT
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+BS
+BS
+BS
+BS
+BS
 xm
 xm
 xm
@@ -58249,6 +59493,38 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+Bs
+Bs
+Bs
+Bs
+Bs
 xm
 xm
 xm
@@ -58260,59 +59536,27 @@ xm
 xm
 xm
 xm
+eT
+Ab
+Ab
+Ab
+Ab
+Ab
+Ab
+Ab
+sy
+eT
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+BS
+wl
+mu
+cx
+WX
 xm
 xm
 xm
@@ -58549,6 +59793,24 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -58560,6 +59822,11 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
 xm
 xm
 xm
@@ -58571,50 +59838,27 @@ xm
 xm
 xm
 xm
+Pq
+YB
+Ab
+yZ
+Ab
+Wo
+Wo
+DW
+Hj
+eT
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+BS
+sP
+Yg
+lb
+BS
 xm
 xm
 xm
@@ -58850,6 +60094,41 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+xm
+Zt
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+Bs
+Bs
+Bs
+Bs
+Bs
 xm
 xm
 xm
@@ -58861,62 +60140,27 @@ xm
 xm
 xm
 xm
+Pq
+YB
+Ab
+PF
+ZN
+rG
+rG
+ZN
+NJ
+ZU
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+OI
+tH
+uD
+lb
+OI
 xm
 xm
 xm
@@ -59151,6 +60395,26 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -59162,6 +60426,11 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
 xm
 xm
 xm
@@ -59173,52 +60442,27 @@ xm
 xm
 xm
 xm
+CJ
+Ee
+uR
+cm
+ca
+gD
+ib
+YZ
+YB
+CJ
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+OI
+ow
+vX
+EN
+OI
 xm
 xm
 xm
@@ -59453,6 +60697,25 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -59465,6 +60728,11 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
 xm
 xm
 xm
@@ -59476,51 +60744,27 @@ xm
 xm
 xm
 xm
+eT
+CG
+Ab
+uR
+Ab
+Ab
+Ab
+Ab
+YB
+CJ
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+je
+CA
+Gy
+NT
+OI
 xm
 xm
 xm
@@ -59755,6 +60999,26 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -59766,63 +61030,43 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
+xm
+xm
+kO
+Bs
+Or
+kO
+Or
+Bs
+Bs
+kO
+Or
+fH
+Hj
+Ab
+PF
+yZ
+hZ
+Ab
+Ab
+YB
+Pq
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+BS
+BJ
+Ri
+Gy
+BS
 xm
 xm
 xm
@@ -60057,6 +61301,26 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -60068,63 +61332,43 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-Ce
+Bs
+kO
+Bs
+Bs
+Bs
+Bs
 Or
+Bs
 Or
-Or
-Or
-Or
-Or
-Or
-YC
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+fH
+DW
+Hj
+Ab
+uR
+uR
+PF
+Ab
+Ab
+fH
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
+BS
+CA
+sP
+kb
+BS
 xm
 xm
 xm
@@ -60359,6 +61603,28 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -60368,65 +61634,43 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-Ce
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
 Or
-Kv
-PF
-Kv
-PF
-Kv
-Or
-YC
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+Bs
+fH
+Ab
+Ab
+ib
+Ab
+uR
+uR
+qh
+IX
+eT
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
+BS
+cx
+yr
+sP
+zE
 xm
 xm
 xm
@@ -60662,6 +61906,26 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -60672,63 +61936,43 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
 xm
 xm
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-Yj
-HF
 Or
-Kv
-vT
-pK
-PF
-Kv
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
 Or
-YC
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+Or
+fH
+ca
+gD
+tN
+Px
+nm
+uR
+uR
+my
+eT
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
+OI
+lb
+zB
+sP
+BS
 xm
 xm
 xm
@@ -60965,6 +62209,26 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -60974,63 +62238,43 @@ xm
 xm
 xm
 xm
+Bs
+Bs
+Bs
+Bs
+Bs
 xm
-Ce
-ot
-ww
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-Kv
-zE
-IC
-Pq
-Kv
+xm
+kO
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
 Or
-YC
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+Or
+fH
+fH
+Xk
+kV
+fH
+eT
+Tb
+Tb
+ZU
+eT
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
+OI
+kF
+lb
+zZ
+BS
 xm
 xm
 xm
@@ -61267,6 +62511,25 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -61277,62 +62540,43 @@ xm
 xm
 xm
 xm
-Ce
-TP
-ot
-CJ
-DW
-ot
-ot
-tH
-tH
-tH
-ot
-Kv
-VU
-Kv
-Kv
-Kv
-Kv
-ot
-Kv
-Kv
-Kv
-EU
-Kv
-Kv
+xm
+xm
+xm
+xm
+xm
+xm
+xm
 Or
-YC
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
+Or
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+fH
+ZR
+tN
+Ab
+Ab
+Pr
+uR
+uR
+ct
+fH
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
+OI
+sP
+SR
+ow
+BS
 xm
 xm
 xm
@@ -61570,6 +62814,25 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -61579,62 +62842,43 @@ xm
 xm
 xm
 xm
-Ce
-zm
-GX
-QS
-DW
-ot
-ot
-ot
-ot
-ot
-ot
-kQ
-fH
-Fn
-ot
-mt
-ot
-ot
-Kv
-ot
-Kv
-PF
-Kv
-PF
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+Bs
 Or
-YC
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
+Bs
+Bs
+Bs
+Bs
+Bs
+Or
+Bs
+fH
+Ab
+pe
+mI
+vY
+Ab
+uR
+uR
+Ee
+fH
 xm
 xm
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
+OI
+Ud
+NT
+Kv
+BS
 xm
 xm
 xm
@@ -61873,6 +63117,24 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -61881,62 +63143,44 @@ xm
 xm
 xm
 xm
-Ce
-Ab
-ot
-je
-DW
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-Hj
-ot
-ot
-ot
-ot
-ot
-ot
-ot
-PF
-ot
-PF
-ot
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+Bs
 Or
-YC
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Bs
+Bs
+Bs
+Bs
+Bs
+Or
+Or
+fH
+xg
+yZ
+Fn
+OG
+vY
+Ab
+Ab
+uV
+eT
+fH
+eT
+eT
+eT
+eT
+eT
+BS
+JN
+BS
+BS
+BS
 xm
 xm
 xm
@@ -62176,6 +63420,22 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -62183,60 +63443,44 @@ xm
 xm
 xm
 xm
-Ce
-FE
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+kO
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+Or
+vT
+qW
+mT
+PF
+cG
+XV
+Ab
+Ab
+WH
 eT
-ot
-ot
-Kv
-ot
-ot
-ot
-ot
-ot
-ot
-eL
-yz
-yz
-yz
-yz
-yz
-yz
-rc
-MV
-ot
-MV
+VV
+HG
+yD
+Bw
+eT
 Fh
-yz
-xm
-xm
-xm
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-fn
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Lv
+wA
+eT
 xm
 xm
 xm
@@ -62480,35 +63724,21 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-Ce
-mJ
-ZN
-Tb
-ot
-Kv
-ot
-ot
-ot
-ot
-ot
-eL
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-Ce
-MV
-ot
-MV
-YC
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -62525,20 +63755,34 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+Or
+Or
+fH
+Ab
+Ab
+PF
+Vr
+Ox
+Ab
+Ab
+XX
+eT
+xv
+Fc
+Fc
+Fc
+eT
+tM
+Fc
+cS
+eT
 xm
 xm
 xm
@@ -62782,65 +64026,65 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
 xm
 xm
-Ce
-cn
-PW
-mT
-ot
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+kO
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+Bs
+fH
+TR
+Ab
+Ab
+ca
+vY
+uR
+uR
+uR
+eT
+EU
 Fc
-Gy
-Gy
-Gy
-XV
-cn
-YC
-xm
-xm
-xm
-xm
-xm
-xm
-MC
-OI
-MV
-ot
-MV
-tK
-Yj
-Yj
-Yj
-Yj
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+VV
+TP
+eT
+QY
+iB
+HD
+eT
 xm
 xm
 xm
@@ -63085,64 +64329,64 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
 xm
-Ce
-cn
-PW
-ot
-ot
-tQ
-au
-au
-ow
-TR
-cn
-YC
 xm
 xm
 xm
 xm
 xm
-ms
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+kO
 Or
 Or
-ot
-ot
-ot
+Bs
+Bs
 Or
 Or
-Or
-Or
-Or
-YC
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Bs
+Bs
+fH
+BE
+Ab
+xg
+Ru
+mI
+XV
+uR
+uR
+ZU
+sn
+TP
+TP
+Ne
+HF
+AE
+xj
+Ge
+eT
 xm
 xm
 xm
@@ -63388,63 +64632,63 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+xm
+Zt
 xm
 xm
 xm
-Ce
-cn
-iB
-rG
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+Bs
+Bs
+Bs
+kO
+kO
+Bs
+Bs
+kO
+Bs
+fH
+Ab
+Pu
+Ab
+PF
+Pu
+Ab
+uR
+uR
+dM
+au
+TP
 ot
-wj
-ow
-ow
-ow
-TR
-cn
-YC
-xm
-xm
-xm
-xm
-xm
-ms
-Or
-Kv
-Kv
-VU
-ot
-ot
-ot
-ot
-ot
-Or
-YC
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+Gg
+eT
+TP
+cS
+QY
+eT
 xm
 xm
 xm
@@ -63691,37 +64935,17 @@ xm
 xm
 xm
 xm
-xm
-xm
-Ce
-cn
-Kv
-Kv
-cn
-Ee
-ZU
-ZU
-ZU
-uR
-cn
-YC
-xm
-xm
-xm
-xm
-xm
-ms
-fN
-Kv
-kQ
-rm
-qh
-Kv
-Kv
-Kv
-Kv
-Or
-YC
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -63747,6 +64971,26 @@ xm
 xm
 xm
 xm
+xm
+fH
+eT
+eT
+fG
+sB
+eT
+eT
+TP
+TP
+dM
+au
+au
+au
+Ge
+eT
+nZ
+nZ
+eT
+eT
 xm
 xm
 xm
@@ -63994,61 +65238,61 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
-Ce
-ot
-TV
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+fH
+fH
+PF
+PF
+uR
+Ab
+rm
+fH
+fH
+eT
+eT
 dM
 dM
-cn
-cn
-cn
-cn
-cn
-cn
-YC
-xm
-xm
-xm
-xm
-xm
-ms
-fN
-ot
-Kv
-MH
-ot
-Kv
-Kv
-Kv
-Kv
-Or
-YC
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+eT
+eT
+UG
+Sr
+QY
+eT
 xm
 xm
 xm
@@ -64297,34 +65541,16 @@ xm
 xm
 xm
 xm
-xm
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-yz
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-BS
-BS
-BS
-mO
-mO
-mO
-BS
-BS
-mO
-mO
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -64351,6 +65577,24 @@ xm
 xm
 xm
 xm
+fH
+bY
+kH
+VU
+at
+fH
+xm
+xm
+eT
+kz
+au
+au
+Rq
+au
+TP
+TP
+pK
+eT
 xm
 xm
 xm
@@ -64600,6 +65844,15 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -64626,33 +65879,24 @@ xm
 xm
 xm
 xm
+fH
+Ab
+Bl
+Am
+JT
+fH
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+eT
+ds
+au
+au
+au
+au
+TP
+TP
+WK
+eT
 xm
 xm
 xm
@@ -64903,6 +66147,15 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -64928,33 +66181,24 @@ xm
 xm
 xm
 xm
+fH
+uR
+uR
+Ab
+Sc
+fH
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+eT
+au
+QS
+ww
+QS
+PW
+Ca
+au
+au
+eT
 xm
 xm
 xm
@@ -65206,6 +66450,14 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -65231,32 +66483,24 @@ xm
 xm
 xm
 xm
+fH
+CJ
+CJ
+vT
+fH
+fH
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+eT
+rZ
+au
+ju
+lT
+rH
+Ci
+lR
+TP
+eT
 xm
 xm
 xm
@@ -65508,6 +66752,15 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -65540,25 +66793,16 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+eT
+ak
+au
+PW
+mt
+mt
+mt
+Ca
+au
+eT
 xm
 xm
 xm
@@ -65811,6 +67055,14 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -65844,23 +67096,15 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+ZU
+au
+MV
+MH
+MH
+MH
+up
+au
+eT
 xm
 xm
 xm
@@ -66114,6 +67358,14 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -66146,23 +67398,15 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+ZU
+uw
+au
+au
+au
+oH
+GX
+Zg
+eT
 xm
 xm
 xm
@@ -66417,6 +67661,12 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -66450,21 +67700,15 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+eT
+Ni
+oH
+GX
+TC
+au
+TP
+TP
+eT
 xm
 xm
 xm
@@ -66721,6 +67965,10 @@ xm
 xm
 xm
 xm
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -66754,19 +68002,15 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+eT
+iP
+bN
+bN
+ZU
+bN
+iP
+bN
+eT
 xm
 xm
 xm
@@ -67025,9 +68269,9 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
+Zt
+Zt
+Zt
 xm
 xm
 xm

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
@@ -8,6 +8,11 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ambientlighting/building/i)
+"aah" = (
+/obj/structure/debris/v4,
+/obj/structure/debris/v2,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "aax" = (
 /obj/machinery/workbench,
 /turf/open/indestructible/ground/outside/road,
@@ -110,6 +115,14 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"abJ" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "abS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -200,14 +213,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/abandoned/z)
 "adY" = (
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "aeE" = (
 /obj/structure/rack,
 /obj/item/clothing/under/blacktango,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/h)
+"aeX" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
 "aeY" = (
 /obj/structure/sign/departments/medbay/alt{
 	name = "TRIAGE"
@@ -253,14 +274,13 @@
 /turf/open/floor/carpet/orange,
 /area/f13/ambientlighting/building/c)
 "age" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+/obj/structure/fence{
+	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+	icon_state = "verticalleftborderleft2bottom"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "agf" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft3"
@@ -385,6 +405,13 @@
 	},
 /turf/open/floor/wood_common/wood_common_light,
 /area/f13/building/abandoned/x)
+"aiw" = (
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "aiH" = (
 /obj/structure/simple_door/house{
 	name = "Mayor's Office"
@@ -565,11 +592,11 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/w)
 "alK" = (
-/obj/effect/overlay/desert/sonora/edge{
+/obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	icon_state = "horizontaloutermain2right"
 	},
 /area/f13/wasteland)
 "alP" = (
@@ -876,11 +903,13 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legioncamp)
 "arA" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "arP" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticalcorroded"
@@ -920,6 +949,12 @@
 /area/f13/ambientlighting/building/h)
 "asD" = (
 /mob/living/simple_animal/hostile/raider/thief,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"asG" = (
+/obj/structure/car/rubbish2,
+/obj/structure/wreck/trash/one_barrel,
+/obj/effect/decal/cleanable/oil/streak,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "asH" = (
@@ -985,6 +1020,16 @@
 	},
 /turf/open/floor/plating,
 /area/f13/bar)
+"atH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "atI" = (
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
@@ -1007,9 +1052,9 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "atY" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/obj/structure/sign/stop,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "auc" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -1416,14 +1461,9 @@
 	},
 /area/f13/building/lower_firetower)
 "ayR" = (
-/obj/machinery/power/port_gen/pacman/diesel{
-	anchored = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "azd" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
@@ -1520,6 +1560,14 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ambientlighting/building/x)
+"aAL" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "aAO" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -1613,9 +1661,16 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ambientlighting/building/t)
 "aCZ" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "aDa" = (
 /obj/structure/shelf_wood,
 /obj/item/flashlight/flare/torch,
@@ -1633,11 +1688,15 @@
 	},
 /area/f13/wasteland)
 "aDA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/legendary,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "aDF" = (
 /obj/structure/table,
 /obj/item/storage/pill_bottle/chem_tin/radx,
@@ -1655,6 +1714,15 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/x)
+"aEd" = (
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	dir = 1
+	},
+/area/f13/wasteland)
 "aEf" = (
 /obj/machinery/workbench/mbench,
 /obj/effect/decal/cleanable/dirt,
@@ -1846,14 +1914,26 @@
 	},
 /area/f13/followers)
 "aHQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/stairs/south,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/brotherhood/surface)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2top"
+	},
+/area/f13/brotherhood/powered)
 "aHU" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"aHV" = (
+/obj/machinery/door/unpowered/secure_bos,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/brotherhood/powered)
 "aIi" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -1906,13 +1986,9 @@
 /turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "aJp" = (
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood)
 "aJr" = (
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/inside/dirt,
@@ -2029,10 +2105,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/abandoned/t)
 "aLr" = (
-/obj/structure/campfire/barrel,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
 "aLv" = (
@@ -2119,6 +2195,17 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"aMD" = (
+/obj/item/gun/energy/laser/pistol,
+/obj/item/gun/energy/laser/pistol,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/guncase,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "aMQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -2189,12 +2276,11 @@
 	},
 /area/f13/building/abandoned/t)
 "aOi" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/indestructible/ground/outside/sidewalk{
+/turf/open/indestructible/ground/outside/road{
 	dir = 1;
-	icon_state = "horizontaloutermain1"
+	icon_state = "innermaincornerinner"
 	},
-/area/f13/wasteland)
+/area/f13/caves)
 "aOn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -2391,6 +2477,19 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ambientlighting/building/g)
+"aRk" = (
+/obj/item/toy/cards/deck,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "aRp" = (
 /obj/structure/wreck/trash/autoshaft{
 	pixel_x = -8
@@ -2441,15 +2540,11 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/caves)
 "aRO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/surface)
+/obj/structure/table,
+/obj/item/taperecorder/empty,
+/obj/item/tape,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "aRQ" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
@@ -2576,6 +2671,17 @@
 	dir = 5
 	},
 /area/f13/ambientlighting/building/j)
+"aTU" = (
+/obj/machinery/vending/tool,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "aTW" = (
 /turf/closed/mineral/random,
 /area/f13/wasteland)
@@ -2722,16 +2828,12 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "aWg" = (
-/obj/structure/railing/handrail{
-	dir = 8
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
 	},
-/obj/structure/railing/handrail{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs{
-	dir = 1
-	},
-/area/f13/building/abandoned/m)
+/area/f13/wasteland)
 "aWh" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/knife,
@@ -2925,6 +3027,11 @@
 "aYN" = (
 /turf/open/floor/plasteel/darkbrown,
 /area/f13/ambientlighting/building/y)
+"aYP" = (
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "aYS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3017,18 +3124,28 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "ban" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/surface)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "baq" = (
 /obj/structure/wreck/bus/rusted,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "bav" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#d8b1b1"
+	},
+/obj/structure/table,
+/obj/item/crafting/coffee_pot,
+/obj/item/reagent_containers/food/drinks/bottle/instatea{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "bax" = (
 /obj/effect/overlay/desert_side{
 	dir = 1
@@ -3058,10 +3175,13 @@
 	},
 /area/f13/ambientlighting/building/f)
 "baQ" = (
-/obj/machinery/power/apc/fusebox/south,
-/obj/structure/cable,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "baS" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -3369,6 +3489,14 @@
 /obj/structure/nest/scorpion,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"bgO" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "bgV" = (
 /obj/effect/overlay/desert_side{
 	dir = 8
@@ -3438,6 +3566,10 @@
 	},
 /turf/open/indestructible/ground/outside/water/running,
 /area/f13/wasteland)
+"bhV" = (
+/obj/structure/wreck/trash/engine,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building/powered)
 "bhW" = (
 /obj/structure/table,
 /obj/item/locked_box/misc/attachments,
@@ -3537,6 +3669,11 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/g)
+"bjT" = (
+/turf/open/floor/plasteel/stairs{
+	dir = 4
+	},
+/area/f13/building/powered)
 "bjZ" = (
 /obj/structure/chair{
 	dir = 8
@@ -3699,6 +3836,16 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/building/abandoned/j)
+"bmK" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood)
 "bmV" = (
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -3955,6 +4102,19 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/ncr)
+"bsi" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/item/reagent_containers/glass/bottle/blackpowder,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 9
+	},
+/area/f13/brotherhood)
 "bsp" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4005,12 +4165,12 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legioncamp)
 "btr" = (
-/obj/machinery/light{
-	pixel_x = -16
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood)
 "btx" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -4063,10 +4223,9 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "bug" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/oil/streak,
+/obj/structure/debris/v4,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/area/f13/building/powered)
 "buo" = (
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /turf/open/indestructible/ground/outside/dirt,
@@ -4324,12 +4483,17 @@
 	},
 /area/f13/wasteland)
 "bzH" = (
-/obj/structure/flora/tree/tall,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirtcorner"
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/wasteland)
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "bzT" = (
 /obj/structure/chair/bench{
 	dir = 4;
@@ -4715,6 +4879,16 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"bGM" = (
+/obj/structure/barricade/sandbags,
+/obj/machinery/camera/autoname{
+	name = "Secuirty Camera";
+	network = list("BoS")
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
 "bHd" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/disposalpipe/segment{
@@ -4768,6 +4942,14 @@
 	dir = 1
 	},
 /area/f13/ambientlighting/building/y)
+"bHI" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "bHL" = (
 /obj/structure/railing{
 	color = "#A47449"
@@ -4852,13 +5034,11 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ambientlighting/building/x)
 "bJL" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
+/obj/structure/car/rubbish3{
+	icon_state = "car_rubish2"
 	},
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plating/f13/outside/road,
-/area/f13/building/abandoned/m)
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "bJW" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
@@ -4869,9 +5049,15 @@
 	},
 /area/f13/ambientlighting/building/j)
 "bJX" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "bKe" = (
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/plating/rust,
@@ -4943,6 +5129,13 @@
 	},
 /turf/open/floor/carpet/arcade,
 /area/f13/ambientlighting/building/j)
+"bLo" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "bLC" = (
 /turf/open/floor/plating/dirt,
 /area/f13/ncr)
@@ -5246,6 +5439,14 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"bQf" = (
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bQi" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -5326,6 +5527,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland/city)
+"bRp" = (
+/obj/structure/guncase,
+/obj/item/gun/energy/laser/aer9,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood)
 "bRv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -5955,14 +6163,16 @@
 	},
 /area/f13/wasteland)
 "ccm" = (
-/obj/structure/railing/handrail{
-	dir = 4
+/obj/structure/barricade/wooden/strong,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/obj/structure/railing/handrail{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/building/abandoned/m)
+/area/f13/building/powered)
 "ccp" = (
 /turf/open/floor/wood_common{
 	icon_state = "common-broken2"
@@ -6098,10 +6308,16 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
 "cfw" = (
-/obj/effect/decal/cleanable/oil/streak,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/machinery/camera/autoname{
+	name = "Secuirty Camera";
+	network = list("BoS")
+	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "cfy" = (
 /obj/effect/overlay/desert/sonora/edge{
 	dir = 1
@@ -6190,6 +6406,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/e)
+"chn" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "cht" = (
 /obj/structure/flora/wasteplant/wild_broc,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -6296,10 +6519,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblack,
 /area/f13/building/abandoned/l)
+"cjQ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "cjZ" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating/dirt,
 /area/f13/ncr)
+"ckc" = (
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "ckf" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -6406,6 +6645,11 @@
 /obj/structure/closet/cabinet/anchored,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/building/abandoned/z)
+"cla" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "clg" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/generic,
@@ -6721,9 +6965,13 @@
 	},
 /area/f13/wasteland)
 "crL" = (
-/obj/structure/debris/v3,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2"
+	},
+/area/f13/brotherhood/powered)
 "crO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -7016,14 +7264,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/e)
 "cwf" = (
-/obj/effect/spawner/lootdrop/maybe_enclave_beret,
-/obj/structure/cable/outdoors{
-	icon_state = "1-2"
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/effect/overlay/desert/sonora/edge,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
-/area/f13/brotherhood/surface)
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "cwn" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/structure/reagent_dispensers/barrel/dangerous{
@@ -7229,13 +7481,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
 "cyJ" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain3"
+/obj/machinery/vending/wallmed{
+	pixel_x = -32
 	},
-/area/f13/wasteland)
+/obj/structure/stairs/west,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "cyL" = (
 /obj/structure/simple_door/room/dirty,
 /turf/open/floor/plasteel/f13{
@@ -7392,12 +7650,14 @@
 	},
 /area/f13/building/abandoned/h)
 "cBt" = (
-/obj/structure/junk/machinery,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "cBx" = (
 /mob/living/simple_animal/hostile/gecko,
 /obj/structure/nest/gecko,
@@ -7426,6 +7686,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/legion)
+"cCa" = (
+/obj/machinery/power/apc/fusebox/north,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "cCj" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/overlay/desert_side{
@@ -7461,9 +7729,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/ambientlighting/building/j)
 "cCL" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cCM" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13/wood,
@@ -7737,9 +8005,16 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/building/abandoned/g)
 "cGL" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "cGM" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/indestructible/ground/outside/dirt,
@@ -8086,6 +8361,13 @@
 "cLz" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/wasteland/legion)
+"cLA" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "cLF" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/books,
 /turf/open/floor/f13{
@@ -8207,12 +8489,12 @@
 	},
 /area/f13/wasteland)
 "cNX" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/wreck/trash/engine,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/wreck/trash/four_barrels,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "cOh" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/dirt{
@@ -8334,11 +8616,9 @@
 	},
 /area/f13/wasteland)
 "cQV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/light_emitter,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/junk/locker,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
 "cRa" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -8811,10 +9091,14 @@
 	},
 /area/f13/wasteland)
 "cYh" = (
-/obj/structure/wreck/trash/machinepile,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 2
+	},
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "cYi" = (
 /obj/structure/chair/bench{
 	dir = 8;
@@ -8960,12 +9244,9 @@
 /turf/open/floor/wood_worn,
 /area/f13/building/abandoned/x)
 "daz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "daG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/trash,
@@ -9096,6 +9377,14 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/ambientlighting/building/o)
+"dcW" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/ammo_box/a556/sport,
+/obj/item/ammo_box/a556/sport,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "dcZ" = (
 /obj/machinery/grill,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -9156,6 +9445,17 @@
 /obj/structure/closet/crate/footlocker,
 /turf/open/floor/plating/dirt,
 /area/f13/ncr)
+"ddL" = (
+/obj/structure/chair/west_middle,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "ddO" = (
 /obj/structure/chair/sofa/right,
 /obj/effect/decal/cleanable/dirt,
@@ -9176,14 +9476,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "dej" = (
-/obj/structure/fence{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#d8b1b1"
 	},
-/obj/effect/overlay/barbed,
-/obj/structure/obstacle/barbedwire{
-	dir = 4
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "deA" = (
 /obj/effect/decal/cleanable/dirt{
@@ -9248,12 +9548,17 @@
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland)
 "dgx" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/decoration/rag{
+	icon_state = "skulls";
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dgy" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2"
@@ -9359,6 +9664,10 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/plating/dirt/dark,
 /area/f13/ncr)
+"dhM" = (
+/obj/item/clothing/under/f13/recon/outcast,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dhW" = (
 /obj/machinery/light{
 	dir = 8;
@@ -9460,6 +9769,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"djw" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	name = "north gate";
+	id = "Northone"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood/powered)
 "djx" = (
 /mob/living/simple_animal/hostile/raider/sulphite{
 	faction = list("raider")
@@ -9719,12 +10035,15 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legioncamp)
 "doz" = (
-/obj/machinery/computer/shuttle/bosentryelevator{
-	dir = 8;
-	pixel_x = 2
+/obj/machinery/power/apc/fusebox/north,
+/obj/machinery/sleeper,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "doD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/closet/fridge,
@@ -9821,6 +10140,12 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/town)
+"dpM" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "dpN" = (
 /obj/structure/simple_door/metal/fence/wooden,
 /turf/open/indestructible/ground/outside/desert,
@@ -9924,11 +10249,10 @@
 	},
 /area/f13/ambientlighting/building/o)
 "dqX" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2"
+	},
+/area/f13/brotherhood/powered)
 "dra" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/desert,
@@ -9990,23 +10314,15 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "drQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
+/obj/structure/fence{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/turf/open/water,
-/area/f13/brotherhood/surface)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "drU" = (
 /turf/closed/wall/rust,
 /area/f13/den)
@@ -10035,14 +10351,15 @@
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/building/abandoned/z)
 "dsF" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood)
 "dsH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -10079,6 +10396,10 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"dtm" = (
+/obj/structure/sign/poster/prewar/protectron,
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "dtn" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -10266,11 +10587,10 @@
 	},
 /area/f13/wasteland)
 "dxL" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 1
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
 	},
 /area/f13/wasteland)
 "dxP" = (
@@ -10348,10 +10668,12 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/ncr)
 "dzh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/computer/security/bos,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood)
 "dzl" = (
 /obj/structure/bed,
 /obj/machinery/light/small{
@@ -10403,14 +10725,14 @@
 /turf/open/indestructible/ground/outside/dirthole,
 /area/f13/wasteland)
 "dzN" = (
-/obj/structure/wreck/car/bike{
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
 	dir = 8;
-	icon_state = "bike_rust_med_no_wheels"
+	icon_state = "horizontalinnermain2left"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/area/f13/brotherhood/powered)
 "dAc" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood_common,
@@ -10427,6 +10749,11 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/ambientlighting/building/t)
+"dAu" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building/powered)
 "dAB" = (
 /obj/machinery/autolathe/ammo/unlocked,
 /turf/open/floor/plasteel/f13,
@@ -10488,6 +10815,10 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/wasteland)
+"dBA" = (
+/obj/effect/spawner/lootdrop/armylootelite,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dBH" = (
 /obj/machinery/light{
 	dir = 4;
@@ -10498,11 +10829,12 @@
 	},
 /area/f13/followers)
 "dBI" = (
-/obj/structure/fence/corner,
-/obj/structure/obstacle/barbedwire/end{
-	dir = 8
+/obj/structure/car/rubbish3{
+	icon_state = "car_rubish2"
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
 /area/f13/wasteland)
 "dBL" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -10513,6 +10845,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/b)
+"dBR" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/melee/onehanded/knife/switchblade,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "dBT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
@@ -10524,12 +10868,13 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/abandoned/g)
 "dCa" = (
-/obj/structure/simple_door/interior,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/sandbags,
+/turf/open/floor/f13{
+	icon_state = "dark"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
 "dCm" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -10572,9 +10917,12 @@
 	},
 /area/f13/ambientlighting/building/m)
 "dDx" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
-/obj/effect/decal/cleanable/greenglow,
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
 /turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
@@ -10734,6 +11082,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/ambientlighting/building/j)
+"dGT" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/lamp_post/triples,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "dHg" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	dir = 4
@@ -10770,13 +11125,13 @@
 	},
 /area/f13/wasteland/legion)
 "dHE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/f13/army/officer,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/button/door{
+	id = "boslockdown";
+	name = "Bunker Lockdown Button";
+	pixel_y = 8
+	},
+/turf/closed/wall/r_wall/rust,
+/area/f13/brotherhood)
 "dHZ" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -10808,10 +11163,14 @@
 	},
 /area/f13/ambientlighting/building/o)
 "dIK" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 5
+/obj/structure/barricade/sandbags,
+/obj/machinery/camera/autoname{
+	dir = 1;
+	name = "Gate Camera";
+	network = list("BoS");
+	pixel_x = -1
 	},
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "dIM" = (
 /obj/structure/obstacle/old_locked_door,
@@ -10936,14 +11295,23 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"dKu" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "dKv" = (
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/tank/internals/anesthetic,
-/obj/item/clothing/mask/breath/medical,
-/obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/debris/v2,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright2"
+	},
+/area/f13/wasteland)
 "dKF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/stairs{
@@ -10990,6 +11358,15 @@
 	icon_state = "dark"
 	},
 /area/f13/ambientlighting/building/o)
+"dLj" = (
+/obj/structure/lamp_post/doubles/bent{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "dLl" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road{
@@ -11149,6 +11526,18 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/m)
+"dNx" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/spawner/lootdrop/f13/cash_random_low,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "dNA" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -11225,16 +11614,20 @@
 	},
 /area/f13/ambientlighting/building/i)
 "dOQ" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/obj/machinery/pool/drain,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
+	},
+/area/f13/wasteland)
 "dOZ" = (
 /obj/structure/closet/crate/secure/loot,
 /turf/open/floor/wood_wide,
+/area/f13/wasteland)
+"dPj" = (
+/obj/structure/guncase,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "dPk" = (
 /obj/machinery/washing_machine,
@@ -11336,6 +11729,16 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
+"dQR" = (
+/obj/structure/table,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood)
 "dRb" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/chair/bench{
@@ -11361,10 +11764,10 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/ambientlighting/building/d)
 "dRz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innermaincornerouter"
+	},
+/area/f13/caves)
 "dRF" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -11381,10 +11784,12 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "dRK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/car/rubbish4,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 2;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "dRL" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -11437,9 +11842,13 @@
 	},
 /area/f13/building/powered)
 "dTf" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "dTy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -11534,6 +11943,10 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"dUG" = (
+/obj/item/clothing/suit/armor/medium/combat/brotherhood/exile,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dUJ" = (
 /obj/structure/debris/v2,
 /obj/effect/spawner/lootdrop/trash,
@@ -11572,6 +11985,14 @@
 	dir = 4
 	},
 /area/f13/ambientlighting/building/y)
+"dVd" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/door/poddoor/shutters{
+	id = "boslockdown";
+	name = "entrance shutters"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "dVh" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -11680,12 +12101,9 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/r)
 "dXN" = (
-/obj/structure/fence{
-	dir = 4
-	},
-/obj/effect/overlay/barbed,
+/obj/structure/wreck/trash/two_barrels,
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "dXO" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -11729,6 +12147,26 @@
 	dir = 1
 	},
 /area/f13/wasteland)
+"dZj" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/chair/right{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
+"dZk" = (
+/obj/machinery/power/apc/fusebox/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "dZl" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderlefttop"
@@ -11802,6 +12240,10 @@
 	},
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/legioncamp)
+"eal" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "eat" = (
 /obj/machinery/workbench/forge,
 /obj/item/clothing/glasses/welding,
@@ -11827,8 +12269,12 @@
 	},
 /area/f13/ambientlighting/building/b)
 "eaR" = (
-/turf/closed/indestructible/f13/obsidian,
-/area/f13/brotherhood/surface)
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "eaW" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -11937,9 +12383,13 @@
 	},
 /area/f13/wasteland)
 "edr" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/brotherhood/powered)
 "edv" = (
 /obj/structure/table/wood/bar,
 /obj/structure/fence/wooden{
@@ -12096,6 +12546,17 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
+"efI" = (
+/obj/machinery/vending/coffee,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "efJ" = (
 /obj/structure/showcase/horrific_experiment,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12117,6 +12578,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ambientlighting/building/j)
+"efZ" = (
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "egg" = (
 /obj/structure/fence/corner{
 	dir = 1
@@ -12168,13 +12638,9 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "egD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/chair/stool/retro,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "egF" = (
 /obj/effect/turf_decal{
 	dir = 4
@@ -12403,6 +12869,13 @@
 	icon_state = "verticalrightborderrightbottom"
 	},
 /area/f13/wasteland)
+"elj" = (
+/obj/structure/junk/small/table,
+/obj/structure/junk/small/tv,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "elt" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -12420,11 +12893,13 @@
 /turf/closed/wall/f13/sunset/brick_small,
 /area/f13/building/abandoned/z)
 "eme" = (
-/obj/structure/junk/small/table,
-/obj/item/storage/toolbox/ammo,
-/obj/item/storage/toolbox/ammo/surplus,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/machinery/vending/wallmed{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/brotherhood)
 "emg" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/structure/reagent_dispensers/barrel/dangerous{
@@ -12537,12 +13012,12 @@
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
 "env" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/clothing/head/welding,
-/obj/item/weldingtool/largetank,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "enA" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -12811,21 +13286,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ern" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "BoS Outer Surface Gate";
-	name = "Brotherhood Front Gate"
-	},
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
-	},
+/obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+	icon_state = "horizontaloutermain2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "erB" = (
 /obj/structure/debris/v4,
 /turf/open/indestructible/ground/outside/desert,
@@ -12838,6 +13303,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/powered)
+"erM" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright2"
+	},
+/area/f13/brotherhood/powered)
 "erQ" = (
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -12956,16 +13429,10 @@
 	},
 /area/f13/ambientlighting/building/y)
 "etA" = (
-/obj/structure/cable/outdoors{
-	icon_state = "1-2"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertopleft"
 	},
-/obj/structure/cable/outdoors{
-	icon_state = "1-8"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
 "etB" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -13030,11 +13497,10 @@
 	},
 /area/f13/building/powered)
 "euA" = (
-/obj/effect/overlay/desert/sonora/edge,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "euK" = (
 /obj/structure/chalkboard,
 /turf/open/floor/wood_common/wood_common_dark,
@@ -13146,6 +13612,12 @@
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
+"ewN" = (
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "innermaincornerinner"
+	},
+/area/f13/caves)
 "exl" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/decal/cleanable/dirt{
@@ -13279,23 +13751,15 @@
 	},
 /area/f13/building/powered)
 "ezV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/water,
-/area/f13/brotherhood/surface)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "ezX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13432,13 +13896,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
 "eCx" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -15
+/obj/structure/rack/shelf_metal,
+/obj/item/radio/tribal{
+	pixel_x = 3;
+	pixel_y = 17
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood)
 "eCy" = (
 /obj/structure/car/rubbish3,
 /obj/effect/decal/cleanable/oil{
@@ -13609,6 +14079,12 @@
 	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland/city)
+"eFl" = (
+/obj/structure/fence/corner{
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "eFo" = (
 /obj/item/pickaxe,
 /obj/structure/table/reinforced,
@@ -13665,6 +14141,20 @@
 /obj/item/pda,
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/ncr)
+"eGd" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "eGi" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 1;
@@ -13948,11 +14438,12 @@
 	},
 /area/f13/building/powered)
 "eKQ" = (
-/obj/structure/chair/stool{
-	pixel_y = 6
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "eKT" = (
 /obj/structure/car/rubbish2{
 	icon_state = "car_rubish3"
@@ -13960,12 +14451,17 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "eLf" = (
-/obj/structure/fence/cut/medium{
-	dir = 4
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/obj/structure/barricade/wooden/planks,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/area/f13/brotherhood/powered)
 "eLj" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/am_containment,
@@ -14025,16 +14521,12 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "eLT" = (
-/obj/structure/debris/v4,
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
 	},
-/area/f13/building/abandoned/m)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "eMa" = (
 /obj/structure/reagent_dispensers/barrel/dangerous{
 	pixel_y = -5;
@@ -14113,17 +14605,15 @@
 	},
 /area/f13/building/powered)
 "eNA" = (
-/obj/item/storage/trash_stack{
-	icon_state = "Junk_10"
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/area/f13/wasteland)
 "eNN" = (
-/obj/structure/wreck/trash/three_barrels,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/area/f13/building/powered)
 "eNP" = (
 /obj/structure/table/booth,
 /obj/effect/decal/cleanable/dirt,
@@ -14136,17 +14626,27 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
-"eOt" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+"eOi" = (
+/obj/machinery/camera/autoname{
+	name = "Secuirty Camera";
+	network = list("BoS")
 	},
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
+"eOt" = (
+/obj/structure/fence/corner{
+	dir = 4;
+	icon_state = "end"
 	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+	icon_state = "horizontaloutermain2left"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "eOv" = (
 /obj/structure/closet/crate/footlocker{
 	pixel_y = -1;
@@ -14480,6 +14980,14 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"eUJ" = (
+/obj/item/storage/trash_stack{
+	pixel_y = 17
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "eUK" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleft0"
@@ -14590,6 +15098,12 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legioncamp)
+"eWF" = (
+/obj/structure/flora/branch,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
 "eWP" = (
 /obj/structure/dresser,
 /turf/open/floor/wood_common,
@@ -14715,12 +15229,17 @@
 /turf/open/floor/wood_wide,
 /area/f13/ncr)
 "eYY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool{
-	pixel_y = 6
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/item/trash/f13/mechanist,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "eZm" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/books,
 /turf/open/floor/plating/rust,
@@ -14840,6 +15359,13 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/x)
+"fbm" = (
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_10";
+	pixel_y = 5
+	},
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
 "fbq" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -14948,13 +15474,18 @@
 /obj/effect/overlay/desert/sonora/edge{
 	dir = 8
 	},
-/obj/structure/cable/outdoors{
-	icon_state = "4-8"
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/area/f13/wasteland)
+"fdb" = (
+/obj/structure/car/rubbish1,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermainbottom"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "fdo" = (
 /obj/structure/chair{
 	dir = 8
@@ -14995,6 +15526,29 @@
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
+"feg" = (
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = -2;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/crafting/coffee_pot,
+/obj/structure/table{
+	layer = 2.9
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "fel" = (
 /obj/structure/flora/bush,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -15233,18 +15787,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fic" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
 "fig" = (
 /obj/structure/fence{
 	dir = 4
@@ -15376,10 +15922,12 @@
 	},
 /area/f13/wasteland)
 "fjK" = (
+/obj/structure/wreck/trash/one_barrel,
 /obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole"
+	},
+/area/f13/wasteland)
 "fjV" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/raiderharness,
@@ -15602,15 +16150,16 @@
 /turf/open/transparent/openspace,
 /area/f13/wasteland/legion)
 "fnV" = (
-/obj/structure/fence{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/barricade/wooden/planks,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
-	icon_state = "dirt"
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "foc" = (
 /obj/structure/table/wood,
 /obj/item/paper/contract/employment,
@@ -15677,23 +16226,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/e)
 "foT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/machinery/door/unpowered/secure_bos,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	icon_state = "dark"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
 "foW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/wreck/trash/machinepile,
@@ -15713,13 +16251,11 @@
 	},
 /area/f13/wasteland)
 "fpj" = (
-/obj/structure/table/optable,
-/obj/machinery/iv_drip{
-	pixel_x = 15;
-	pixel_y = -2
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
 "fpo" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15730,10 +16266,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fpD" = (
-/obj/structure/fence,
-/obj/structure/obstacle/barbedwire,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "fpE" = (
 /obj/structure/fence/end/wooden{
 	dir = 8
@@ -15742,6 +16282,13 @@
 	dir = 2
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"fpF" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "fpG" = (
 /mob/living/simple_animal/hostile/ghoul,
@@ -15979,14 +16526,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "ftf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/effect/overlay/desert/sonora/edge,
-/obj/structure/debris/v2,
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/building/abandoned/m)
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "ftp" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/f13/wood,
@@ -16044,6 +16590,19 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/x)
+"fur" = (
+/obj/structure/kitchenspike_frame{
+	name = "Power armour frame"
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "fut" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/reinforced/spawner,
@@ -16056,6 +16615,15 @@
 /obj/item/flag/legion,
 /turf/closed/wall/mineral/wood,
 /area/f13/legioncamp)
+"fvg" = (
+/obj/machinery/power/apc/fusebox/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/brotherhood)
 "fvm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -16090,6 +16658,16 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/floor/wood_wide,
+/area/f13/wasteland)
+"fvS" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/planks,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
 /area/f13/wasteland)
 "fwi" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -16488,6 +17066,11 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"fCe" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "fCo" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/item/storage/trash_stack{
@@ -16510,11 +17093,14 @@
 	},
 /area/f13/ambientlighting/building/b)
 "fCI" = (
-/obj/structure/flora/tree/wasteland{
-	pixel_y = 10
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "fCK" = (
 /obj/structure/chair{
 	dir = 8
@@ -16637,23 +17223,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "fEG" = (
-/obj/structure/fence/wooden{
-	climbable = 0;
-	density = 0;
-	dir = 1;
-	layer = 3.6;
-	pixel_x = 13;
-	pixel_y = 1
+/obj/structure/chair/stool/retro,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/fence/wooden{
-	pixel_x = -15
-	},
-/obj/structure/cable/outdoors{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/lootdrop/maybe_enclave_flag,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "fEJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa{
@@ -16713,9 +17289,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ambientlighting/building/j)
 "fFs" = (
-/obj/structure/wreck/trash/engine,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/oil/streak,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "fGa" = (
 /obj/structure/rack,
 /obj/item/clothing/head/caphat/parade,
@@ -16789,10 +17369,12 @@
 	},
 /area/f13/wasteland)
 "fHT" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/wreck/trash/bus_door,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "fIa" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -16807,11 +17389,15 @@
 	},
 /area/f13/ambientlighting/building/m)
 "fIo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "fIC" = (
 /obj/structure/barricade/tentclothedge{
 	color = "#7c0A02";
@@ -16846,16 +17432,11 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "fJi" = (
-/obj/effect/landmark/poster_spawner/prewar,
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
 	},
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood)
 "fJl" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor2";
@@ -17121,12 +17702,16 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/wasteland)
 "fMA" = (
-/obj/structure/closet/crate/footlocker{
-	anchored = 1
+/obj/structure/table,
+/obj/machinery/light{
+	pixel_x = 16
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "fMD" = (
 /obj/structure/flora/ausbushes/palebush,
 /turf/open/indestructible/ground/outside/grass/dirtpath{
@@ -17374,11 +17959,8 @@
 	},
 /area/f13/wasteland)
 "fQC" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
-	},
-/obj/effect/overlay/desert/sonora/edge,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/junk/small/bed,
+/turf/open/floor/plating/rust,
 /area/f13/wasteland)
 "fQV" = (
 /obj/effect/decal/remains/human,
@@ -17386,6 +17968,12 @@
 	icon_state = "horizontaloutermain2"
 	},
 /area/f13/ambientlighting/building/m)
+"fRa" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright2"
+	},
+/area/f13/wasteland)
 "fRi" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17410,11 +17998,19 @@
 	},
 /area/f13/ambientlighting/building/w)
 "fRv" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/building/abandoned/m)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/stairs/west,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "fRw" = (
 /obj/machinery/computer/terminal{
 	dir = 8;
@@ -17539,13 +18135,13 @@
 	},
 /area/f13/wasteland/city)
 "fTz" = (
-/obj/effect/overlay/desert/sonora/edge{
+/obj/structure/fence{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/brotherhood/surface)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "fTC" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood/house,
@@ -17599,6 +18195,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/ambientlighting/building/y)
+"fUK" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "fUL" = (
 /obj/effect/overlay/desert_side{
 	dir = 1
@@ -17705,10 +18308,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/followers)
 "fVV" = (
-/obj/structure/barricade/sandbags,
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plating/f13/outside/road,
-/area/f13/wasteland)
+/obj/structure/car/rubbish3{
+	pixel_x = -17
+	},
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "fWj" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -17814,6 +18418,10 @@
 /obj/item/crafting/duct_tape,
 /turf/open/floor/wood_wide,
 /area/f13/ambientlighting/building/u)
+"fYz" = (
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "fYB" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants{
@@ -17912,20 +18520,11 @@
 	},
 /area/f13/ambientlighting/building/b)
 "gaw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/flora/junglebush/b,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/floor/f13{
+	icon_state = "dark"
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
 "gax" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/tires/five,
@@ -18085,6 +18684,24 @@
 /obj/item/locked_box/weapon/range/tier3,
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/x)
+"gdH" = (
+/obj/machinery/vending/nukacolavendfull,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
+"gdK" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "gdQ" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/greenglow,
@@ -18247,19 +18864,13 @@
 	},
 /area/f13/ambientlighting/building/b)
 "gfG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	pixel_x = 5;
-	pixel_y = 3
+/obj/effect/overlay/desert/sonora/edge,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
 	},
-/obj/item/paper{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "gfH" = (
 /obj/structure/fence{
 	dir = 8
@@ -18361,6 +18972,10 @@
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
+"ggS" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
 "ggY" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/rack,
@@ -18374,6 +18989,11 @@
 	dir = 10
 	},
 /area/f13/ambientlighting/building/j)
+"ghc" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "ghi" = (
 /obj/effect/landmark/start/f13/ncroffduty,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -18489,10 +19109,11 @@
 	},
 /area/f13/wasteland)
 "gjy" = (
-/obj/structure/wreck/trash/secway,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
+	},
+/area/f13/wasteland)
 "gjG" = (
 /obj/structure/bonfire,
 /obj/item/stack/rods/ten,
@@ -18594,7 +19215,7 @@
 /area/f13/building/abandoned/t)
 "glB" = (
 /turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "glH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -18638,11 +19259,10 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "gmu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/junk/small/table,
+/obj/structure/junk/small/tv,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "gmz" = (
 /obj/structure/fence{
 	dir = 1;
@@ -18711,6 +19331,14 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"gnS" = (
+/obj/machinery/jukebox,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "gnY" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -18788,11 +19416,24 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "gpv" = (
-/obj/effect/overlay/junk/telescreen{
-	pixel_y = 29
+/obj/effect/overlay/desert/sonora/edge,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
+"gpz" = (
+/obj/machinery/light/lampost{
+	dir = 1;
+	pixel_x = -32
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "gpB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -19219,11 +19860,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ambientlighting/building/j)
+"gxQ" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gxW" = (
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/ambientlighting/building/o)
+"gxY" = (
+/obj/item/trash/f13/mre,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerbordercorner"
+	},
+/area/f13/wasteland)
 "gxZ" = (
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/legion)
@@ -19254,11 +19906,23 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/c)
 "gyJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/ghoul,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "gyP" = (
 /obj/machinery/workbench,
 /obj/item/storage/toolbox/mechanical,
@@ -19455,10 +20119,16 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "gCd" = (
-/obj/structure/closet/crate/trashcart,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/sign/flag_america,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood/powered)
 "gCo" = (
 /obj/machinery/light/small{
 	brightness = 7
@@ -19511,10 +20181,14 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "gCS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "gCU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/port_gen/pacman/diesel{
@@ -19638,14 +20312,10 @@
 /turf/open/floor/carpet/royalblack,
 /area/f13/ambientlighting/building/w)
 "gES" = (
-/obj/machinery/door/window/survival_pod,
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/obj/structure/barricade/sandbags,
+/obj/structure/table,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "gEU" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticaldegraded"
@@ -19689,6 +20359,14 @@
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/snow{
 	icon_state = "snow4"
+	},
+/area/f13/wasteland)
+"gGf" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
 "gGi" = (
@@ -19919,9 +20597,10 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "gJG" = (
-/obj/structure/fence/door,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderrightbottom"
+	},
+/area/f13/caves)
 "gJH" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
@@ -19962,6 +20641,17 @@
 /obj/item/shovel,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"gKo" = (
+/obj/machinery/vending/medical/free,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood)
 "gKq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/room,
@@ -20010,10 +20700,8 @@
 	},
 /area/f13/ambientlighting/building/f)
 "gLd" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
-	},
+/obj/structure/barricade/wooden/strong,
+/turf/open/floor/plating/rust,
 /area/f13/wasteland)
 "gLg" = (
 /obj/effect/decal/cleanable/glass,
@@ -20024,12 +20712,8 @@
 	},
 /area/f13/ambientlighting/building/p)
 "gLh" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/wasteland)
 "gLk" = (
 /obj/effect/turf_decal,
 /obj/structure/barricade/sandbags,
@@ -20069,13 +20753,16 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/ambientlighting/building/y)
 "gLz" = (
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
+/obj/structure/fence{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/barricade/wooden/planks,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 2;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "gLH" = (
 /obj/structure/rack,
 /obj/item/stack/medical/suture{
@@ -20388,12 +21075,10 @@
 /turf/open/floor/carpet/blue,
 /area/f13/followers)
 "gPW" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermain2"
 	},
-/area/f13/wasteland)
+/area/f13/caves)
 "gQf" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -20416,6 +21101,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building/abandoned/t)
+"gQq" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building/powered)
 "gQs" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20439,6 +21128,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblack,
 /area/f13/ambientlighting/building/w)
+"gQA" = (
+/obj/structure/chair/left{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "gQF" = (
 /obj/structure/car/rubbish1{
 	pixel_x = -10;
@@ -20838,19 +21537,8 @@
 /turf/closed/indestructible/f13/matrix,
 /area/f13/wasteland)
 "gXM" = (
-/obj/structure/fence/wooden{
-	pixel_x = -15
-	},
-/obj/structure/fence/wooden{
-	climbable = 0;
-	density = 0;
-	dir = 1;
-	layer = 3.6;
-	pixel_x = 13;
-	pixel_y = 1
-	},
-/obj/effect/spawner/lootdrop/maybe_enclave_flag,
-/turf/open/indestructible/ground/outside/desert,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "gXP" = (
 /obj/structure/chair/bench,
@@ -21102,6 +21790,11 @@
 	},
 /turf/open/indestructible/ground/outside/snow,
 /area/f13/wasteland)
+"hbp" = (
+/obj/machinery/power/apc/fusebox/north,
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "hbr" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -21148,10 +21841,16 @@
 	},
 /area/f13/ncr)
 "hbV" = (
-/obj/structure/junk/micro,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "hci" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ambientlighting/building/t)
@@ -21227,10 +21926,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/k)
 "hdw" = (
-/obj/structure/nest/ghoul,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "hdI" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt{
@@ -21380,6 +22085,12 @@
 	icon_state = "bar"
 	},
 /area/f13/ambientlighting/building/g)
+"hgt" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "hgv" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13/wood,
@@ -21399,6 +22110,35 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/legioncamp)
+"hgR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light/small{
+	light_color = "red"
+	},
+/obj/machinery/button/door{
+	pixel_x = -5;
+	id = "Southone"
+	},
+/obj/machinery/button/door{
+	pixel_x = 5;
+	id = "Southtwo"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
+"hgU" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "hhh" = (
 /obj/structure/fence,
 /turf/open/indestructible/ground/outside/dirt,
@@ -21434,6 +22174,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/ambientlighting/building/o)
+"hhJ" = (
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1"
+	},
+/area/f13/brotherhood/powered)
 "hhM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -21459,6 +22205,10 @@
 	pixel_x = 7
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
+/area/f13/wasteland)
+"hib" = (
+/obj/item/trash/f13/instamash,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "hid" = (
 /turf/closed/indestructible/fakeglass,
@@ -21499,6 +22249,10 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/powered)
+"hiP" = (
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hiW" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 2
@@ -21543,6 +22297,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/abandoned/h)
+"hjo" = (
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hjp" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/cig_packs,
@@ -21596,13 +22355,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/abandoned/q)
 "hjV" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerouter"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/brotherhood/surface)
+/area/f13/caves)
 "hkm" = (
 /obj/structure/wreck/trash/five_tires,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -21620,14 +22377,12 @@
 	},
 /area/f13/building/powered)
 "hkD" = (
-/obj/structure/fence{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/brotherhood/surface)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "hkM" = (
 /obj/structure/car/rubbish3,
 /obj/effect/decal/cleanable/dirt,
@@ -21652,13 +22407,9 @@
 	},
 /area/f13/wasteland)
 "hlh" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/structure/window/reinforced/tinted,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood)
 "hlm" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/armor/costumes,
@@ -21856,10 +22607,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
 "hnr" = (
-/obj/effect/overlay/desert_side{
+/obj/structure/fence{
 	dir = 4
 	},
-/turf/open/floor/plating/f13/outside/road,
+/obj/structure/barricade/wooden/planks,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "hnt" = (
 /obj/item/storage/box/medicine/stimpaks/superstimpaks5,
@@ -21967,12 +22720,10 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
 "hoH" = (
-/obj/structure/simple_door/interior,
-/obj/structure/cable{
-	icon_state = "4-8"
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalleftborderleft2top"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "hoL" = (
 /obj/structure/barricade/wooden,
 /turf/closed/mineral/random/low_chance,
@@ -22002,6 +22753,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/ambientlighting/building/p)
+"hpA" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "hpE" = (
 /obj/item/clothing/under/f13/police,
 /obj/item/clothing/head/f13/police,
@@ -22070,9 +22832,16 @@
 	},
 /area/f13/building/powered)
 "hqt" = (
-/obj/structure/car/rubbish2,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "hqx" = (
 /obj/effect/turf_decal/weather/dirt{
 	color = "#a98c5d";
@@ -22462,6 +23231,20 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"hwn" = (
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood)
 "hwy" = (
 /obj/effect/overlay/desert/sonora/edge{
 	dir = 1
@@ -22551,10 +23334,13 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "hyb" = (
-/obj/effect/overlay/desert_side,
-/obj/structure/wreck/trash/bus_door,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft"
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
 /area/f13/wasteland)
 "hyh" = (
@@ -22764,24 +23550,26 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building/powered)
+"hAY" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/brotherhood/powered)
 "hBb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "BoS Outer Surface Gate";
-	name = "BoS Outer Surface Gate";
-	pixel_x = -4
+/obj/machinery/workbench,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/machinery/button/door{
-	id = "BoS Inner Surface Gate";
-	name = "BoS Inner Surface Gate";
-	pixel_x = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "hBn" = (
 /obj/structure/rack/large/shelf_rust,
 /obj/effect/spawner/lootdrop/ammo/shotgun,
@@ -23102,6 +23890,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/k)
+"hFP" = (
+/obj/structure/campfire/barrel,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "hGa" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -23114,10 +23906,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/abandoned/q)
 "hGe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/junk/machinery,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "hGo" = (
 /obj/structure/junk/locker,
 /turf/open/floor/f13{
@@ -23258,6 +24051,24 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/white,
 /area/f13/ambientlighting/building/j)
+"hIi" = (
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/item/stack/sheet/prewar/five,
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "hIl" = (
 /obj/structure/reagent_dispensers/barrel/dangerous{
 	pixel_x = -1;
@@ -23624,11 +24435,10 @@
 	},
 /area/f13/wasteland)
 "hON" = (
-/obj/structure/junk/small/tv,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood/junk,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "hOU" = (
 /obj/machinery/door/poddoor/gate{
 	id = "Supermutant";
@@ -23732,11 +24542,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "hQA" = (
-/obj/structure/fence{
-	dir = 4
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
 	},
-/obj/structure/sign/flag_america,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "hQB" = (
 /obj/structure/barricade/sandbags,
@@ -23839,6 +24649,13 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/building/abandoned/j)
+"hRM" = (
+/obj/machinery/door/unpowered/secure_bos,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood)
 "hRN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -23854,6 +24671,15 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"hRW" = (
+/obj/structure/lamp_post/doubles/bent{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "hSb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stairs/east,
@@ -24463,6 +25289,10 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"icG" = (
+/obj/structure/debris/v2,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
 "icM" = (
 /obj/structure/flora/brushwood{
 	pixel_x = -21
@@ -24483,6 +25313,10 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"icW" = (
+/obj/machinery/light/small/broken,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "icY" = (
 /obj/machinery/door/airlock/medical/glass{
 	req_access_txt = "124"
@@ -24505,10 +25339,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building/tribal)
 "ido" = (
-/obj/machinery/light,
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/table/optable,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "idr" = (
 /obj/structure/janitorialcart,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -24630,6 +25468,12 @@
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
+"ige" = (
+/obj/structure/table_frame,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "igz" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -24650,26 +25494,28 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"igI" = (
+/obj/structure/wreck/trash/one_barrel{
+	pixel_y = 17
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "igO" = (
-/obj/structure/cable/outdoors{
-	icon_state = "1-2"
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/brotherhood/surface)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "igP" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/shovel,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/abandoned/g)
 "igR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/barricade/wooden/strong,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "igS" = (
 /obj/structure/fence/end/wooden{
 	dir = 8
@@ -24911,11 +25757,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/f13/ambientlighting/building/w)
 "ijU" = (
-/obj/structure/barricade/sandbags,
-/obj/effect/overlay/desert_side{
-	dir = 8
+/obj/structure/sign/stop,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
 	},
-/turf/open/floor/plating/f13/outside/road,
 /area/f13/wasteland)
 "ijV" = (
 /obj/machinery/light/fo13colored/Red{
@@ -25213,13 +26059,14 @@
 	},
 /area/f13/ambientlighting/building/o)
 "ipg" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "ipk" = (
 /obj/structure/fluff/fokoff_sign,
 /turf/open/indestructible/ground/outside/dirt{
@@ -25339,6 +26186,11 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
 /turf/open/floor/carpet/red,
 /area/f13/ambientlighting/building/g)
+"irJ" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innermaincornerinner"
+	},
+/area/f13/caves)
 "irK" = (
 /obj/structure/fence/corner{
 	dir = 4
@@ -25357,6 +26209,11 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
+"isg" = (
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertopright"
+	},
+/area/f13/caves)
 "isk" = (
 /obj/structure/table/wood,
 /obj/item/stack/f13Cash/random/denarius/legionpay_officer,
@@ -25596,6 +26453,10 @@
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
+"iwp" = (
+/obj/item/trash/f13/porknbeans,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "iws" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
@@ -25624,6 +26485,17 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/p)
+"ixa" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/brotherhood/powered)
 "ixe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/blood/old,
@@ -25951,14 +26823,12 @@
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "iCV" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+/obj/structure/debris/v2,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "iDg" = (
 /mob/living/simple_animal/hostile/supermutant/rangedmutant,
 /obj/effect/decal/cleanable/dirt/dust{
@@ -25977,6 +26847,15 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
+"iDr" = (
+/obj/machinery/power/apc/fusebox/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/f13{
+	icon_state = "dark"
+	},
+/area/f13/brotherhood/powered)
 "iDv" = (
 /obj/structure/table/wood/bar,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -26351,11 +27230,13 @@
 	},
 /area/f13/ambientlighting/building/m)
 "iKg" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "iKi" = (
 /obj/structure/barricade/wooden,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -26593,6 +27474,17 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/building/tribal)
+"iNH" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "iNM" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/stock_parts/cell/high/empty,
@@ -26678,13 +27570,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/e)
 "iQc" = (
-/obj/machinery/door/window/survival_pod,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbear1"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "iQs" = (
 /turf/closed/wall/f13/store,
 /area/f13/building)
@@ -26698,18 +27593,12 @@
 	},
 /area/f13/wasteland)
 "iQC" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/decoration/vent/rusty{
-	desc = "It's very old and rusty.";
-	name = "rusty grate";
-	pixel_x = 2;
-	pixel_y = -3
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood)
 "iQM" = (
 /obj/effect/overlay/desert/sonora/edge{
 	dir = 4
@@ -26903,6 +27792,15 @@
 /obj/item/storage/box/beakers,
 /turf/open/floor/plasteel/neutral,
 /area/f13/building/abandoned/y)
+"iUZ" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/brotherhood)
 "iVl" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -27215,9 +28113,17 @@
 /turf/open/indestructible/ground/outside/sidewalkdirt,
 /area/f13/wasteland/followers)
 "jad" = (
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/overlay/desert/sonora/edge,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "jae" = (
 /turf/closed/indestructible/f13/obsidian,
 /area/f13/tunnel/southwest)
@@ -27279,6 +28185,14 @@
 "jbq" = (
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubbleslab"
+	},
+/area/f13/wasteland)
+"jbr" = (
+/obj/structure/fence/corner{
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
 "jby" = (
@@ -27345,9 +28259,15 @@
 	},
 /area/f13/wasteland)
 "jcB" = (
-/obj/structure/closet/crate/trashcart,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/brotherhood/surface)
+/obj/machinery/vending/wallmed{
+	pixel_x = -32
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "jcO" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -27440,11 +28360,23 @@
 	},
 /turf/open/indestructible/ground/outside/dirthole,
 /area/f13/wasteland)
+"jea" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "jem" = (
 /turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainright"
+	icon_state = "verticalleftborderleft2top"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood/powered)
 "jez" = (
 /obj/effect/overlay/desert/sonora/edge{
 	dir = 4
@@ -27656,15 +28588,24 @@
 	icon_state = "wasteland32"
 	},
 /area/f13/caves)
+"jid" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/caves)
 "jio" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/ruins,
 /area/f13/wasteland)
 "jip" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/junk/machinery,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/car/rubbish3,
+/turf/open/floor/plasteel/stairs{
+	dir = 4
+	},
+/area/f13/building/powered)
 "jiu" = (
 /obj/structure/flora/tree/wasteland,
 /obj/effect/turf_decal/weather/dirt{
@@ -27786,14 +28727,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/a)
 "jjU" = (
-/obj/structure/fence{
-	dir = 1
-	},
-/obj/structure/obstacle/barbedwire,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
+/turf/open/floor/plating/rust,
 /area/f13/wasteland)
 "jkf" = (
 /obj/structure/flora/tree/oak_three,
@@ -28287,16 +29221,11 @@
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
 "jsS" = (
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 4
+/obj/structure/closet/crate/freezer/blood/anchored,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
 	},
-/obj/structure/closet/fridge{
-	anchored = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood)
 "jsU" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -28362,10 +29291,14 @@
 /turf/open/indestructible/ground/outside/sidewalkdirt,
 /area/f13/wasteland/followers)
 "jtA" = (
-/obj/effect/overlay/desert_side{
-	dir = 8
+/obj/structure/fence{
+	dir = 4
 	},
-/turf/open/floor/plating/f13/outside/road,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "jtB" = (
 /obj/machinery/smartfridge/bottlerack/gardentool/primitive,
@@ -28681,14 +29614,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "jyS" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/overlay/junk/telescreen{
-	pixel_y = 29
+/obj/machinery/vending/snack/random,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/item/twohanded/sledgehammer/rockethammer/courtmartial,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood)
 "jyT" = (
 /obj/structure/wreck/trash/engine,
 /turf/open/indestructible/ground/outside/roaddirt{
@@ -28716,6 +29648,18 @@
 /obj/effect/landmark/poster_spawner/pinup,
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/powered)
+"jzf" = (
+/obj/structure/bookcase/manuals,
+/obj/item/book/manual/wiki/robotics_cyborgs,
+/obj/item/codespeak_manual,
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/book/manual/wiki/engineering_guide,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "jzo" = (
 /obj/structure/sign/poster/contraband/pinup_topless{
 	pixel_x = 5;
@@ -29108,13 +30052,9 @@
 	},
 /area/f13/wasteland)
 "jFR" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain3"
-	},
-/area/f13/brotherhood/surface)
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
 "jFY" = (
 /obj/effect/overlay/desert/sonora/edge{
 	dir = 4
@@ -29280,12 +30220,26 @@
 /turf/open/floor/plating/rust,
 /area/f13/ambientlighting/building/j)
 "jJC" = (
-/obj/effect/overlay/desert/sonora/edge/corner,
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/structure/sign/painting/library_secure{
+	persistence_id = "brotherhood_secure";
+	pixel_y = 32
 	},
-/area/f13/wasteland)
+/obj/item/canvas,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/canvas/twentythreeXnineteen,
+/obj/item/canvas/twentythreeXtwentythree,
+/obj/item/canvas/nineteenXnineteen,
+/obj/item/canvas/nineteenXnineteen,
+/obj/structure/closet/crate,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/obj/item/toy/crayon/spraycan,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "jJG" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood/house/broken,
@@ -29377,6 +30331,20 @@
 	icon_state = "dark"
 	},
 /area/f13/ambientlighting/building/o)
+"jLH" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = -16
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "jLT" = (
 /obj/structure/table/wood,
 /obj/item/stack/f13Cash/random/med,
@@ -29469,6 +30437,13 @@
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"jNL" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "jNM" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/tentleatheredge{
@@ -29496,14 +30471,18 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/x)
 "jOC" = (
-/obj/structure/cargocrate{
-	layer = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 8;
-	icon_state = "dirt"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "jOF" = (
 /obj/structure/chair/right{
 	dir = 1
@@ -29784,11 +30763,11 @@
 	},
 /area/f13/wasteland)
 "jTm" = (
-/obj/structure/cable/outdoors{
-	icon_state = "4-8"
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
 "jTq" = (
 /obj/effect/overlay/desert/sonora/edge{
 	dir = 8
@@ -29806,6 +30785,20 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
+"jTC" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	dir = 4;
+	pixel_y = 10
+	},
+/obj/item/storage/belt/utility/full,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "jTK" = (
 /obj/machinery/smartfridge/bottlerack/grownbin,
 /obj/effect/overlay/desert_side,
@@ -29820,6 +30813,10 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/d)
+"jTV" = (
+/obj/item/flag/bos,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "jUa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -30095,17 +31092,14 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland/town)
 "jZa" = (
-/obj/machinery/light{
-	pixel_x = -16
+/obj/structure/fence{
+	dir = 1
 	},
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	pixel_y = 4
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/area/f13/wasteland)
 "jZc" = (
 /obj/structure/fence/wooden,
 /obj/effect/overlay/desert/sonora/edge/corner{
@@ -30258,12 +31252,16 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/ncr)
 "kbF" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -15
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plating/f13/outside/road,
-/area/f13/building/abandoned/m)
+/obj/structure/sign/poster/official/medical_green_cross{
+	pixel_y = +32
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood)
 "kbM" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -30481,15 +31479,13 @@
 /turf/open/floor/carpet/orange,
 /area/f13/ambientlighting/building/c)
 "kfS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/area/f13/brotherhood/surface)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright3"
+	},
+/area/f13/wasteland)
 "kfU" = (
 /obj/item/ammo_casing/spent,
 /obj/item/ammo_casing/spent,
@@ -30517,16 +31513,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "kgs" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+/obj/structure/wreck/trash/one_barrel,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole"
 	},
-/obj/structure/cable/outdoors{
-	icon_state = "4-8"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "kgz" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -30784,9 +31775,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/h)
 "kjM" = (
-/obj/structure/wreck/trash/bus_door,
-/turf/open/floor/plating/f13/outside/road,
-/area/f13/wasteland)
+/obj/structure/table/optable,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/sign/poster/official/medical_green_cross{
+	pixel_y = +32
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "kjQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30874,14 +31874,8 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/legion)
 "kkW" = (
-/obj/effect/overlay/desert/sonora/edge/corner{
-	dir = 1
-	},
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "verticaloutermain3"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft0"
 	},
 /area/f13/wasteland)
 "klh" = (
@@ -30995,6 +31989,15 @@
 /mob/living/simple_animal/hostile/retaliate/talker/trader/basic,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/ambientlighting/building/t)
+"kna" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "knE" = (
 /obj/structure/barricade/wooden/strong,
 /obj/structure/barricade/bars,
@@ -31021,6 +32024,10 @@
 /obj/item/radio/tribal,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/w)
+"koe" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kof" = (
 /obj/effect/decal/cleanable/greenglow{
 	pixel_x = 19;
@@ -31121,10 +32128,14 @@
 	},
 /area/f13/ambientlighting/building/b)
 "kpA" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/glowing,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "kpE" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -31281,8 +32292,10 @@
 /turf/open/floor/plating,
 /area/f13/building/powered)
 "ktw" = (
-/obj/machinery/light/lampost,
-/turf/open/floor/plating/f13/outside/road,
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
 /area/f13/wasteland)
 "ktB" = (
 /obj/effect/turf_decal/weather/snow/corner,
@@ -31451,12 +32464,10 @@
 	},
 /area/f13/building/abandoned/h)
 "kvH" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalleftborderright2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/area/f13/wasteland)
 "kvI" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/diy,
 /turf/open/floor/f13{
@@ -31492,6 +32503,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/hobo,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/k)
+"kwy" = (
+/obj/structure/car/rubbish1{
+	pixel_y = -16
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kwJ" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -31667,6 +32684,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/building/abandoned/u)
+"kAv" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "kAx" = (
 /turf/open/indestructible/ground/outside/grass/corner{
 	dir = 8
@@ -31716,14 +32742,9 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legioncamp)
 "kBe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/brotherhood/surface)
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "kBr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -31988,9 +33009,11 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "kGt" = (
-/obj/structure/debris/v1,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/wreck/trash/two_tire,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "kGv" = (
 /obj/structure/junk/micro,
 /obj/structure/fence{
@@ -32134,6 +33157,15 @@
 	},
 /turf/open/indestructible/ground/outside/snow,
 /area/f13/wasteland)
+"kIN" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "kIO" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/rack,
@@ -32274,6 +33306,15 @@
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"kKF" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "kKI" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/crafting,
@@ -32323,6 +33364,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ambientlighting/building/j)
+"kLg" = (
+/obj/structure/chair/sofa/left,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "kLh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/smartfridge/bottlerack,
@@ -32376,6 +33425,14 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/c)
+"kMn" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/caves)
 "kMA" = (
 /obj/machinery/door/poddoor/shutters,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -32467,6 +33524,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/tribal)
+"kNs" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "kNu" = (
 /obj/structure/junk/small/bed,
 /obj/effect/turf_decal/box/white,
@@ -32551,12 +33616,9 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/ncr)
 "kOg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/item/storage/toolbox/ammo,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "kOn" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -32776,12 +33838,16 @@
 	},
 /area/f13/building/abandoned/l)
 "kRU" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "kRW" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
@@ -32797,6 +33863,17 @@
 	},
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
+"kSl" = (
+/obj/machinery/power/apc/fusebox/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "kSq" = (
 /obj/structure/simple_door/metal/store,
 /obj/effect/decal/cleanable/dirt,
@@ -33008,6 +34085,17 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/wasteland/town)
+"kWF" = (
+/obj/machinery/vending/cigarette/syndicate,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "kWH" = (
 /obj/structure/flora/tree/oak_three,
 /turf/open/indestructible/ground/outside/grass,
@@ -33090,9 +34178,13 @@
 	},
 /area/f13/ambientlighting/building/b)
 "kXE" = (
-/obj/structure/sign/poster/prewar/corporate_espionage,
-/turf/closed/wall/mineral/concrete/blastproof,
-/area/f13/building/abandoned/m)
+/obj/structure/stairs/east,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "kXG" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "verticalrightborderleft2"
@@ -33391,13 +34483,14 @@
 	},
 /area/f13/wasteland)
 "lcg" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/structure/car/rubbish1{
+	pixel_y = -16
 	},
-/obj/structure/window/reinforced/tinted,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerouter"
+	},
+/area/f13/wasteland)
 "lcl" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop2right"
@@ -33582,15 +34675,10 @@
 	},
 /area/f13/ambientlighting/building/i)
 "lgp" = (
-/obj/structure/barricade/wooden/planks,
-/obj/structure/fence/cut/large{
-	dir = 4
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermainbottom"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/area/f13/caves)
 "lgt" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/grass/dirtpath{
@@ -33759,10 +34847,12 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "lkP" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	dir = 6
+	},
+/area/f13/wasteland)
 "lld" = (
 /obj/item/ammo_casing/caseless{
 	dir = 4;
@@ -33938,9 +35028,17 @@
 	},
 /area/f13/ambientlighting/building/o)
 "loD" = (
-/obj/structure/gas_pump/oilpump1,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/planks,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 2;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "loJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -33967,17 +35065,16 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "lpg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bookcase/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
-"lpo" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	icon_state = "dark"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
+"lpo" = (
+/obj/structure/wreck/trash/engine,
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "lpq" = (
 /obj/structure/obstacle/barbedwire{
 	dir = 4
@@ -34062,9 +35159,13 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "lqC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "lqD" = (
 /obj/structure/closet,
 /turf/open/floor/f13{
@@ -34102,10 +35203,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/k)
 "lrm" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/junk/small/table,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "lrn" = (
 /obj/structure/bed,
 /obj/machinery/light/small{
@@ -34122,16 +35224,9 @@
 	},
 /area/f13/building/abandoned/a)
 "lrq" = (
-/obj/structure/wreck/trash/autoshaft,
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/wreck/trash/five_tires{
-	pixel_x = 12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/car/rubbish4,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "lrw" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/food/drinks/mug/coco,
@@ -34142,8 +35237,13 @@
 /turf/open/floor/carpet/blue,
 /area/f13/followers)
 "lrB" = (
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "lrC" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -34371,6 +35471,15 @@
 	icon_state = "yellowrustychess"
 	},
 /area/f13/ambientlighting/building/b)
+"lvW" = (
+/obj/machinery/camera/autoname{
+	name = "Secuirty Camera";
+	network = list("BoS")
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
 "lvZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
@@ -34398,8 +35507,17 @@
 /turf/open/floor/plating/dirt,
 /area/f13/wasteland)
 "lxa" = (
-/turf/closed/wall/f13/tunnel,
-/area/f13/brotherhood/surface)
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "lxb" = (
 /obj/structure/simple_door/repaired,
 /obj/structure/barricade/wooden/planks,
@@ -34572,9 +35690,13 @@
 	},
 /area/f13/ambientlighting/building/f)
 "lzB" = (
-/obj/item/flag/bos,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "lzF" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/turf_decal/weather/dirt{
@@ -34597,9 +35719,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/ambientlighting/building/j)
 "lzK" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/brotherhood/powered)
 "lzL" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -34638,6 +35764,15 @@
 	},
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/ncr)
+"lAT" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	name = "north gate";
+	id = "Northtwo";
+	icon_state = "closed";
+	density = 1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood/powered)
 "lAU" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontalbottomborderbottom0"
@@ -35039,17 +36174,14 @@
 /turf/open/floor/plating/rust,
 /area/f13/ambientlighting/building/j)
 "lIM" = (
-/obj/machinery/door/poddoor/gate/preopen{
-	id = "BoS Inner Surface Gate";
-	name = "Brotherhood Inner Gate"
-	},
+/obj/effect/overlay/desert/sonora/edge,
 /obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "lIV" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -35208,6 +36340,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/abandoned/l)
+"lLs" = (
+/obj/effect/overlay/desert/sonora/edge,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/caves)
 "lLC" = (
 /obj/structure/junk/locker,
 /obj/item/storage/backpack/enclave,
@@ -35388,6 +36529,14 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"lNJ" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "lNK" = (
 /obj/machinery/light{
 	dir = 8
@@ -35402,23 +36551,30 @@
 /obj/structure/fence{
 	dir = 1
 	},
-/obj/structure/obstacle/barbedwire,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
-	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "lOb" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/under/f13/army,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom0"
+	},
+/area/f13/wasteland)
 "lOd" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks,
 /turf/closed/mineral/random/low_chance,
 /area/f13/building/tribal)
+"lOu" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom2right"
+	},
+/area/f13/wasteland)
 "lOA" = (
 /mob/living/simple_animal/hostile/raider/junker/boss,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -35444,6 +36600,17 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"lOZ" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "lPf" = (
 /obj/structure/fence/corner/wooden{
 	dir = 4
@@ -35490,8 +36657,9 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/w)
 "lPQ" = (
-/turf/open/floor/plating/f13/outside/road,
-/area/f13/building/abandoned/m)
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "lQf" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -35571,12 +36739,14 @@
 /turf/open/indestructible/ground/outside/grass/dirtpath,
 /area/f13/wasteland)
 "lSr" = (
-/obj/structure/wreck/trash/autoshaft,
-/obj/structure/wreck/trash/five_tires{
-	pixel_x = 12
+/obj/machinery/camera/autoname{
+	name = "Secuirty Camera";
+	network = list("BoS")
 	},
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "lSt" = (
 /obj/effect/spawner/lootdrop/weapon_parts,
 /turf/open/indestructible/ground/outside/dirt,
@@ -35828,17 +36998,20 @@
 /turf/closed/wall/rust,
 /area/f13/wasteland)
 "lWr" = (
-/obj/structure/fence/cut/medium{
+/obj/structure/fence{
 	dir = 4
 	},
-/obj/structure/fence/cut/medium{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
-	icon_state = "dirt"
-	},
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"lWM" = (
+/obj/machinery/autolathe,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "lWW" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/outside/dirt{
@@ -35905,15 +37078,26 @@
 /turf/open/floor/carpet/red,
 /area/f13/building/abandoned/t)
 "lXR" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/structure/sink{
-	pixel_y = 17
+/obj/machinery/recharger,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood)
+"lXS" = (
+/obj/item/reagent_containers/food/snacks/f13/canned/ncr/ham_and_eggs,
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "lXU" = (
 /obj/structure/table/wood,
 /obj/structure/curtain{
@@ -36090,14 +37274,15 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ambientlighting/building/x)
 "mbx" = (
-/obj/structure/railing/handrail{
-	dir = 8
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/obj/structure/railing/handrail{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/building/abandoned/m)
+/area/f13/building/powered)
 "mbF" = (
 /obj/structure/closet,
 /obj/item/coin/iron,
@@ -36182,11 +37367,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ambientlighting/building/c)
 "mcP" = (
+/obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
+	icon_state = "horizontalbottomborderbottom2right"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "mcQ" = (
 /obj/effect/turf_decal/huge{
 	dir = 4
@@ -36509,8 +37694,9 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "mhi" = (
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mhl" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags,
@@ -36556,9 +37742,17 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "mhM" = (
-/obj/structure/car/rubbish1,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/knot,
+/obj/machinery/power/port_gen/pacman/diesel{
+	anchored = 1
+	},
+/obj/item/stack/sheet/mineral/plasma/fifty,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "mhN" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
@@ -36597,10 +37791,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/q)
 "miQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/machinery/door/unpowered/secure_bos,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/brotherhood)
 "miU" = (
 /obj/structure/fluff/railing{
 	dir = 9
@@ -36915,13 +38111,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/a)
 "mnP" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
-/obj/structure/wreck/trash/machinepiletwo,
-/turf/open/floor/plating/f13/outside/road,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "mnW" = (
 /obj/machinery/light/small{
 	brightness = 7
@@ -36970,6 +38166,9 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legioncamp)
+"moK" = (
+/turf/open/indestructible/ground/outside/road,
+/area/f13/brotherhood/powered)
 "mpc" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/m)
@@ -37112,8 +38311,12 @@
 	},
 /area/f13/wasteland)
 "msE" = (
-/turf/closed/wall/mineral/concrete/blastproof,
-/area/f13/building/abandoned/m)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "msS" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37207,15 +38410,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
-"muA" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 8;
-	icon_state = "outermaincornerinner"
+"muz" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "innermaincornerinner"
 	},
 /area/f13/wasteland)
+"muA" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood)
 "muL" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -37250,6 +38454,10 @@
 "mvc" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/wasteland)
+"mve" = (
+/obj/structure/sign/poster/prewar/corporate_espionage,
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "mvs" = (
 /obj/item/reagent_containers/glass/bucket/wood,
 /turf/open/indestructible/ground/inside/dirt,
@@ -37303,6 +38511,18 @@
 	icon_state = "housewood2"
 	},
 /area/f13/building/abandoned/a)
+"mwi" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "mww" = (
 /mob/living/simple_animal/hostile/raider/junker,
 /obj/effect/decal/cleanable/generic,
@@ -37396,11 +38616,21 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "mym" = (
-/obj/structure/wreck/trash/bus_door,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
+"myo" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 6
+	},
+/area/f13/brotherhood)
 "myr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -37531,12 +38761,16 @@
 	},
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
+"mzY" = (
+/obj/structure/wreck/trash/engine,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mAi" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/junk/small,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "mAo" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/outside/dirt{
@@ -37631,11 +38865,18 @@
 	},
 /area/f13/wasteland)
 "mBV" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/f13/army,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/iv_drip,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood)
+"mCa" = (
+/obj/structure/table/wood/settler,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "mCf" = (
 /obj/structure/closet/crate/bin,
 /obj/item/reagent_containers/pill/salicyclic,
@@ -37774,11 +39015,12 @@
 	},
 /area/f13/building/abandoned/h)
 "mDN" = (
-/obj/structure/table/wood/junk,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "mDT" = (
 /obj/structure/railing/corner{
 	color = "#A47449"
@@ -37797,10 +39039,14 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/ncr)
 "mEa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/junk/small/bed,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/door/unpowered/secure_bos,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "mEc" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
@@ -37982,6 +39228,14 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"mGx" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "mGD" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedhorizontal"
@@ -38062,10 +39316,11 @@
 	},
 /area/f13/ambientlighting/building/w)
 "mHS" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/brotherhood/powered)
 "mHX" = (
 /obj/machinery/light/lampost,
 /turf/open/indestructible/ground/outside/sidewalk,
@@ -38120,9 +39375,14 @@
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/building/abandoned/z)
 "mJj" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "mJv" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -38177,6 +39437,10 @@
 	icon_state = "dark"
 	},
 /area/f13/ambientlighting/building/o)
+"mKW" = (
+/obj/structure/table,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "mLa" = (
 /obj/docking_port/stationary{
 	area_type = /area/f13;
@@ -38187,7 +39451,7 @@
 	width = 5
 	},
 /turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "mLy" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/inside/mountain,
@@ -38805,11 +40069,25 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
 "mVK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/item/stock_parts/cell/ammo/mfc,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "mVL" = (
 /obj/structure/simple_door/room/dirty,
 /turf/open/floor/wood_common,
@@ -38856,13 +40134,13 @@
 	},
 /area/f13/ambientlighting/building/f)
 "mWO" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
+/obj/structure/car/rubbish1{
+	pixel_y = -16
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "mWS" = (
 /obj/effect/overlay/desert_side,
 /obj/effect/overlay/desert_side{
@@ -38987,11 +40265,35 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/followers)
+"mZV" = (
+/obj/machinery/computer/operating/bos{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "naa" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/ten,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ambientlighting/building/x)
+"nal" = (
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "Secuirty Camera";
+	network = list("BoS")
+	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "naq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/kirbyplants,
@@ -39008,10 +40310,8 @@
 	},
 /area/f13/wasteland)
 "naK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/junk/small/bed2,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "naM" = (
 /obj/structure/simple_door/metal/store,
 /turf/open/floor/plasteel/f13/stone,
@@ -39324,6 +40624,13 @@
 	icon_state = "innerpavement"
 	},
 /area/f13/wasteland)
+"nfG" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	layer = 4.3
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "nfI" = (
 /obj/structure/wreck/trash/two_barrels,
 /obj/effect/decal/cleanable/greenglow,
@@ -39402,9 +40709,16 @@
 	},
 /area/f13/ambientlighting/building/o)
 "ngu" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/surface)
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "ngx" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/inside/dirt,
@@ -39569,12 +40883,33 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/k)
+"njF" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 4;
+	layer = 2.7;
+	pixel_y = 17
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "njW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/keg/gargle,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/abandoned/g)
+"njY" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/barricade/bars,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "nkd" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
@@ -39966,11 +41301,9 @@
 	},
 /area/f13/wasteland)
 "nqB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/nest/deathclaw,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nqC" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -40633,10 +41966,18 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/legion)
 "nBR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/decal/cleanable/oil/streak,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building/powered)
 "nBU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -40778,10 +42119,13 @@
 /turf/open/floor/wood_mosaic,
 /area/engine/workshop)
 "nEf" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/brotherhood/surface)
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "nEj" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 4;
@@ -40917,13 +42261,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/den)
 "nGy" = (
-/obj/structure/closet/crate/footlocker{
-	anchored = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/splats,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nGM" = (
 /obj/structure/fence/corner/wooden{
 	dir = 4
@@ -40940,10 +42281,14 @@
 	},
 /area/f13/ambientlighting/building/i)
 "nGT" = (
-/obj/structure/nest/ghoul,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/obj/structure/cargocrate{
+	pixel_x = 3
+	},
+/obj/structure/cargocrate{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building/powered)
 "nHb" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -40985,6 +42330,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_mosaic,
 /area/engine/workshop)
+"nIn" = (
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/brotherhood)
 "nIy" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -41154,6 +42505,10 @@
 	},
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"nLu" = (
+/obj/structure/junk/jukebox,
+/turf/open/floor/plating/rust,
+/area/f13/wasteland)
 "nLx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -41381,6 +42736,17 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland/followers)
+"nOP" = (
+/obj/structure/chair/stool/retro,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "nOT" = (
 /obj/structure/table/wood/bar,
 /obj/effect/spawner/bundle/f13/varmint,
@@ -41568,11 +42934,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/a)
 "nSN" = (
-/obj/structure/junk/small/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/door/unpowered/secure_bos,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "nSO" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -41648,10 +43013,16 @@
 /turf/open/floor/carpet,
 /area/f13/ambientlighting/building/q)
 "nUm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/remains/human,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/sign/poster/random,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood)
 "nUn" = (
 /obj/effect/overlay/desert/sonora/edge{
 	dir = 9
@@ -41812,6 +43183,20 @@
 	icon_state = "horizontaltopborderbottom2right"
 	},
 /area/f13/wasteland)
+"nXU" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood)
 "nYd" = (
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/outside/dirt/harsh,
@@ -41871,6 +43256,15 @@
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/tentwall,
 /area/f13/wasteland)
+"nZj" = (
+/obj/structure/cargocrate{
+	icon_state = "cargocrate2"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "nZk" = (
 /obj/item/target,
 /turf/open/indestructible/ground/outside/dirt,
@@ -41888,10 +43282,16 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "nZH" = (
-/obj/structure/toilet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
 "nZP" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
@@ -41956,13 +43356,20 @@
 	icon_state = "horizontaltopbordertop0"
 	},
 /area/f13/wasteland)
+"obq" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 10
+	},
+/area/f13/brotherhood)
 "obr" = (
-/obj/structure/junk/small/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/crafting/lunchbox,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "obt" = (
 /obj/structure/table/wood/bar,
 /obj/item/candle,
@@ -42092,6 +43499,13 @@
 /obj/structure/spacevine,
 /turf/closed/wall/f13/store,
 /area/f13/ambientlighting/building/m)
+"odh" = (
+/obj/structure/wreck/trash/one_barrel{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "odm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/card/id/dogtag/town/legion,
@@ -42166,10 +43580,8 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "odO" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood)
 "odR" = (
 /obj/structure/obstacle/barbedwire,
 /obj/structure/barricade/sandbags,
@@ -42225,7 +43637,9 @@
 /obj/structure/fence{
 	dir = 4
 	},
-/obj/structure/barricade/wooden/planks,
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
 	icon_state = "dirt"
@@ -42243,12 +43657,8 @@
 	},
 /area/f13/wasteland)
 "oeG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/simple_door/interior,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/brotherhood/surface)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "oeO" = (
 /obj/effect/overlay/desert/sonora/edge/corner{
 	dir = 1
@@ -42530,12 +43940,13 @@
 	},
 /area/f13/building/abandoned/h)
 "ojC" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/junk/small/table,
-/obj/item/radio/old,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "ojG" = (
 /turf/open/indestructible/ground/outside/ruins{
 	dir = 1;
@@ -42791,9 +44202,10 @@
 	},
 /area/f13/building/powered)
 "omH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/obj/item/reagent_containers/food/snacks/f13/deathclawegg,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "omK" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/dirt,
@@ -42900,19 +44312,19 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/a)
 "oov" = (
-/obj/structure/junk/small/table,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
-	icon_state = "dirt"
+/obj/effect/spawner/lootdrop/f13/advboards,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "ooG" = (
-/obj/structure/fence/corner{
-	dir = 8
-	},
-/obj/structure/obstacle/barbedwire/end{
-	dir = 4
-	},
+/obj/item/trash/f13/steak,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "ooH" = (
@@ -42955,6 +44367,11 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"opK" = (
+/obj/effect/decal/cleanable/blood/splats,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "opO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table,
@@ -43015,11 +44432,12 @@
 	},
 /area/f13/building/powered)
 "ori" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13{
+	icon_state = "dark"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
 "orj" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticaldegraded"
@@ -43029,6 +44447,21 @@
 	icon_state = "horizontalinnermain3"
 	},
 /area/f13/wasteland)
+"orl" = (
+/obj/structure/wreck/trash/engine,
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"orz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/engineering,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 5
+	},
+/area/f13/brotherhood)
 "orO" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -43068,8 +44501,10 @@
 	},
 /area/f13/wasteland)
 "osi" = (
-/turf/closed/mineral/random/low_chance,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/remains/human,
+/mob/living/simple_animal/hostile/deathclaw/legendary,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "osr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/ghoul/soldier/armored,
@@ -43130,6 +44565,10 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland/town)
+"ouC" = (
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "ouF" = (
 /obj/structure/curtain{
 	color = "#5c131b";
@@ -43225,12 +44664,12 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "owz" = (
-/obj/structure/fence,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/obj/machinery/light,
+/obj/machinery/vending/clothing/bos,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 6
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "owD" = (
 /obj/effect/mob_spawn/human/corpse,
 /turf/open/indestructible/ground/outside/desert,
@@ -43444,6 +44883,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/powered)
+"oAt" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "oAx" = (
 /obj/structure/wreck/car,
 /turf/open/indestructible/ground/outside/dirt,
@@ -43574,6 +45018,12 @@
 /obj/item/melee/unarmed/brass/spiked,
 /turf/open/floor/plating,
 /area/f13/bar)
+"oCZ" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "oDd" = (
 /mob/living/simple_animal/hostile/giantant,
 /turf/open/indestructible/ground/outside/dirt,
@@ -43683,14 +45133,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
 "oEP" = (
-/obj/structure/railing/handrail{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
-/obj/structure/railing/handrail{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood/powered)
 "oEW" = (
 /obj/structure/cable/outdoors{
 	icon_state = "1-2"
@@ -43705,6 +45153,10 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"oFf" = (
+/obj/structure/sign/poster/official/safety_eye_protection,
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "oFg" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -43864,6 +45316,13 @@
 	icon_state = "outerborder"
 	},
 /area/f13/wasteland)
+"oHU" = (
+/obj/structure/debris/v2,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "oHW" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -43965,15 +45424,12 @@
 	},
 /area/f13/building/abandoned/a)
 "oJL" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	doc_content_1 = "I'd like to report a crime happening at your house, Officer Mack. Your house is about to burn for the crimes you committed against the People's Republic of China! I hope your sleeping family wakes up in time.. GLORY TO CHINA.";
-	doc_title_1 = "Crime Report."
+/obj/machinery/autolathe/ammo,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood)
 "oJO" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/clothing/mask/bandana/legion/legrecruit,
@@ -44041,6 +45497,13 @@
 	dir = 8
 	},
 /area/f13/ambientlighting/building/y)
+"oKR" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "oKV" = (
 /obj/machinery/light/fo13colored/Red,
 /turf/open/floor/plating/rust,
@@ -44166,10 +45629,14 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/z)
 "oMP" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/wasteland)
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "bosgate";
+	pixel_y = 6;
+	pixel_x = 7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "oMV" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -44280,6 +45747,17 @@
 /obj/structure/rack/large/shelf,
 /turf/open/floor/plasteel/rockvault,
 /area/f13/ambientlighting/building/c)
+"oNQ" = (
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "oNS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small,
@@ -44535,12 +46013,11 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/tribal)
 "oQR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13chair2{
-	dir = 4
+/obj/structure/table/wood/settler,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "oRq" = (
 /obj/item/storage/trash_stack{
 	icon_state = "Junk_10"
@@ -44670,6 +46147,15 @@
 	icon_state = "yellowrustychess"
 	},
 /area/f13/ambientlighting/building/m)
+"oUs" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaltopbordertop0"
+	},
+/area/f13/wasteland)
 "oUv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -44685,6 +46171,14 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/abandoned/t)
+"oUH" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "oUL" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -44799,17 +46293,17 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "oWB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/sign/flag_america,
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "oWG" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/brotherhood/surface)
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/wasteland)
 "oWH" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/dirt{
@@ -44875,10 +46369,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
 "oXt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "oXB" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -44923,11 +46418,31 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
+"oYR" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "oYW" = (
-/obj/structure/junk/locker,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/medium/combat/brotherhood,
+/obj/item/clothing/suit/armor/medium/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
+/obj/item/clothing/head/helmet/f13/combat/brotherhood,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "oZf" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
@@ -44998,6 +46513,15 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/w)
+"paD" = (
+/obj/effect/overlay/desert/sonora/edge,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "paG" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/turf_decal/weather/dirt{
@@ -45045,6 +46569,10 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/building/abandoned/z)
+"pbv" = (
+/obj/structure/junk/machinery,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "pbC" = (
 /obj/machinery/door/password,
 /turf/open/floor/f13{
@@ -45082,6 +46610,20 @@
 /obj/structure/flora/tree/cactus_alt,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"pcl" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/crafting/coffee_pot{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/coffee,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/brotherhood)
 "pcp" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/sidewalkdirt,
@@ -45195,13 +46737,9 @@
 /turf/open/floor/plating/rust,
 /area/f13/ambientlighting/building/j)
 "peG" = (
-/obj/item/storage/trash_stack{
-	pixel_x = 3;
-	pixel_y = 12
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/junk/small/table,
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
 "peN" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -45209,6 +46747,10 @@
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/d)
+"pfo" = (
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building/powered)
 "pfv" = (
 /obj/structure/window/fulltile/house{
 	dir = 2
@@ -45312,6 +46854,17 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ambientlighting/building/i)
+"phk" = (
+/obj/structure/sign/poster/random,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood/powered)
 "phn" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plating/f13/inside/gravel,
@@ -45617,11 +47170,11 @@
 /turf/open/floor/f13,
 /area/f13/ambientlighting/building/o)
 "pmu" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirt"
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "pmI" = (
 /obj/structure/bed/wooden,
 /obj/structure/bed/wooden{
@@ -45650,12 +47203,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pnc" = (
-/obj/effect/overlay/junk/telescreen{
-	pixel_y = 29
+/obj/structure/wreck/trash/engine,
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
-/obj/machinery/workbench,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/area/f13/wasteland)
 "pnd" = (
 /obj/structure/table/wood/bar,
 /obj/item/fishingrod,
@@ -45730,14 +47284,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
 "pot" = (
-/obj/structure/fence/corner{
-	dir = 8
+/obj/structure/junk/locker,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 4;
-	icon_state = "dirtcorner"
-	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "poz" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -45852,6 +47405,16 @@
 /obj/structure/table/wood/fancy/green,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/v)
+"pqG" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3"
+	},
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "pqH" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13{
@@ -45912,13 +47475,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "prC" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = -16
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "prT" = (
 /obj/structure/flora/tree/oak_two,
 /turf/open/indestructible/ground/outside/grass/corner{
@@ -46022,10 +47585,12 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/ambientlighting/building/o)
 "ptI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/debris/v3,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/decoration/vent/rusty,
+/obj/machinery/shower{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood)
 "ptJ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -46200,6 +47765,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/g)
+"pvW" = (
+/obj/machinery/power/apc/fusebox/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "pwb" = (
 /obj/structure/car/rubbish4,
 /obj/effect/decal/cleanable/dirt,
@@ -46303,11 +47882,27 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland/town)
+"pyl" = (
+/obj/structure/car/rubbish3{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/structure/car/rubbish3{
+	icon_state = "car_rubish2"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "pyu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/carpet/red,
 /area/f13/legioncamp)
+"pyI" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright2"
+	},
+/area/f13/wasteland)
 "pyL" = (
 /obj/structure/toilet{
 	dir = 8
@@ -46328,16 +47923,22 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ambientlighting/building/x)
 "pzp" = (
-/obj/structure/wreck/trash/two_tire,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
-"pzv" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/house{
-	icon_state = "storewindowbottom"
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood/powered)
+"pzv" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "pzF" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowbottom"
@@ -46358,6 +47959,15 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"pAd" = (
+/obj/structure/car/rubbish3{
+	icon_state = "car_rubish2"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 2;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "pAh" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -46373,9 +47983,9 @@
 /obj/structure/fence{
 	dir = 1
 	},
-/obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/outside/dirt{
-	icon_state = "dirtcorner"
+	icon_state = "dirt";
+	dir = 4
 	},
 /area/f13/wasteland)
 "pAW" = (
@@ -46670,6 +48280,12 @@
 /obj/structure/simple_door/metal,
 /turf/open/floor/carpet/royalblack,
 /area/f13/building/abandoned/l)
+"pGp" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright3"
+	},
+/area/f13/wasteland)
 "pGw" = (
 /obj/structure/tires/two,
 /turf/open/indestructible/ground/outside/desert,
@@ -46751,6 +48367,19 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/followers)
+"pIs" = (
+/obj/machinery/power/terminal,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/knot,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "pIu" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbear1"
@@ -46774,11 +48403,15 @@
 	},
 /area/f13/ambientlighting/building/y)
 "pII" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "pIU" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/powered)
@@ -47000,17 +48633,9 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/x)
 "pLm" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = -16
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/filingcabinet,
-/obj/structure/filingcabinet{
-	pixel_x = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pLo" = (
 /obj/structure/butter_churn,
 /turf/open/indestructible/ground/outside/dirt,
@@ -47095,6 +48720,10 @@
 	dir = 6
 	},
 /area/f13/wasteland)
+"pMc" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "pMe" = (
 /obj/structure/closet/fridge,
 /obj/item/reagent_containers/food/condiment/yeast,
@@ -47116,11 +48745,11 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/abandoned/g)
 "pMi" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/f13/army,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "pMm" = (
 /obj/structure/billboard/poseidenenergy1,
 /turf/open/indestructible/ground/outside/dirt,
@@ -47311,19 +48940,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "pPO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bookcase/manuals/research_and_development{
-	allowed_books = list(/obj/item/book,/obj/item/book,/obj/item/storage/book,/obj/item/book,/obj/item/book,/obj/item/book);
-	desc = "A collection of scrolls, archives and relics.";
-	name = "Brotherhood Historical Archives"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/closet/crate/trashcart/somemoney,
+/obj/item/trash/f13/yumyum,
+/obj/item/trash/f13/steak,
+/obj/item/trash/f13/porknbeans,
+/obj/item/trash/f13/mre,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pPU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -47453,14 +49076,15 @@
 	},
 /area/f13/wasteland)
 "pSX" = (
-/obj/structure/wreck/trash/two_tire,
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
+/obj/machinery/light/small{
+	light_color = "red"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "pTf" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
@@ -47570,6 +49194,14 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"pUH" = (
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "pUT" = (
 /obj/effect/gibspawner/human,
 /turf/open/indestructible/ground/outside/graveldirt,
@@ -47751,6 +49383,11 @@
 	},
 /turf/open/floor/carpet/arcade,
 /area/f13/ambientlighting/building/j)
+"pXG" = (
+/obj/effect/decal/remains/human,
+/obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pXK" = (
 /turf/open/indestructible,
 /area/f13/tcoms)
@@ -47774,10 +49411,9 @@
 	},
 /area/f13/ambientlighting/building/g)
 "pXX" = (
-/obj/structure/wreck/trash/engine,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pXZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -47810,6 +49446,14 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/powered)
+"pYo" = (
+/obj/structure/sign/poster/official/medical_green_cross{
+	pixel_y = +32
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
 "pYs" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/greenglow{
@@ -47899,6 +49543,13 @@
 	icon_state = "verticalrightborderright1"
 	},
 /area/f13/wasteland)
+"qan" = (
+/obj/effect/decal/remains/human,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "qas" = (
 /obj/structure/cable/outdoors{
 	icon_state = "4-8"
@@ -47967,14 +49618,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/legion)
 "qbf" = (
-/obj/structure/cable/outdoors{
-	icon_state = "1-8"
+/obj/structure/fence{
+	dir = 1
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
+/turf/open/indestructible/ground/outside/dirt{
 	dir = 1;
-	icon_state = "horizontaloutermain1"
+	icon_state = "dirtcorner"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "qbk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -48035,13 +49686,16 @@
 /turf/open/floor/carpet/airless,
 /area/f13/ambientlighting/building/c)
 "qcl" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/guncase,
-/obj/item/gun/ballistic/automatic/m1garand,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "qcq" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/structure/reagent_dispensers/barrel/dangerous{
@@ -48058,6 +49712,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/underground/cave)
+"qcx" = (
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/brotherhood/powered)
 "qcC" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plating/rust,
@@ -48230,6 +49890,18 @@
 "qfV" = (
 /turf/open/indestructible/ground/outside/grass/dirtpath,
 /area/f13/wasteland)
+"qgb" = (
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood)
 "qgh" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -48254,6 +49926,18 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"qgv" = (
+/obj/effect/overlay/desert/sonora/edge,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalrightborderleft1"
+	},
+/area/f13/brotherhood/powered)
 "qgw" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/indestructible/ground/outside/dirt{
@@ -48529,10 +50213,29 @@
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/ambientlighting/building/c)
 "qkH" = (
+/obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
+"qkJ" = (
+/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large{
+	layer = 2.6;
+	pixel_y = 18
+	},
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/stack/sheet/prewar/five,
+/obj/item/stack/sheet/prewar/five,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 9
+	},
+/area/f13/brotherhood)
 "qkN" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
@@ -48607,6 +50310,15 @@
 /obj/structure/junk/small/bed,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"qlm" = (
+/obj/structure/table,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "qln" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -48745,6 +50457,11 @@
 	icon_state = "common_dark-broken2"
 	},
 /area/f13/ncr)
+"qnN" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "qnY" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/tunnel/northeast)
@@ -48844,11 +50561,16 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "qpv" = (
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/indestructible/ground/outside/desert{
-	icon_state = "wasteland32"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/area/f13/wasteland)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "qpA" = (
 /turf/closed/indestructible/rock{
 	desc = "A pre-War supermart wall made of reinforced concrete.";
@@ -48902,19 +50624,9 @@
 	},
 /area/f13/ncr)
 "qqM" = (
-/obj/machinery/power/port_gen/pacman/diesel{
-	anchored = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13{
-	icon_state = "floorgrime"
-	},
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/blood/splats,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qqW" = (
 /obj/structure/table/wood/settler,
 /obj/item/stack/sheet/metal/five,
@@ -49058,12 +50770,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/town)
 "qth" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/vending/robotics,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "qti" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -49101,11 +50817,17 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/y)
 "qtI" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/f13/army/officer,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Armory Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/brotherhood)
 "qtQ" = (
 /obj/structure/chair/bench{
 	dir = 4;
@@ -49629,15 +51351,14 @@
 /turf/open/indestructible/ground/outside/snow,
 /area/f13/wasteland)
 "qCP" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
+/obj/structure/cargocrate{
+	pixel_y = 32
 	},
-/obj/structure/sink{
-	pixel_y = 17
+/obj/structure/car/rubbish3{
+	icon_state = "debris1"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building/powered)
 "qCQ" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -49647,10 +51368,15 @@
 	},
 /area/f13/ambientlighting/building/b)
 "qDa" = (
-/obj/structure/cargocrate{
-	icon_state = "cargocrate2"
+/obj/structure/fence{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt,
+/obj/structure/barricade/wooden/planks,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "qDl" = (
 /obj/structure/car,
@@ -49772,9 +51498,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/legion)
 "qEZ" = (
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermainleft"
-	},
+/obj/structure/debris/v2,
+/turf/open/floor/plating/rust,
 /area/f13/wasteland)
 "qFp" = (
 /obj/structure/chair/booth{
@@ -49843,6 +51568,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/legioncamp)
+"qGz" = (
+/obj/machinery/button/door{
+	id = "bosgarage";
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "qGJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -49855,9 +51594,12 @@
 	},
 /area/f13/building/powered)
 "qHj" = (
-/obj/machinery/light,
-/turf/open/floor/plating/f13/outside/road,
-/area/f13/building/abandoned/m)
+/obj/item/trash/f13/crisps,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "qHs" = (
 /obj/structure/bed/dogbed,
 /turf/open/floor/f13/wood,
@@ -49929,6 +51671,17 @@
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/ncr)
+"qIA" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	name = "south gate";
+	id = "Southone";
+	icon_state = "closed";
+	density = 1
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertopright"
+	},
+/area/f13/brotherhood/powered)
 "qIC" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -50085,18 +51838,16 @@
 	},
 /area/f13/ambientlighting/building/o)
 "qLY" = (
-/obj/machinery/power/port_gen/pacman/diesel{
-	anchored = 1
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "qLZ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -50138,12 +51889,10 @@
 	},
 /area/f13/wasteland)
 "qML" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
 "qMR" = (
 /obj/structure/curtain{
 	color = "#808080";
@@ -50690,10 +52439,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/den)
 "qVQ" = (
-/obj/structure/car/rubbish3,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/structure/fence{
+	dir = 4
 	},
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qWc" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -50714,11 +52465,14 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "qWq" = (
-/obj/structure/sign/poster/prewar/poster72{
-	pixel_x = -32
+/obj/effect/overlay/desert/sonora/edge,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "qWv" = (
 /obj/structure/chair/office/dark,
 /mob/living/simple_animal/hostile/raider/junker,
@@ -50791,23 +52545,18 @@
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/building/abandoned/z)
 "qXn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/guncase,
-/obj/item/gun/ballistic/automatic/m1carbine/compact,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "qXs" = (
-/obj/structure/sign/poster/prewar/poster62,
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
 	},
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/brotherhood/powered)
 "qXx" = (
 /obj/structure/window/fulltile/store{
 	icon_state = "storewindowbottom"
@@ -51070,6 +52819,17 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland)
+"rcc" = (
+/obj/machinery/workbench/forge,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "rcf" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -51151,10 +52911,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/h)
 "rdo" = (
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 10
+	},
+/area/f13/brotherhood)
 "rdp" = (
 /obj/structure/debris/v4,
 /obj/effect/decal/cleanable/dirt,
@@ -51203,6 +52969,14 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/legioncamp)
+"ref" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/brotherhood/powered)
 "rek" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/power/apc/fusebox/north,
@@ -51239,6 +53013,9 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/j)
+"reL" = (
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "reP" = (
 /obj/structure/flora/burnedlog{
 	pixel_x = 15;
@@ -51331,12 +53108,13 @@
 /turf/closed/wall/f13/supermart,
 /area/f13/followers)
 "rge" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old{
-	icon_state = "gibbearcore"
+/obj/machinery/vending/nukacolavend,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood)
 "rgm" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -51537,11 +53315,9 @@
 	},
 /area/f13/wasteland)
 "riO" = (
-/obj/structure/junk/small/table,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "riS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -51561,14 +53337,7 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/r)
 "rjn" = (
-/obj/structure/fence/cut/large{
-	dir = 4
-	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
+/turf/closed/wall/mineral/concrete/blastproof,
 /area/f13/wasteland)
 "rjo" = (
 /obj/effect/spawner/lootdrop/trash,
@@ -51793,6 +53562,15 @@
 /obj/structure/wreck/trash/one_barrel,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"roe" = (
+/obj/structure/car/rubbish3{
+	icon_state = "car_rubish2"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "roq" = (
 /mob/living/simple_animal/hostile/raider,
 /obj/structure/chair/f13chair1{
@@ -51842,6 +53620,18 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"rpg" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = -16
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "rpu" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/indestructible/ground/outside/dirt{
@@ -52208,6 +53998,14 @@
 	icon_state = "dirtcorner"
 	},
 /area/f13/wasteland/legion)
+"rvt" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "rvE" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/powered)
@@ -52216,10 +54014,12 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "rvP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/sign/radiation,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "rvQ" = (
 /obj/structure/railing{
 	layer = 4.1
@@ -52343,14 +54143,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/ncr)
 "ryn" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/wreck/trash/machinepiletwo,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood)
 "ryM" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -52416,6 +54214,12 @@
 "rzR" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/indestructible/ground/inside/dirt,
+/area/f13/wasteland)
+"rAc" = (
+/obj/structure/wreck/trash/halftire,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
 /area/f13/wasteland)
 "rAe" = (
 /obj/structure/car/rubbish3,
@@ -52571,6 +54375,12 @@
 "rCx" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ambientlighting/building/c)
+"rCz" = (
+/obj/structure/debris/v4,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "rCC" = (
 /obj/structure/table/booth,
 /obj/item/seeds/coffee,
@@ -52682,16 +54492,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/legion)
 "rEi" = (
-/obj/structure/railing/handrail{
-	dir = 4
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/railing/handrail{
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs{
-	dir = 1
-	},
-/area/f13/building/abandoned/m)
+/area/f13/wasteland)
 "rEk" = (
 /obj/structure/chair/sofa,
 /obj/structure/curtain{
@@ -52746,6 +54552,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
+"rEX" = (
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "rFa" = (
 /obj/machinery/door/locked/easy,
 /turf/open/floor/wood_wide,
@@ -52777,12 +54596,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/ncr)
 "rFY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "rGa" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/car/rubbish3,
@@ -52881,6 +54699,14 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ambientlighting/building/w)
+"rIs" = (
+/obj/structure/window/fulltile/house,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/obj/structure/barricade/bars,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "rIw" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/mineral/wood,
@@ -53094,13 +54920,15 @@
 	},
 /area/f13/building/abandoned/x)
 "rMr" = (
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 4
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "rMu" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	dir = 4
@@ -53123,10 +54951,23 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "rMM" = (
-/obj/structure/bed,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/rack/large/shelf_rust,
+/obj/effect/spawner/lootdrop/f13/advboards,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "rMP" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 6
@@ -53234,11 +55075,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
 "rOR" = (
-/obj/structure/car/rubbish1,
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/area/f13/wasteland)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "rOT" = (
 /turf/open/floor/f13,
 /area/f13/ambientlighting/building/o)
@@ -53275,6 +55116,17 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/h)
+"rPK" = (
+/obj/structure/sign/painting/library_secure{
+	persistence_id = "brotherhood_secure";
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "rPP" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -53338,16 +55190,11 @@
 	},
 /area/f13/ambientlighting/building/i)
 "rQJ" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -15
+/obj/structure/cargocrate,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
 	},
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 1;
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/building/abandoned/m)
+/area/f13/wasteland)
 "rQL" = (
 /obj/structure/floodlight_frame,
 /turf/open/indestructible/ground/outside/desert,
@@ -53543,13 +55390,22 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/engine/workshop)
+"rTY" = (
+/obj/machinery/autolathe,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "rUi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bookcase/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "rUp" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
@@ -53643,6 +55499,14 @@
 	icon_state = "housewood1-broken"
 	},
 /area/f13/ambientlighting/building/s)
+"rVU" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "rVW" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/condiment,
 /obj/effect/decal/cleanable/dirt,
@@ -53701,11 +55565,14 @@
 	},
 /area/f13/wasteland)
 "rXm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/card/id/rusted/brokenholodog,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/item/clothing/under/f13/recon,
+/obj/structure/closet/anchored,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 5
+	},
+/area/f13/brotherhood)
 "rXu" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	dir = 4
@@ -53784,9 +55651,27 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"rYX" = (
+/obj/effect/turf_decal/loading_area/white,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "rZc" = (
 /turf/open/floor/wood_common,
 /area/f13/followers)
+"rZd" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "rZy" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalleftborderleftbottom"
@@ -53916,9 +55801,11 @@
 	},
 /area/f13/ncr)
 "scn" = (
-/obj/structure/junk/cabinet,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "sct" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/legion)
@@ -54344,6 +56231,15 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/ambientlighting/building/w)
+"sjl" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "sjp" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/rack,
@@ -54515,6 +56411,10 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/c)
+"smn" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/rust,
+/area/f13/wasteland)
 "smo" = (
 /obj/machinery/rnd/experimentor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -54528,6 +56428,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13,
 /area/f13/ambientlighting/building/o)
+"smx" = (
+/obj/structure/car/rubbish2,
+/obj/structure/car/rubbish4,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "smB" = (
 /obj/machinery/shower{
 	dir = 8
@@ -54685,15 +56590,16 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar)
 "soG" = (
-/obj/structure/fence/cut/medium{
-	dir = 4
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
-	icon_state = "dirt"
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "sps" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/dirt{
@@ -54721,6 +56627,19 @@
 /mob/living/simple_animal/hostile/raider/sulphite,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/abandoned/g)
+"spL" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	id = "bosgate";
+	name = "outpost gate";
+	icon_state = "closed";
+	density = 1
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "sqd" = (
 /obj/structure/cable/outdoors{
 	icon_state = "4-8"
@@ -54751,11 +56670,8 @@
 /turf/open/floor/f13,
 /area/f13/ambientlighting/building/o)
 "sqC" = (
-/obj/structure/junk/small/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/f13/army/beret,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/brotherhood)
 "sqF" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -54819,6 +56735,18 @@
 	icon_state = "common-broken4"
 	},
 /area/f13/wasteland/town)
+"ssm" = (
+/obj/structure/car/rubbish1{
+	pixel_y = -16
+	},
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
+"ssu" = (
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontalbottomborderbottom3"
+	},
+/area/f13/wasteland)
 "ssJ" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
@@ -54907,10 +56835,10 @@
 	},
 /area/f13/building/powered)
 "sui" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermaintop"
+	},
+/area/f13/caves)
 "suq" = (
 /obj/effect/overlay/desert_side,
 /obj/structure/fence{
@@ -55096,13 +57024,25 @@
 	icon_state = "housewood1-broken"
 	},
 /area/f13/building/abandoned/j)
-"sxo" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+"sxh" = (
+/obj/structure/fence{
+	dir = 4
 	},
-/obj/effect/overlay/desert/sonora/edge,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 2;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
+"sxo" = (
+/obj/item/flag/bos,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "sxt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt,
@@ -55150,13 +57090,15 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/building/powered)
 "syn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bookcase/random,
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "syo" = (
 /obj/structure/reagent_dispensers/fueltank{
 	anchored = 1;
@@ -55168,11 +57110,11 @@
 	},
 /area/f13/wasteland)
 "syt" = (
-/obj/structure/cable/outdoors{
-	icon_state = "1-2"
+/obj/structure/car/rubbish1{
+	pixel_y = -16
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/turf/open/floor/plating/rust,
+/area/f13/wasteland)
 "syC" = (
 /obj/structure/fermenting_barrel,
 /turf/open/indestructible/ground/outside/desert,
@@ -55238,6 +57180,14 @@
 /obj/machinery/workbench,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/d)
+"szO" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "szY" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/barricade/sandbags,
@@ -55295,16 +57245,16 @@
 	},
 /area/f13/wasteland)
 "sBa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/spawner/lootdrop/f13/armor/tier3,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sBb" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "sBc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden/strong,
@@ -55427,8 +57377,10 @@
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
 "sCR" = (
-/turf/closed/wall/f13/store,
-/area/f13/brotherhood/surface)
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "sDb" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -55470,15 +57422,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/k)
 "sDo" = (
-/obj/structure/fence/corner{
-	dir = 1;
-	max_integrity = 900;
-	name = "reinforced fence"
-	},
-/obj/structure/obstacle/barbedwire/end{
+/obj/structure/fence{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "sDx" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -55860,11 +57810,9 @@
 	},
 /area/f13/wasteland)
 "sKF" = (
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 6;
-	icon_state = "dirt"
-	},
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "sKJ" = (
 /obj/structure/chair/f13chair1,
 /obj/machinery/light{
@@ -55872,6 +57820,11 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/y)
+"sKQ" = (
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/brotherhood)
 "sKR" = (
 /obj/structure/simple_door/dirtyglass,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -55999,11 +57952,11 @@
 /turf/open/indestructible/ground/outside/sidewalkdirt,
 /area/f13/wasteland/followers)
 "sMv" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/fence{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "sMD" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontalbottombordertop0"
@@ -56089,9 +58042,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/b)
 "sOd" = (
-/obj/structure/decoration/cctv,
-/turf/closed/wall/mineral/concrete/blastproof,
-/area/f13/building/abandoned/m)
+/obj/structure/barricade/sandbags,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "sOl" = (
 /obj/machinery/light{
 	dir = 1;
@@ -56287,6 +58245,16 @@
 	},
 /turf/open/floor/f13,
 /area/f13/ambientlighting/building/o)
+"sRi" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "sRm" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/generic,
@@ -56403,6 +58371,15 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/building/powered)
+"sTu" = (
+/obj/machinery/door/poddoor/gate/preopen{
+	name = "south gate";
+	id = "Southtwo"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/brotherhood/powered)
 "sTv" = (
 /obj/effect/landmark/start/f13/auxilia,
 /turf/open/indestructible/ground/outside/dirt,
@@ -56497,10 +58474,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ambientlighting/building/j)
 "sUF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/junk/small/table,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "sUJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall{
@@ -56888,11 +58870,10 @@
 	},
 /area/f13/building/powered)
 "taL" = (
-/obj/structure/cable/outdoors{
-	icon_state = "2-8"
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "taM" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/f13{
@@ -56931,7 +58912,7 @@
 /turf/open/indestructible/ground/outside/desert{
 	icon_state = "wasteland32"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
 "tbo" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -57031,6 +59012,10 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/ambientlighting/building/u)
+"tcS" = (
+/obj/structure/lamp_post/doubles,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "tcT" = (
 /obj/structure/table/optable,
 /obj/machinery/defibrillator_mount/loaded{
@@ -57039,25 +59024,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building/abandoned/y)
 "tcW" = (
-/obj/structure/railing/handrail{
-	dir = 4
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/railing/handrail{
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood)
 "tdc" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/tentleatheredge,
 /turf/closed/wall/f13/tentwall,
 /area/f13/building/tribal)
 "tdd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "tdk" = (
 /obj/structure/fence{
 	dir = 8
@@ -57093,9 +59080,11 @@
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/h)
 "teh" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/mineral/concrete/blastproof,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/wasteland)
 "tey" = (
 /mob/living/simple_animal/hostile/gecko,
 /turf/open/indestructible/ground/outside/dirt,
@@ -57190,19 +59179,27 @@
 	icon_state = "verticaloutermain2"
 	},
 /area/f13/wasteland)
+"tgj" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "tgo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	desc = "An airtight door, built to withstand a nuclear blast.";
-	max_integrity = 10000;
-	name = "Brotherhood of Steel";
-	req_access_txt = "120"
+/obj/effect/overlay/desert/sonora/edge,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/caves)
 "tgB" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood/house,
@@ -57228,6 +59225,10 @@
 	icon_state = "snow3"
 	},
 /area/f13/wasteland)
+"tgJ" = (
+/obj/effect/spawner/lootdrop/f13/armor/tier4,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tgR" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
@@ -57319,9 +59320,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
 "tix" = (
-/obj/structure/car/rubbish3,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/road{
+	dir = 8;
+	icon_state = "horizontalinnermain2left"
+	},
+/area/f13/wasteland)
 "tiz" = (
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
@@ -57379,14 +59386,9 @@
 	},
 /area/f13/wasteland)
 "tjM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/mineral/plasma/fifty,
-/obj/item/stack/sheet/mineral/plasma/fifty,
-/obj/item/stack/sheet/mineral/plasma/fifty,
-/obj/item/wrench,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/barricade/wooden/strong,
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
 "tkd" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalkdirt{
@@ -57495,12 +59497,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/ncr)
 "tkX" = (
-/obj/structure/junk/small/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirtcorner"
+	},
+/area/f13/wasteland)
 "tld" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
@@ -57704,6 +59707,11 @@
 	icon_state = "darkrusty";
 	name = "dirty floor"
 	},
+/area/f13/building/powered)
+"toy" = (
+/obj/structure/wreck/trash/two_barrels,
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building/powered)
 "toA" = (
 /obj/machinery/door/unpowered/secure_legion,
@@ -57978,9 +59986,16 @@
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
 "ttO" = (
-/obj/structure/wreck/trash/four_barrels,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/machinery/smartfridge,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood)
 "ttZ" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/grass/dirtpath{
@@ -58250,10 +60265,16 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/r)
 "tzc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/power/apc/fusebox/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "tzh" = (
 /obj/structure/bed/double,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -58609,9 +60630,11 @@
 	},
 /area/f13/ambientlighting/building/p)
 "tEA" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
+	},
+/area/f13/brotherhood/powered)
 "tEM" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -58821,6 +60844,24 @@
 /mob/living/simple_animal/hostile/ghoul/glowing/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tIu" = (
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
+	},
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/item/stock_parts/cell/ammo/ec,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
+	},
+/area/f13/brotherhood)
 "tID" = (
 /obj/machinery/smartfridge/bottlerack,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -59074,15 +61115,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/powered)
 "tNB" = (
-/obj/structure/barricade/bars,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/area/f13/brotherhood/surface)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain1"
+	},
+/area/f13/wasteland)
 "tNE" = (
 /obj/structure/window/fulltile/house{
 	dir = 2;
@@ -59178,6 +61217,19 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/ambientlighting/building/x)
+"tPj" = (
+/obj/structure/table/booth,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/trash/f13/c_ration_3,
+/obj/item/trash/f13/mre,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "tPA" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -59257,10 +61309,11 @@
 	},
 /area/f13/ncr)
 "tQR" = (
-/obj/structure/cargocrate{
-	layer = 1
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
 	},
-/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "tQS" = (
 /obj/structure/window/fulltile/house{
@@ -59339,14 +61392,19 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/caves)
 "tRw" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
 	},
-/area/f13/brotherhood/surface)
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood/powered)
 "tRA" = (
 /obj/structure/junk/small/bed,
 /obj/structure/wreck/trash/five_tires,
@@ -59423,6 +61481,14 @@
 "tSA" = (
 /obj/effect/overlay/desert/sonora/edge/corner,
 /turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"tSB" = (
+/obj/item/storage/trash_stack,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
 /area/f13/wasteland)
 "tSC" = (
 /obj/structure/window/fulltile/house{
@@ -59510,12 +61576,17 @@
 	},
 /area/f13/building/powered)
 "tTP" = (
-/obj/effect/overlay/desert/sonora/edge,
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/button/door{
+	pixel_x = -5;
+	id = "Northone"
 	},
-/turf/open/floor/plating/f13/outside/road,
-/area/f13/wasteland)
+/obj/machinery/button/door{
+	pixel_x = 5;
+	id = "Northtwo"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "tTX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/handy/assaultron/laser,
@@ -59568,11 +61639,10 @@
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
 "tUI" = (
-/obj/structure/cable/outdoors{
-	icon_state = "2-4"
-	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/obj/machinery/door/unpowered/secure_bos,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "tUJ" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -59948,12 +62018,15 @@
 	},
 /area/f13/ncr)
 "ubM" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
+/obj/structure/junk/small/table,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain0"
 	},
+/area/f13/wasteland)
+"ubP" = (
+/obj/structure/gas_pump/oilpump1,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/area/f13/building/powered)
 "ubQ" = (
 /obj/structure/simple_door/tent{
 	color = "#7c0A02"
@@ -59980,16 +62053,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/w)
 "ucl" = (
-/obj/structure/cable/outdoors{
-	icon_state = "1-2"
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
-/obj/structure/cable/outdoors{
-	icon_state = "1-4"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
-	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "uco" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -60071,12 +62141,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/a)
 "udp" = (
-/obj/structure/fence{
-	dir = 1
+/obj/machinery/door/unpowered/secure_bos,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/obj/structure/obstacle/barbedwire,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "udy" = (
 /obj/effect/landmark/start/f13/campfollower,
 /obj/effect/decal/cleanable/dirt{
@@ -60294,10 +62365,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "uge" = (
-/obj/structure/wreck/trash/one_tire,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outerpavementcorner"
+	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland)
 "ugi" = (
@@ -60560,6 +62632,11 @@
 /obj/structure/table/wood/bar,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"ujW" = (
+/obj/structure/wreck/trash/three_barrels,
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
 "ujX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -60678,6 +62755,10 @@
 /obj/structure/simple_door/metal/fence/wooden,
 /turf/open/indestructible/ground/outside/snow,
 /area/f13/ncr)
+"umQ" = (
+/obj/item/target/clown,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/powered)
 "umR" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/bars{
@@ -60759,14 +62840,15 @@
 	},
 /area/f13/wasteland)
 "uoy" = (
-/obj/structure/fence{
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/obj/effect/overlay/desert/sonora/edge{
 	dir = 4
 	},
-/obj/structure/obstacle/barbedwire{
-	dir = 4
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
 	},
-/obj/structure/decoration/cctv,
-/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "uoD" = (
 /obj/structure/obstacle/barbedwire/end{
@@ -60791,7 +62873,7 @@
 /area/f13/building/abandoned/l)
 "uoW" = (
 /turf/open/floor/plasteel/elevatorshaft,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "upe" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
@@ -60849,8 +62931,18 @@
 	},
 /area/f13/wasteland)
 "uqm" = (
-/obj/structure/billboard/nukagirl,
-/turf/open/indestructible/ground/outside/desert,
+/obj/machinery/camera/autoname{
+	dir = 1;
+	name = "Gate Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright3"
+	},
 /area/f13/wasteland)
 "uqz" = (
 /mob/living/simple_animal/hostile/retaliate/talker/buyer/basic,
@@ -60938,14 +63030,9 @@
 	},
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/ncr)
-"usy" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+"usq" = (
+/turf/open/floor/plating/dirt,
+/area/f13/brotherhood/powered)
 "usB" = (
 /obj/structure/table/wood/bar,
 /obj/item/paper/secretrecipe,
@@ -61029,13 +63116,15 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar)
 "utR" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
+/obj/structure/fence{
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain2"
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 2;
+	icon_state = "dirt"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "utV" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -61297,9 +63386,9 @@
 /turf/open/indestructible/ground/outside/desert/harsh,
 /area/f13/wasteland)
 "uyc" = (
-/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/item/trash/f13/blamco_large,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/area/f13/building/powered)
 "uyg" = (
 /obj/machinery/light{
 	dir = 8
@@ -61328,6 +63417,16 @@
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland/town)
+"uyK" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/brotherhood)
 "uyR" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	dir = 8;
@@ -61426,6 +63525,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/abandoned/t)
+"uAt" = (
+/obj/structure/car/rubbish3{
+	pixel_x = -17
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "uAH" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -61724,15 +63829,14 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "uFK" = (
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/obj/structure/noticeboard{
+	pixel_y = 32
 	},
-/area/f13/building/abandoned/m)
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood)
 "uFP" = (
 /obj/effect/landmark/npc_wastelander_spawn_position,
 /turf/open/indestructible/ground/outside/road,
@@ -61942,7 +64046,7 @@
 /area/f13/caves)
 "uHW" = (
 /turf/open/indestructible/ground/outside/desert,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
 "uHY" = (
 /obj/effect/overlay/desert_side{
 	dir = 4
@@ -62003,14 +64107,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/ncr)
 "uIC" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = -16
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/junk/locker,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood)
 "uIF" = (
 /obj/structure/reagent_dispensers/rainwater_tank,
 /turf/open/indestructible/ground/inside/dirt,
@@ -62135,11 +64236,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/k)
 "uLu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "uLw" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/rack,
@@ -62208,9 +64311,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legioncamp)
 "uMl" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "uMn" = (
 /obj/structure/chair{
 	dir = 4
@@ -62335,9 +64440,17 @@
 	},
 /area/f13/ambientlighting/building/w)
 "uOo" = (
-/obj/item/storage/trash_stack,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/machinery/computer/shuttle/bosentryelevator{
+	dir = 8;
+	pixel_x = 2
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "uOt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
@@ -62393,9 +64506,15 @@
 	},
 /area/f13/building/powered)
 "uPp" = (
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 2;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "uPC" = (
 /obj/structure/car/rubbish2{
 	pixel_x = -18;
@@ -62454,6 +64573,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ambientlighting/building/j)
+"uQx" = (
+/obj/machinery/power/apc/fusebox/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood)
 "uQB" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -62473,12 +64601,16 @@
 	},
 /area/f13/wasteland)
 "uQS" = (
-/obj/machinery/power/port_gen/pacman/diesel{
-	anchored = 1
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = -16
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "uQU" = (
 /obj/machinery/light/small/broken{
 	dir = 4
@@ -62642,18 +64774,34 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar)
+"uTq" = (
+/obj/machinery/defibrillator_mount/loaded,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood)
 "uTr" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/ambientlighting/building/y)
 "uTu" = (
-/obj/structure/wreck/trash/two_barrels,
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 2;
-	icon_state = "dirt"
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood/powered)
 "uTw" = (
 /obj/effect/spawner/lootdrop/wastelootgood,
 /turf/open/indestructible/ground/outside/dirt,
@@ -63133,16 +65281,11 @@
 	},
 /area/f13/followers)
 "vbF" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 1
-	},
-/obj/effect/overlay/desert/sonora/edge{
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain1"
-	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "vbT" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/delivery,
@@ -63200,6 +65343,18 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland/city)
+"vcY" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "vcZ" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/bars,
@@ -63221,16 +65376,12 @@
 	},
 /area/f13/ambientlighting/building/o)
 "vdg" = (
-/obj/structure/sign/flag_america,
-/turf/closed/indestructible/rock{
-	desc = "A pre-War wall made of solid concrete.";
-	icon = 'icons/turf/walls/f13store.dmi';
-	icon_state = "store";
-	icon_type_smooth = "store";
-	name = "Concrete wall";
-	smooth = 1
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 4;
+	icon_state = "outerborder"
 	},
-/area/f13/building/abandoned/m)
+/area/f13/wasteland)
 "vdh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -63260,8 +65411,11 @@
 	},
 /area/f13/ambientlighting/building/o)
 "vdT" = (
-/obj/structure/sign/flag_china,
-/turf/closed/wall/rust,
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "vdU" = (
 /obj/structure/rack/large/shelf_rust,
@@ -63279,6 +65433,15 @@
 /obj/item/encryptionkey/headset_legion,
 /turf/open/floor/carpet/red,
 /area/f13/legioncamp)
+"vdY" = (
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "vei" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken{
@@ -63331,9 +65494,14 @@
 	},
 /area/f13/ambientlighting/building/o)
 "veV" = (
-/obj/structure/debris/v2,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/door/unpowered/secure_bos,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "veW" = (
 /obj/machinery/autolathe/ammo,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -63367,9 +65535,13 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "vfE" = (
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plating/f13/outside/road,
-/area/f13/building/abandoned/m)
+/obj/structure/debris/v4,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/wasteland)
 "vfF" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -63503,13 +65675,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/a)
 "vhF" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
 	},
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "vhH" = (
 /obj/structure/car/rubbish4,
 /turf/open/indestructible/ground/inside/dirt,
@@ -63541,6 +65711,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ambientlighting/building/o)
+"vjD" = (
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright0"
+	},
+/area/f13/brotherhood/powered)
 "vjM" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticalcorroded"
@@ -63617,13 +65792,14 @@
 /turf/open/floor/carpet/airless,
 /area/f13/ambientlighting/building/c)
 "vkw" = (
-/obj/machinery/light{
-	dir = 1;
-	layer = 2.9
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
 	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain2"
+	},
+/area/f13/wasteland)
 "vkz" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -63858,6 +66034,12 @@
 /obj/structure/decoration/rag,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"voM" = (
+/obj/structure/wreck/trash/three_barrels,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "voS" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
@@ -63873,13 +66055,16 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "vpf" = (
-/obj/structure/barricade/bars,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowright"
+/obj/structure/sign/poster/ripped,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/area/f13/brotherhood)
 "vpp" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -64206,6 +66391,10 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar)
+"vuF" = (
+/mob/living/simple_animal/hostile/deathclaw/mother,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vuP" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	dir = 4
@@ -64315,11 +66504,18 @@
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
 "vwa" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/radio/old,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood)
+"vwc" = (
+/obj/machinery/light/lampost{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 7;
+	icon_state = "outerpavement"
+	},
+/area/f13/wasteland)
 "vwf" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/mountain,
@@ -64486,12 +66682,10 @@
 	},
 /area/f13/wasteland)
 "vzY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/obj/structure/barricade/wooden,
+/obj/structure/decoration/rag,
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
 "vzZ" = (
 /obj/structure/ladder/unbreakable{
 	height = 2;
@@ -64575,6 +66769,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
+"vBv" = (
+/obj/structure/car/rubbish3,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "verticalinnermainbottom"
+	},
+/area/f13/wasteland)
 "vBx" = (
 /obj/structure/butter_churn,
 /obj/effect/decal/cleanable/dirt{
@@ -64755,14 +66955,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/powered)
 "vEv" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 8
-	},
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 10
-	},
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/building/abandoned/m)
+/obj/structure/wreck/trash/one_barrel,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating/dirt,
+/area/f13/wasteland)
 "vEH" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -65127,6 +67323,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ambientlighting/building/k)
+"vKh" = (
+/obj/structure/campfire/barrel,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
 "vKq" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "drip1"
@@ -65208,9 +67410,11 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
 "vLP" = (
-/obj/item/target/communist,
-/turf/open/indestructible/ground/outside/dirt,
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/item/clothing/head/welding,
+/obj/item/weldingtool/largetank,
+/turf/open/floor/plating/rust,
+/area/f13/building/powered)
 "vLU" = (
 /obj/machinery/light{
 	dir = 1;
@@ -65223,11 +67427,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/abandoned/g)
 "vMK" = (
-/obj/structure/junk/locker,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_y = -7
+	},
+/obj/structure/table,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "vMM" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22";
@@ -65319,13 +67525,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vOf" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-2"
+/turf/open/indestructible/ground/outside/road{
+	dir = 4;
+	icon_state = "innermaincornerinner"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/caves)
 "vOh" = (
 /obj/structure/chair/stool,
 /obj/machinery/light{
@@ -65342,12 +67546,27 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/abandoned/g)
 "vOq" = (
-/obj/machinery/light{
-	pixel_x = -16
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalbottombordertopleft"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/area/f13/wasteland)
+"vOr" = (
+/obj/item/storage/toolbox/electrical,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "red"
+	},
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "vOD" = (
 /obj/item/flag/followers,
 /obj/effect/turf_decal/weather/dirt{
@@ -65560,6 +67779,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
+"vTu" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/toy/plush/nukeplushie{
+	desc = "A stuffed toy that resembles a Chinese spy/ The tag claims operatives to be purely fictitious and not stealing your armory.";
+	name = "Knight-Captain Aryom";
+	pixel_x = 9
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "vTy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood/settler,
@@ -65658,11 +67894,13 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "vWj" = (
-/obj/structure/barricade/sandbags,
-/obj/effect/overlay/desert_side{
+/obj/effect/overlay/desert/sonora/edge{
 	dir = 4
 	},
-/turf/open/floor/plating/f13/outside/road,
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
 /area/f13/wasteland)
 "vWn" = (
 /obj/item/shovel,
@@ -65692,9 +67930,9 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "vXl" = (
-/obj/effect/overlay/desert_side,
-/obj/effect/overlay/desert_side,
-/turf/open/floor/plating/f13/outside/road,
+/obj/structure/barricade/wooden/strong,
+/obj/structure/barricade/wooden/planks,
+/turf/open/indestructible/ground/outside/ruins,
 /area/f13/wasteland)
 "vXp" = (
 /obj/structure/fence/wooden{
@@ -65714,6 +67952,11 @@
 /obj/structure/simple_door/tentflap_leather,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
+"vXL" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood)
 "vYk" = (
 /turf/open/indestructible/ground/outside/road{
 	icon_state = "horizontaltopborderbottom2right"
@@ -65841,6 +68084,15 @@
 "waD" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
+"waE" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor1-old"
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 4;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "waH" = (
 /obj/effect/decal/cleanable/generic,
@@ -66236,6 +68488,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/blue,
 /area/f13/followers)
+"whF" = (
+/obj/machinery/power/apc/fusebox/south,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/cable,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "whJ" = (
 /turf/open/floor/f13{
 	icon_state = "stagestairs"
@@ -66261,6 +68525,10 @@
 "wie" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/building/abandoned/v)
+"win" = (
+/obj/item/trash/f13/sugarbombs,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "wiB" = (
 /obj/structure/sign/poster/prewar/poster72,
 /turf/closed/indestructible/rock{
@@ -66696,6 +68964,17 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/followers)
+"woq" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "boslockdown";
+	name = "entrance shutters"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "wot" = (
 /turf/closed/wall/f13/wood/house,
 /area/f13/ambientlighting/building/b)
@@ -66719,11 +68998,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/powered)
 "woZ" = (
-/obj/effect/overlay/desert/sonora/edge{
-	dir = 5
-	},
-/turf/open/indestructible/ground/outside/ruins,
-/area/f13/building/abandoned/m)
+/obj/structure/closet/anchored,
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/item/clothing/suit/toggle/labcoat/scribecoat,
+/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
+/obj/item/clothing/suit/toggle/labcoat/fieldscribe,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood)
 "wpc" = (
 /obj/structure/junk/small/table,
 /turf/open/indestructible/ground/inside/dirt,
@@ -66922,6 +69205,15 @@
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"wsb" = (
+/obj/machinery/door/unpowered/secure_bos,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#a6968e";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "wsd" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticalrightborderright0"
@@ -67022,14 +69314,12 @@
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/ambientlighting/building/c)
 "wta" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/wasteland)
 "wtd" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/glass,
@@ -67058,6 +69348,15 @@
 /obj/item/reagent_containers/food/drinks/bottle/sunset,
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
+"wtD" = (
+/obj/structure/fence/corner{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "wtJ" = (
 /obj/structure/sink{
 	dir = 4;
@@ -67068,6 +69367,14 @@
 "wtL" = (
 /obj/structure/obstacle/barbedwire/end,
 /turf/open/indestructible/ground/outside/road,
+/area/f13/wasteland)
+"wtO" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1";
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "wtP" = (
 /obj/structure/chair/right,
@@ -67369,6 +69676,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"wyj" = (
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/wasteland)
 "wyk" = (
 /obj/structure/table/wood,
 /obj/structure/curtain{
@@ -67421,6 +69734,22 @@
 	},
 /turf/closed/wall/mineral/wood,
 /area/f13/legioncamp)
+"wyZ" = (
+/obj/structure/car/rubbish2{
+	icon_state = "car_rubish3"
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermainleft"
+	},
+/area/f13/wasteland)
+"wzm" = (
+/obj/structure/debris/v3,
+/obj/structure/debris/v4,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "wzq" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /turf/open/floor/f13{
@@ -67717,12 +70046,10 @@
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
 "wDK" = (
-/obj/effect/overlay/desert/sonora/edge,
 /turf/open/indestructible/ground/outside/sidewalk{
-	dir = 10;
-	icon_state = "outerpavement"
+	icon_state = "horizontaloutermain0"
 	},
-/area/f13/wasteland)
+/area/f13/brotherhood/powered)
 "wDP" = (
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 1
@@ -67792,9 +70119,16 @@
 	},
 /area/f13/building/powered)
 "wEL" = (
-/obj/structure/wreck/trash/five_tires,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood)
 "wEO" = (
 /obj/structure/flora/stump,
 /turf/open/indestructible/ground/outside/snow{
@@ -68272,6 +70606,14 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/p)
+"wNf" = (
+/obj/structure/fence{
+	dir = 4
+	},
+/obj/structure/decoration/rag,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "wNm" = (
 /obj/machinery/chem_master,
 /turf/open/floor/f13{
@@ -68391,6 +70733,15 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"wPb" = (
+/obj/structure/window/fulltile/house/broken,
+/obj/structure/barricade/bars,
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "wPB" = (
 /obj/structure/closet/crate/large,
 /obj/item/clothing/suit/armor/light/legion/recruit,
@@ -68717,13 +71068,22 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
-"wUf" = (
-/obj/machinery/light/small,
-/obj/structure/cable{
-	icon_state = "4-8"
+"wUa" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "bosgarage"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
+"wUf" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
 "wUg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/window/fulltile/house{
@@ -68867,19 +71227,28 @@
 	},
 /area/f13/wasteland)
 "wVK" = (
-/obj/structure/closet/crate/footlocker{
-	anchored = 1
+/obj/structure/wreck/bus/rusted{
+	pixel_y = -10
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/f13/army/beret,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain0"
+	},
+/area/f13/wasteland)
 "wVL" = (
 /obj/structure/fence{
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"wVT" = (
+/obj/machinery/door/unpowered/secure_bos,
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "wWi" = (
 /obj/machinery/light{
 	dir = 1;
@@ -69056,6 +71425,14 @@
 	icon_state = "innerpavement"
 	},
 /area/f13/building/abandoned/t)
+"wZK" = (
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderrightbottom"
+	},
+/area/f13/wasteland)
 "wZL" = (
 /obj/structure/fence{
 	pixel_x = -14
@@ -69167,15 +71544,11 @@
 	},
 /area/f13/building/powered)
 "xbm" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = 16
+/obj/structure/car/rubbish1{
+	pixel_y = -16
 	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building/powered)
 "xbq" = (
 /obj/structure/campfire,
 /turf/open/indestructible/ground/outside/desert,
@@ -69240,11 +71613,13 @@
 	},
 /area/f13/building/powered)
 "xde" = (
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/white,
-/area/f13/building/abandoned/m)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2left"
+	},
+/area/f13/wasteland)
 "xdg" = (
 /obj/item/clothing/head/f13/enclave,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -69327,10 +71702,15 @@
 	},
 /area/f13/wasteland)
 "xes" = (
-/obj/effect/overlay/desert/sonora/edge,
-/obj/item/flag/bos,
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/wasteland)
+/obj/structure/table,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath/medical,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/brotherhood)
 "xeI" = (
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/road,
@@ -69680,6 +72060,20 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/ambientlighting/building/u)
+"xjY" = (
+/obj/structure/barricade/wooden/strong,
+/obj/structure/decoration/rag{
+	icon_state = "skin"
+	},
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/building/powered)
 "xkl" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/outside/dirt{
@@ -69704,6 +72098,12 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/x)
+"xkI" = (
+/obj/structure/car/rubbish4,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "xla" = (
 /obj/structure/decoration/rag,
 /obj/structure/decoration/rag{
@@ -69835,11 +72235,12 @@
 	},
 /area/f13/wasteland/legion)
 "xmm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/junk/small/table,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/barricade/sandbags,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	dir = 4
+	},
+/area/f13/wasteland)
 "xms" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -70155,18 +72556,13 @@
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
 "xrd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/shower{
-	dir = 8
+/obj/machinery/computer/operating/bos{
+	dir = 1
 	},
-/obj/structure/decoration/vent/rusty{
-	desc = "It's very old and rusty.";
-	name = "rusty grate";
-	pixel_x = 2;
-	pixel_y = -3
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood)
 "xrt" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 1
@@ -70239,11 +72635,10 @@
 	},
 /area/f13/wasteland)
 "xsl" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/turf/open/floor/f13{
+	icon_state = "dark"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/area/f13/brotherhood/powered)
 "xsp" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/outside/dirt{
@@ -70278,6 +72673,10 @@
 	dir = 1;
 	icon_state = "outerborder"
 	},
+/area/f13/wasteland)
+"xtf" = (
+/obj/structure/fence/corner,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xtj" = (
 /obj/structure/table/reinforced,
@@ -70506,9 +72905,16 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "xwj" = (
-/obj/structure/nest/ghoul,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/machinery/power/apc/fusebox/south,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "xwm" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -70750,6 +73156,14 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier2,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"xAu" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "xAA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -71099,9 +73513,13 @@
 /turf/open/floor/carpet/airless,
 /area/f13/ambientlighting/building/c)
 "xFk" = (
-/obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "hole"
+	},
+/area/f13/wasteland)
 "xFm" = (
 /mob/living/simple_animal/hostile/ghoul/scorched,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -71188,6 +73606,13 @@
 /obj/item/key/scollar,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"xGS" = (
+/obj/machinery/power/apc/fusebox/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "xGT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -71205,18 +73630,38 @@
 /turf/closed/wall/f13/tentwall,
 /area/f13/ambientlighting/building/b)
 "xHn" = (
-/obj/structure/junk/small/table,
-/obj/item/clothing/head/f13/army,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "xHu" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedvertical"
 	},
 /turf/open/indestructible/ground/outside/road,
 /area/f13/building/lower_firetower)
+"xHI" = (
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/reagent_containers/blood/OMinus,
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood)
 "xHX" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/curtain{
@@ -71450,11 +73895,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ambientlighting/building/j)
 "xLO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
-/area/f13/building/abandoned/m)
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "xLQ" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/wood_common,
@@ -71565,9 +74015,13 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/ncr)
 "xOf" = (
-/obj/structure/reagent_dispensers/barrel/explosive,
-/turf/open/floor/plating/f13/outside/road,
-/area/f13/wasteland)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/f13{
+	icon_state = "bluedirtychess2"
+	},
+/area/f13/brotherhood)
 "xOi" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/shiny,
@@ -71681,12 +74135,34 @@
 /obj/item/stock_parts/cell/high,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"xQq" = (
+/obj/item/storage/trash_stack,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 8;
+	icon_state = "outerborder"
+	},
+/area/f13/wasteland)
 "xQD" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/outside/grass/corner{
 	dir = 8
 	},
 /area/f13/wasteland)
+"xQV" = (
+/obj/structure/table,
+/obj/machinery/vending/wallmed{
+	pixel_x = -30
+	},
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood/powered)
 "xRe" = (
 /obj/structure/stairs/north{
 	color = "#A47449"
@@ -71745,14 +74221,21 @@
 	},
 /area/f13/building/abandoned/a)
 "xRQ" = (
-/obj/structure/fence/cut/medium{
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Armory Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/dirt{
-	dir = 1;
-	icon_state = "dirt"
-	},
-/area/f13/wasteland)
+/area/f13/brotherhood)
 "xRT" = (
 /obj/structure/fence{
 	dir = 8
@@ -71775,6 +74258,14 @@
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/ncr)
+"xRZ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "horizontaloutermain2"
+	},
+/area/f13/wasteland)
 "xSm" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -71782,6 +74273,16 @@
 /obj/effect/landmark/start/f13/ncrcombatmedic,
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/ncr)
+"xSr" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/vending/snack,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/brotherhood)
 "xSv" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -71941,6 +74442,14 @@
 	icon_state = "dark"
 	},
 /area/f13/ambientlighting/building/o)
+"xVs" = (
+/obj/machinery/light/small{
+	dir = 4;
+	layer = 2.7;
+	pixel_y = 17
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood)
 "xVt" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedhorizontal"
@@ -72019,6 +74528,17 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"xWR" = (
+/obj/structure/sign/poster/prewar/poster71,
+/turf/closed/indestructible/rock{
+	desc = "A pre-War wall made of solid concrete.";
+	icon = 'icons/turf/walls/f13store.dmi';
+	icon_state = "store";
+	icon_type_smooth = "store";
+	name = "Concrete wall";
+	smooth = 1
+	},
+/area/f13/brotherhood)
 "xWX" = (
 /obj/machinery/light{
 	dir = 8;
@@ -72057,6 +74577,14 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/i)
+"xXq" = (
+/obj/structure/debris/v2,
+/obj/structure/debris/v3,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 8;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "xXx" = (
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
@@ -72418,20 +74946,17 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
 "ydn" = (
-/obj/machinery/button/door{
-	id = "BoS Inner Surface Gate";
-	name = "BoS Inner Surface Gate";
-	pixel_x = 8
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "BoS Outer Surface Gate";
-	name = "BoS Outer Surface Gate";
-	pixel_x = -4
+/obj/effect/overlay/desert/sonora/edge,
+/obj/structure/car/rubbish3{
+	icon_state = "car_rubish2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
+/turf/open/indestructible/ground/outside/road{
+	icon_state = "horizontalinnermain1"
+	},
+/area/f13/wasteland)
 "ydp" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "verticaloutermaintop"
@@ -72461,18 +74986,17 @@
 	},
 /area/f13/ambientlighting/building/o)
 "yeu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/stairs/north,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
 	},
-/turf/open/floor/plasteel/f13/stone,
-/area/f13/brotherhood/surface)
-"yeC" = (
-/obj/structure/barricade/sandbags,
-/turf/open/floor/plating/f13/outside/road,
 /area/f13/wasteland)
+"yeC" = (
+/obj/structure/car/rubbish4,
+/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
+/area/f13/building/powered)
 "yeD" = (
 /obj/structure/fence{
 	dir = 4
@@ -72625,10 +75149,10 @@
 	},
 /area/f13/ambientlighting/building/b)
 "ygI" = (
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
-/area/f13/building/abandoned/m)
+/turf/open/indestructible/ground/outside/sidewalk{
+	icon_state = "verticalrightborderright3"
+	},
+/area/f13/brotherhood/powered)
 "ygU" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -72866,8 +75390,8 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "yku" = (
-/obj/structure/wreck/trash/one_barrel,
-/turf/open/indestructible/ground/outside/desert,
+/obj/structure/car/rubbish4,
+/turf/open/floor/plating/rust,
 /area/f13/wasteland)
 "yky" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -72927,7 +75451,10 @@
 	},
 /area/f13/ambientlighting/building/b)
 "ylI" = (
-/turf/open/indestructible/ground/outside/sidewalk,
+/turf/open/indestructible/ground/outside/sidewalk{
+	dir = 1;
+	icon_state = "outerpavement"
+	},
 /area/f13/caves)
 "ylX" = (
 /obj/structure/simple_door,
@@ -97930,9 +100457,9 @@ uVn
 uVn
 eml
 tfP
-smK
-smK
-smK
+mJM
+ntm
+wsh
 sJc
 sLI
 qfR
@@ -98232,9 +100759,9 @@ sgn
 nqZ
 ner
 tfP
-smK
-smK
-smK
+oDH
+dzm
+xOE
 sJc
 sLI
 azA
@@ -98534,9 +101061,9 @@ nqZ
 azA
 ner
 tfP
-smK
-smK
-smK
+gTs
+dcx
+xOE
 sJc
 sLI
 azA
@@ -98837,8 +101364,8 @@ oAf
 ner
 tfP
 smK
-smK
-smK
+gTs
+dVN
 sJc
 sLI
 azA
@@ -102074,15 +104601,15 @@ uBG
 cBf
 nrq
 azA
+thW
+nqa
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+thW
+ioi
+ioi
+ioi
+ioi
+wZK
 azA
 azA
 azA
@@ -102378,10 +104905,10 @@ ctN
 azA
 thW
 jCi
-sZp
+rZd
 sZp
 wjJ
-wjJ
+sZp
 sZp
 ase
 kHs
@@ -103368,7 +105895,7 @@ ner
 tfP
 smK
 eIM
-smK
+cKE
 sJc
 odS
 odS
@@ -103585,7 +106112,7 @@ rRz
 ovy
 nrq
 nAI
-dgM
+nqa
 azA
 dzm
 azA
@@ -103668,8 +106195,8 @@ azA
 azA
 ner
 kmk
-smK
-smK
+cKE
+mfA
 smK
 sJc
 cMb
@@ -103970,9 +106497,9 @@ azA
 azA
 ner
 tfP
-smK
-smK
-smK
+mJM
+ntm
+wsh
 sJc
 sLI
 azA
@@ -104272,9 +106799,9 @@ azA
 azA
 ner
 tfP
-smK
-smK
-smK
+oDH
+ueC
+xOE
 sJc
 sLI
 azA
@@ -104574,9 +107101,9 @@ azA
 azA
 ner
 tfP
-smK
-smK
-smK
+gTs
+wyZ
+dVN
 sJc
 sLI
 azA
@@ -104878,7 +107405,7 @@ ner
 tfP
 smK
 smK
-smK
+mfA
 sJc
 sLI
 azA
@@ -105179,8 +107706,8 @@ azA
 ner
 tfP
 smK
-smK
-smK
+mfA
+lxu
 sJc
 sLI
 azA
@@ -105481,8 +108008,8 @@ azA
 ner
 tfP
 smK
-smK
-smK
+cKE
+mfA
 sJc
 sLI
 azA
@@ -106047,14 +108574,6 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
 rRz
 rRz
 rRz
@@ -106064,8 +108583,6 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
 rRz
 rRz
 rRz
@@ -106073,7 +108590,17 @@ rRz
 rRz
 rRz
 rRz
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 rRz
 rRz
 rRz
@@ -106084,8 +108611,8 @@ azA
 azA
 ner
 tfP
-smK
-smK
+cKE
+mfA
 smK
 sJc
 sLI
@@ -106346,38 +108873,38 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 rRz
 rRz
 rRz
@@ -106386,8 +108913,8 @@ rRz
 dzm
 ner
 tfP
-smK
-smK
+lxu
+cKE
 smK
 sJc
 sLI
@@ -106649,38 +109176,38 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 rRz
 rRz
 rRz
@@ -106688,7 +109215,7 @@ rRz
 iZq
 ner
 tfP
-smK
+mfA
 smK
 smK
 sJc
@@ -106952,45 +109479,45 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 rRz
 rRz
 dzm
 ner
 tfP
-smK
+kds
 smK
 smK
 sJc
@@ -107253,48 +109780,48 @@ rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+azA
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
 azA
+rRz
+rRz
 azA
 azA
+rRz
+rRz
 azA
+rRz
+rRz
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rRz
+rRz
 azA
 dzm
 ner
 tfP
-smK
-smK
-smK
+cKE
+cKE
+cKE
 sJc
 sLI
 azA
@@ -107554,49 +110081,49 @@ rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+azA
+rRz
+rRz
 azA
 azA
-ooG
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
+rjn
 pAJ
+pAJ
+pAJ
+pAJ
+pAJ
+pAJ
+pAJ
+pAJ
+rjn
+pAJ
+pAJ
+pAJ
+pAJ
+pAJ
+pAJ
+rjn
 lNW
-lNW
-lNW
-lNW
-jjU
-sDo
+nvv
+azA
 azA
 azA
 ner
 tfP
-smK
-smK
-smK
+kds
+mfA
+cKE
 sJc
 sLI
 azA
@@ -107856,49 +110383,49 @@ rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+azA
+rRz
+rRz
+rRz
 azA
 azA
-plW
+rRz
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-dzm
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-oDM
-azA
-azA
-dzN
+utR
+uqB
+uqB
+uqB
+faB
+cBf
+uqB
+uqB
+uqB
 cBf
 cBf
 cBf
-wBK
-nrq
-plW
+cBf
+uqB
+uqB
+uqB
+amS
+azA
+hnr
+azA
 azA
 azA
 ner
 tfP
-smK
-smK
-smK
+mJM
+ntm
+wsh
 sJc
 sLI
 azA
@@ -108157,50 +110684,50 @@ rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
 azA
 azA
-plW
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-oAf
-jKr
+rRz
 azA
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-kDY
-azA
-snR
+dqd
+uqB
+cBf
+cBf
+nDt
+wTQ
+wTQ
+wTQ
+wTQ
+wTQ
+wTQ
+wTQ
+wTQ
+wTQ
+chn
 cBf
 tQR
-tQR
-qDa
-nrq
-plW
+uhS
+kAv
+azA
 azA
 azA
 ner
 tfP
-cSQ
-smK
-smK
+fdb
+dzm
+xOE
 sJc
 sLI
 azA
@@ -108457,20 +110984,14 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
-azA
-plW
-azA
-azA
-azA
-azA
-dzm
-azA
-azA
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
 azA
 azA
@@ -108482,27 +111003,33 @@ azA
 azA
 azA
 azA
-ljW
-azA
-azA
-azA
-azA
-jKr
-gmU
-dDx
-cBf
-cBf
+dqd
+uqB
 cBf
 cBf
 nrq
-plW
+bho
+ckK
+ckK
+pyI
+ckK
+dKv
+fRa
+ckK
+iwB
+doc
+aiJ
+cBf
+kiP
+rjn
+azA
 azA
 azA
 ner
 tfP
-xeI
-smK
-smK
+vBv
+dzm
+xOE
 sJc
 sLI
 azA
@@ -108759,20 +111286,14 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
-azA
-plW
-azA
-dzm
-azA
-oAf
-jKr
-azA
-azA
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
 azA
 azA
@@ -108784,27 +111305,33 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-jKr
-jKr
-snR
-dOy
-sXx
-qMb
+utR
+uqB
 cBf
-nrq
-plW
+uqB
+amS
+ahs
+hyb
+hyb
+hyb
+aeX
+ssm
+hyb
+hyb
+lmd
+doc
+dOy
+okX
+cBf
+qDa
+azA
 azA
 azA
 ner
 tfP
-smK
-smK
-smK
+gTs
+rRZ
+dVN
 sJc
 sLI
 azA
@@ -109060,53 +111587,53 @@ rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
 azA
 azA
 azA
-azA
-azA
-plW
-azA
-azA
-azA
-azA
-msE
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-msE
-azA
-ttF
-azA
-azA
-aUc
-azA
-azA
-qEZ
-qEZ
+rjn
+pAJ
+pAJ
+pAJ
+pAJ
+pAJ
+pAJ
+pAJ
+lkP
+cBf
+cBf
+uqB
+nrq
+ahs
+vXl
+gLd
+fQC
+jjU
+cQV
+kgs
 hyb
-gAg
-wTQ
-wTQ
-jOC
-wTQ
-ctN
-uoy
+lmd
+doc
+uAt
+dOy
+cBf
+pII
+azA
 azA
 azA
 ner
 tfP
-smK
-smK
-smK
+kds
+kds
+kds
 sJc
 sLI
 azA
@@ -109363,45 +111890,45 @@ rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
 azA
 azA
 azA
 azA
-plW
-azA
-azA
-azA
-azA
-uFK
-lrB
-lrB
-lrB
-hqt
-ubM
-lqC
-lrB
-gCd
-gCd
-lrB
-lrB
+sxh
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
+uqB
+bLo
+ahs
+tlA
 qEZ
-qEZ
-qEZ
-qEZ
-qEZ
-qEZ
-azA
-azA
-dGA
+smn
+jjU
+jjU
+ioi
 vXl
-yku
-mEE
+lmd
+doc
+kwy
+orl
+dEx
+lxa
 azA
-azA
-gwF
-azA
-plW
 azA
 azA
 fQA
@@ -109665,45 +112192,45 @@ rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
-azA
-azA
-azA
-azA
-plW
-azA
-azA
-azA
-azA
-uFK
+ndZ
+rDi
+rDi
+rDi
+uhS
 gLz
-lrB
-lrB
-lqC
-lrB
-lrB
-lrB
-lqC
-lqC
-lrB
-lqC
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-vSR
-qEZ
-dGA
+cBf
+cLA
+wTQ
+wTQ
+wTQ
+xXq
+wzm
+iCV
+fGw
+wTQ
+wTQ
+oHU
+ahs
+hyb
+peG
+elj
+ioi
+tlA
+tlA
 ktw
-uge
+lmd
+doc
+cBf
+asG
+cBf
+pII
 azA
-azA
-azA
-gwF
-azA
-hQA
 azA
 azA
 ner
@@ -109966,50 +112493,50 @@ rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
 azA
-azA
-azA
-azA
-azA
-plW
-azA
-azA
-azA
-azA
-uFK
-gpv
-lqC
-rEi
+snR
+hjd
+mzY
+cBf
+nrq
+gLz
+cBf
+nrq
 ccm
-tcW
-lqC
-pXX
+mbx
+mbx
+mbx
 bug
-lrB
-pzp
-lrB
-dGA
-dGA
-qZA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
+bug
+mbx
+mbx
+xfg
+aah
+ahs
+hyb
+icG
+cQV
+jjU
+yku
+gLd
+ktw
+lmd
+qOh
+hib
+cBf
+cBf
 jtA
-jtA
-jtA
-ijU
-jtA
-moC
-moC
-moC
-moC
-smK
+uhS
+azA
+azA
+ner
+tfP
 hiH
 cKE
 smK
@@ -110269,49 +112796,49 @@ rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
 azA
 azA
 azA
+snR
+cBf
+sPT
+vII
+nrq
+uPp
+cBf
+nrq
+mbx
+eNN
+nGT
+eNN
+qCP
+yeC
+toy
+odh
+ipF
+mbx
+ahs
+hyb
+mUx
+hyb
+syt
+hyb
+hyb
+ggS
+lmd
+qOh
+dEx
+kFh
+cBf
+rjn
+nrq
 azA
 azA
-plW
-azA
-azA
-azA
-azA
-uFK
-vkw
-lrB
-lrB
-mhM
-lrB
-lrB
-jad
-lrB
-lrB
-lrB
-lrB
-dGA
-dGA
-qZA
-dGA
-qZA
-qZA
-qZA
-qZA
-dGA
-qZA
-qZA
-dGA
-qZA
-ioi
-izU
-izU
-dGA
-dGA
-dGA
-dGA
-cKE
+ner
+tfP
 lxu
 kds
 smK
@@ -110571,49 +113098,49 @@ rRz
 rRz
 rRz
 rRz
+rRz
+rRz
 azA
 azA
 azA
 azA
-azA
-plW
-azA
-azA
-azA
-azA
-msE
+snR
+wfq
+cBf
+okX
+nrq
 loD
-jad
-lrB
-tix
-lrB
-uOo
-ttO
+cBf
+nrq
+mbx
+eNN
+eNN
+eNN
 jip
-aCZ
-lqC
-lqC
+eNN
+eNN
+smx
 fVV
-izU
-qZA
-dGA
-izU
-dGA
-dGA
-dGA
-qZA
-qZA
-qZA
-dGA
-qZA
+mbx
 ioi
-izU
-izU
-dGA
-izU
-dGA
-dGA
-smK
+hyb
+rCz
+vfE
+jjU
+tlA
+cQV
+jNL
+lmd
+qOh
+cBf
+cBf
+nDt
+dDx
+ctN
+azA
+azA
+ner
+tfP
 cKE
 hiH
 smK
@@ -110871,51 +113398,51 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-plW
-azA
-azA
+rRz
+rRz
+rRz
 dzm
+pyl
 azA
-uFK
+azA
+azA
+gAg
+wTQ
+wTQ
+kyp
+ctN
 uPp
-lrB
-lrB
-lrB
-lrB
-ido
-msE
-lrq
-lrB
+cBf
+nrq
+ccm
+vLP
+lBZ
 eNN
-msE
+lrq
+ubP
+eNN
+xbm
 bJL
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-izU
-dGA
+mbx
+ioi
+ktw
+tlA
+jjU
+nLu
+oWG
+fbm
+aLr
+lmd
+gAg
+wta
+wta
+aWg
 hnr
-hnr
-hnr
-hnr
-hnr
-vWj
-hnr
-ieL
-ieL
-ieL
-ieL
-smK
+azA
+azA
+azA
+ner
+tfP
 mfA
 smK
 iIY
@@ -111165,55 +113692,55 @@ rRz
 rRz
 rRz
 eyn
+igR
 eyn
-eyn
-eyn
+igR
 eyn
 rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
+dzm
+bKN
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-plW
-azA
-azA
-azA
-azA
-uFK
+rjn
+pAJ
+pAJ
+pAJ
+pAJ
 lkP
-lrB
-aCZ
-lqC
-aCZ
-lrB
+cBf
+nrq
+xjY
+hXl
+ipF
 uyc
-lrB
-lrB
-lrB
-dRK
+bjT
+ipF
+gQq
+eNN
 yeC
-dGA
-izU
-qZA
-dGA
-dGA
-dGA
-sgn
-nqZ
+mbx
+ioi
+vXl
+gLd
+tSB
+smn
+tlA
+jFR
+ktw
+gxY
+eSw
+eSw
+kfS
+pGp
+hgU
 azA
-azA
-azA
-azA
-azA
-gwF
-azA
-hQA
 azA
 azA
 ner
@@ -111461,61 +113988,61 @@ uVn
 uVn
 uVn
 uVn
+tjM
+eyn
+eyn
+igR
+irJ
+isg
+isg
+isg
+vOf
+eyn
+eyn
+igR
+jKr
+jKr
 rRz
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
 rRz
 rRz
-azA
-azA
-gwF
-gwF
-gwF
-azA
-plW
+rRz
+dzm
 azA
 azA
 azA
-azA
-uFK
-kvH
-lqC
-lrB
-xwj
-lrB
-lqC
-sBb
-lqC
+sxh
+cBf
+cBf
+cBf
+cBf
+cBf
+dEx
+nrq
+mbx
+hbp
+lpo
+eNN
+eNN
 gmu
-lrB
-lqC
-dGA
-dGA
-dGA
-dGA
-dGA
-uFK
-uFK
-pzv
-pzv
-uFK
-uFK
-uFK
-uFK
-uFK
+pbv
+pfo
+bhV
+ccm
+vhF
+tcS
+hyb
+hyb
+hyb
+hyb
+gLd
+ige
+izU
+alK
+vhF
+vEv
 sOd
-uhS
-plW
+nZH
+azA
 azA
 dxn
 ner
@@ -111764,60 +114291,60 @@ cVY
 cVY
 qZw
 ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-uVn
-ohj
-ohj
-ohj
-dIK
-gwF
-azA
-plW
+oeG
+oeG
+sui
+ewN
+hjV
+oeG
+pqG
+sui
+gJG
+lLs
+kMn
+mnP
+xLO
+dzm
+dBI
+rRz
+rRz
+dzm
 azA
 azA
 azA
-azA
-msE
+gLz
+cBf
+adY
+vdT
+cOh
 pnc
-lrB
+wTQ
 aWg
-oEP
 mbx
-lrB
+mbx
+mbx
+eNN
+dAu
 nBR
-lqC
-nBR
-lrB
-lrB
-dGA
-kjM
-hwA
-hwA
-dGA
-uFK
-lzK
-lzK
-lzK
-uFK
+mbx
+eNN
+eNN
+mbx
+hoH
+uge
+eAw
+hoH
+eAw
+hoH
+eAw
+nEj
+dGT
+hFP
 dOQ
-dOQ
-dOQ
-dOQ
-uFK
-nrq
-uoy
+xRZ
+qkH
+fvS
+azA
 azA
 azA
 ner
@@ -112066,60 +114593,60 @@ azA
 azA
 rwf
 ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-ylI
-cVY
-cVY
-cVY
-qZw
-bsJ
-gwF
+oeG
+oeG
+sui
+gPW
+lgp
+igO
+dRz
+aOi
+gJG
+tgo
+jid
+eUj
+gGf
 azA
-plW
+azA
+voM
+dzm
 azA
 azA
 azA
 azA
-uFK
-kvH
-lrB
-lrB
+gLz
+cBf
+roe
+cwf
 tix
-lrB
-crL
-lqC
-lqC
-miQ
-aCZ
-lrB
-dGA
-hwA
-dGA
-dGA
-qHj
-uFK
-lzK
-lzK
-lzK
-uFK
-bJX
+tix
+tix
+tix
+tix
+mjp
+mjp
+kvH
+mjp
+lxu
+mjp
+mjp
+mjp
+fHT
+lxu
+kds
+lxu
+smK
+eUj
+kvH
+kvH
+ahs
+izU
 xde
-bJX
-bJX
-uFK
-nrq
-plW
+ioi
+izU
+qkH
+oUs
+azA
 azA
 azA
 ner
@@ -112365,63 +114892,63 @@ azA
 azA
 azA
 azA
+tjM
 rRz
 rRz
-rRz
+igR
 eyn
 eyn
 eyn
+ewN
+sfZ
+aOi
+igR
 eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-rRz
-uqm
-azA
-azA
-rwf
-bsJ
-gwF
-azA
-plW
+igR
+igR
+pMi
+dKu
 azA
 azA
 azA
 azA
-uFK
-mJj
-lrB
-xFk
-lrB
-lrB
-lrB
-env
-lqC
-lqC
-gjy
-lrB
-dGA
-dGA
-aLr
-dGA
-vfE
-tEA
-lzK
-lzK
-btr
-uFK
-bJX
-bJX
-bJX
-vOq
-uFK
+azA
+azA
+azA
+azA
+gLz
+cBf
 nrq
-plW
+eNA
+env
+mJj
+mJj
+xFk
+fcP
+fcP
+env
+env
+mjp
+smK
+mjp
+lxu
+mjp
+mjp
+mjp
+eUj
+smK
+eUj
+kgs
+eUj
+smK
+ahs
+eLf
+xHn
+bJX
+bJX
+uTu
+jbr
+azA
 azA
 azA
 ner
@@ -112681,49 +115208,49 @@ eyn
 eyn
 rRz
 rRz
-rRz
+qWq
 azA
 azA
 azA
-azA
-rwf
-bsJ
-gwF
-azA
-plW
-azA
-azA
-azA
-azA
-uFK
-lkP
-lrB
-lrB
-uOo
-lrB
+rjn
+lNW
+lNW
+lNW
+lNW
+lNW
+dRK
+cBf
+nrq
+eNA
+rMr
+hgt
+xmm
+xmm
+wfv
+uhS
 cNX
 teh
-pSX
-lqC
-edr
-msE
-mnP
-dGA
-dGA
-dGA
+wsd
+ckK
+urm
+pmu
+ckK
+urm
+ckK
+eSw
 qHj
-uFK
+smK
 mWO
-rdo
-lzK
-uFK
-uFK
-uMl
-uFK
-uFK
-uFK
-nrq
-plW
+ujW
+smK
+ahs
+pzp
+ngu
+egD
+mGx
+bJX
+lmd
+azA
 azA
 azA
 ner
@@ -112982,50 +115509,50 @@ eyn
 rRz
 rRz
 rRz
-rRz
+tjM
+pMi
+xLO
 azA
 azA
-azA
-azA
-azA
-rwf
-bsJ
-azA
-azA
-plW
-azA
-azA
-azA
-azA
-uFK
-loD
-lrB
-lrB
-kGt
-lSr
-lqC
-lqC
-lqC
-lqC
-lrB
-lrB
-dGA
-hwA
-qZA
-dGA
-dGA
-usy
-lzK
-fjK
-lzK
-tEA
-lzK
-sui
-lzK
-lzK
-uFK
+pzp
+dCa
+dCa
+ori
+pzp
+gwF
+doc
+cBf
 nrq
-plW
+eNA
+rMr
+qOh
+bgO
+cBf
+cBf
+nrq
+jUV
+dpM
+lqC
+sqC
+rIs
+rIs
+efZ
+dsF
+dsF
+oWB
+lmd
+smK
+smK
+fjK
+smK
+lOb
+wsb
+pMc
+uLu
+mGx
+bJX
+lmd
+azA
 azA
 azA
 ner
@@ -113283,51 +115810,51 @@ rRz
 rRz
 rRz
 rRz
-rRz
+tjM
+jKr
+pMi
+gGf
 azA
 azA
-azA
-azA
-azA
-azA
-rwf
-bsJ
-azA
-azA
-plW
-azA
-azA
-dzm
-azA
-uFK
-kvH
-lrB
-lqC
-lrB
-lrB
-ygI
-cfw
-lqC
-lqC
-lqC
-lrB
-dGA
-dGA
-dGA
-dGA
-dGA
-vpf
-lzK
-lzK
-lzK
-uFK
-lzK
-lzK
-lzK
-btr
-uFK
+dCa
+reL
+reL
+reL
+uTu
+wfv
+hUC
+cBf
 nrq
-plW
+eNA
+aAL
+jgP
+jgP
+jgP
+jgP
+jgP
+jgP
+cfw
+fpI
+dsF
+pot
+pot
+rge
+pvW
+lNJ
+jea
+lmd
+snK
+smK
+smK
+smK
+lOb
+pzp
+kSl
+uLu
+reL
+xHn
+lmd
+azA
 azA
 azA
 ner
@@ -113573,10 +116100,6 @@ azA
 rRz
 rRz
 rRz
-taO
-taO
-taO
-taO
 rRz
 rRz
 rRz
@@ -113586,53 +116109,57 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
-azA
-azA
-rwf
-bsJ
-azA
-azA
-plW
-azA
+rRz
+rRz
+rRz
+jKr
+dzm
+lIM
+gGf
+ndZ
+wfv
+dCa
+xsl
+reL
+lpg
+foT
 gXM
-azA
-azA
-uFK
-gpv
-lrB
+gXM
+gXM
+fUK
+gfG
+aAL
+jgP
 rEi
-ccm
-tcW
-lqC
-lqC
-lqC
+rEi
+rEi
+gLh
+jgP
+kIN
+kna
 miQ
-lrB
-lqC
-dGA
-dGA
-dGA
-hwA
-dGA
-uFK
-uFK
-uFK
-uFK
+fnV
+mym
+mym
+mym
+tdd
+jea
+arq
+snK
+smK
+mJM
+ntm
 vdg
-ojC
-lzK
-hdw
-lzK
-uFK
-nrq
-plW
+pzp
+xHn
+xHn
+xHn
+gCd
+lSr
 azA
 azA
-ner
+azA
+vwc
 tfP
 smK
 smK
@@ -113875,68 +116402,68 @@ rRz
 rRz
 rRz
 rRz
-taO
-hLN
-taO
-taO
-taO
 rRz
 rRz
 rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+jKr
+dzm
 azA
 azA
-azA
-azA
-ndZ
-rDi
-rDi
-uhS
-rwf
-bsJ
-azA
-azA
-plW
-azA
-azA
-azA
-azA
-uFK
-kvH
+ydn
+snR
+cBf
+ori
+xsl
+xsl
+pMc
+tRw
+wTQ
+jbl
+cBf
+nrq
+eNA
+msE
+jgP
+yeu
+rEi
+rEi
+rEi
+fYz
+fpI
 lrB
-lrB
-lrB
-lrB
-lrB
-lrB
-lrB
-lrB
-lrB
-lrB
-dGA
-rOR
-dGA
-dGA
-dGA
-uFK
-nZH
-gES
-bJX
-uFK
-sUF
-lzK
+dsF
+fIo
+fIo
+btr
+btr
+xSr
+dsF
+rhZ
+snK
+mJM
+xys
+dzm
+uMl
+qIA
+crL
 lzK
 dqX
-uFK
-nrq
-plW
-azA
-azA
-ner
-tfP
-smK
+sTu
+szO
+szO
+gPI
+fNN
+vkw
+cKE
+cKE
 smK
 smK
 sJc
@@ -114164,82 +116691,82 @@ azA
 azA
 azA
 azA
-azA
-azA
 rRz
 azA
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-taO
-taO
-taO
-taO
-taO
-taO
-taO
-taO
-oMP
 azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rDi
+rDi
+uhS
 azA
-azA
-azA
-azA
-azA
+paD
+gGf
 snR
+uqB
+pzp
+bav
+xsl
+ixa
+pzp
+kJn
+doc
 cBf
-ovy
 nrq
-rwf
-bsJ
-azA
-azA
-plW
-azA
-azA
-azA
-azA
-uFK
-wEL
-lrB
-lrB
-lrB
+eNA
+msE
+jgP
+rEi
+rEi
+rEi
 gLh
-lrB
+jgP
 kRU
 scn
-cBt
+dsF
 uQS
-lrB
-dGA
-qVQ
+btr
+fIo
+fIo
 mym
-qZA
-dGA
-uFK
-lXR
-hlh
-nGT
+dsF
+arq
+snK
+oDH
+dzm
+jKr
 uMl
-lzK
-rdo
-lzK
+tbl
+tbl
+uHW
 mHS
-uFK
-nrq
-plW
-azA
-azA
-ner
-tfP
-smK
-smK
+moK
+cKE
+abJ
+hpA
+szO
+cKE
+mfA
+lxu
+cKE
 smK
 sJc
 mZc
@@ -114465,9 +116992,6 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
 rRz
 rRz
 rRz
@@ -114479,70 +117003,73 @@ rRz
 rRz
 rRz
 rRz
-taO
-taO
-taO
-hLN
-taO
-taO
-taO
 rRz
-oMP
-azA
-azA
-azA
-azA
-azA
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 snR
-wBK
-wfq
-dvB
-rwf
-bsJ
-azA
-azA
-plW
-azA
-azA
-ttF
-azA
-msE
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-kXE
-dGA
-hwA
-hwA
-dGA
-dGA
-uFK
-qCP
-lcg
-bJX
-uFK
-lzK
-lzK
-fjK
-btr
-uFK
+cBf
+ovy
 nrq
-plW
+azA
+pMi
+gGf
+snR
+uqB
+pzp
+iDr
+lpg
+qlm
+pzp
+bGM
+doc
+cBf
+nrq
+eNA
+msE
+jgP
+jgP
+jgP
+jgP
+jgP
+jgP
+fpI
+cjQ
+dsF
+kXE
+kXE
+btr
+fIo
+mym
+nIn
+arq
+snK
+gTs
+lcg
+xkI
+wUf
+etA
+qgv
+tbl
+hhJ
+moK
+ojC
 azA
 azA
-ner
-tfP
-smK
-smK
-smK
+gpv
+cKE
+cKE
+mfA
+lxu
+cKE
 sJc
 vFX
 tlA
@@ -114766,9 +117293,6 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
 rRz
 rRz
 rRz
@@ -114781,69 +117305,72 @@ rRz
 rRz
 rRz
 rRz
-dTf
-taO
-taO
 rRz
 rRz
 rRz
 rRz
 rRz
-cyW
-azA
-azA
-azA
-azA
-azA
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 snR
-fpB
-oAx
+wBK
+wfq
+dvB
+azA
+lIM
+gGf
+snR
+uqB
+pzp
+tTP
+xsl
+reL
+pzp
+kJn
+doc
+cBf
 nrq
-rwf
-bsJ
-azA
-azA
-hQA
-azA
-wlS
-qEZ
-qEZ
-wBl
+eNA
+msE
+fpF
+xDn
+jbl
 ioi
 ioi
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-qZA
-izU
-dGA
-qZA
-uFK
-nZH
-iQc
+ioi
+xRZ
+dsF
+dsF
+dsF
+dsF
+sqC
+fIo
+hdw
+nIn
+rhZ
+snK
+smK
+gTs
 vOq
-uFK
-lzK
-lzK
-lzK
-lzK
-uFK
-nrq
-plW
+pSX
+pzp
+vjD
+erM
+ygI
+pzp
+ijU
 azA
 azA
-ner
+azA
+hRW
 tfP
 smK
-smK
+cKE
 smK
 sJc
 vFX
@@ -115069,6 +117596,7 @@ azA
 azA
 azA
 azA
+tjM
 rRz
 rRz
 rRz
@@ -115079,6 +117607,7 @@ rRz
 rRz
 rRz
 rRz
+tjM
 rRz
 rRz
 rRz
@@ -115089,57 +117618,55 @@ rRz
 rRz
 rRz
 rRz
-rRz
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+jKr
 snR
-cBf
-cBf
-hVm
-rwf
-sqF
-ohj
-muA
-qEZ
-qEZ
-wBl
-ioi
-ioi
-xcL
-ktI
-dGA
-qZA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-qZA
-qZA
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-tEA
-uFK
-uFK
-uFK
+fpB
+oAx
 nrq
-plW
+azA
+azA
+vcY
+snR
+dIK
+pzp
+oEP
+gaw
+pzp
+eLf
+xQq
+doc
+cBf
+nrq
+eNA
+msE
+amS
+vKh
+doc
+kGt
+uVn
+sqC
+dsF
+uTq
+xes
+ido
+xrd
+dsF
+btr
+hdw
+dsF
+rhZ
+snK
+smK
+eUj
+eUj
+lOb
+qcx
+tEA
+usq
+edr
+jTm
+arq
+azA
 azA
 azA
 ner
@@ -115375,80 +117902,80 @@ rRz
 rRz
 rRz
 rRz
+eyn
+eyn
+taO
+eyn
+eyn
+taO
+taO
+taO
+eyn
+eyn
+eyn
 rRz
 rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+tjM
+dzm
 azA
+snR
+cBf
+cBf
+hVm
 azA
+jad
 azA
-azA
-azA
-azA
-azA
-azA
-mBz
+gAg
 wTQ
-wTQ
-ctN
+fpj
 wDK
-uVn
-uVn
-uVn
-hwA
-ioi
-qZA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-izU
-dGA
-dGA
-qZA
-dGA
-usy
-ipg
-lzK
-lzK
-ipg
-lzK
-lzK
-ipg
-lzK
-uFK
-nrq
-plW
+tEA
+usq
+aHV
+lmd
+doc
+cBf
+dxL
+eNA
+msE
+amS
+eWF
+gAg
+wTQ
+wTQ
+dsF
+doz
+qgb
+xOf
+hGe
+uQx
+dsF
+fIo
+mym
+wPb
+lmd
+snK
+mjp
+jqt
+eUj
+lOb
+uTu
+xHn
+bJX
+bJX
+pzp
+arq
+azA
 azA
 azA
 ner
 tfP
-xeI
-smK
-smK
+muz
+ntm
+wsh
 sJc
 eIF
 tQI
@@ -115673,84 +118200,84 @@ azA
 azA
 azA
 azA
+tjM
 rRz
 rRz
 rRz
+taO
+taO
+mhi
+taO
+nfG
+taO
+nqB
+taO
+nfG
+eyn
+eyn
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+qML
+dzm
+dzm
 azA
 azA
+mBz
+wTQ
+wTQ
+ctN
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-lfK
+pMi
+xLO
+jKr
+atY
+pzp
 jem
 jem
-jem
-jem
-jem
-jem
-ioi
-ioi
-dGA
-dGA
-aOi
-gPW
+aHQ
+pzp
+hKZ
+doc
+cBf
+nrq
+eNA
+lxu
+nrq
+ndZ
+uhS
 rQJ
 lPQ
-lPQ
-lPQ
+dsF
+mZV
 kbF
-lPQ
+hGe
 xOf
-dGA
-dGA
-dGA
-dGA
-dGA
-dGA
-vpf
-lzK
+dQR
+ttO
+fIo
+mym
+wPb
+lmd
+snK
+cKE
 wVK
-tzc
-lzK
-fMA
-rdo
-lzK
-fMA
-uFK
-nrq
-plW
+eUj
+lOb
+pzp
+aiw
+rOR
+mGx
+bJX
+arq
+azA
 azA
 azA
 ner
 tfP
-smK
-smK
-smK
+oDH
+dzm
+xOE
 sJc
 mUx
 wjo
@@ -115979,19 +118506,21 @@ rRz
 rRz
 rRz
 rRz
+tgJ
+eyn
+taO
+taO
+taO
+taO
+riO
+mhi
+taO
+taO
+taO
+eyn
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+jKr
+dzm
 azA
 azA
 azA
@@ -116001,58 +118530,56 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-hQA
-azA
-iPK
-thW
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-tEA
-tEA
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-uFK
-msE
-nOY
-uFK
-xbm
-naK
-lzK
-lOb
-mEa
-lzK
 pMi
-naK
-uFK
+dKu
+azA
+dzm
+djw
+fic
+fic
+fic
+lAT
+hQA
+dPr
+cBf
 nrq
-plW
+eNA
+cYh
+nrq
+pAd
+kiP
+uhS
+pYo
+dsF
+kjM
+xOf
+hGe
+xOf
+mBV
+gKo
+fIo
+oYR
+dsF
+lvW
+snK
+eUj
+eUj
+smK
+lOb
+wVT
+uLu
+aiw
+reL
+bJX
+arq
+azA
 azA
 azA
 ner
 tfP
-smK
-smK
-smK
+gTs
+dcx
+xOE
 sJc
 vFX
 vFX
@@ -116281,80 +118808,80 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+eyn
+eyn
+igR
+riO
+cCL
+taO
+taO
+taO
+qqM
+taO
+taO
+eyn
+vzY
+dzm
+azA
+azA
+azA
+oCZ
+azA
+bKN
 azA
 azA
 azA
 azA
+qWq
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-dej
-azA
-azA
-thW
-uFK
+vWj
+mnP
+dzN
+dzN
+dzN
+dzN
+dzN
+mjp
+mjp
+mjp
+mjp
+mjp
 cYh
-ipg
-lzK
-eNA
-uFK
-lzK
-lzK
-lzK
-lzK
-uFK
-hGe
-lzK
-nSN
-dzh
-lzK
-uFK
-qpv
-fJi
-lzK
-lzK
-rdo
-lzK
-nUm
-kpA
-lzK
-btr
-uFK
 nrq
-plW
+doc
+dEx
+kiP
+nZj
+dsF
+oNQ
+hGe
+xOf
+hGe
+bmK
+nSN
+hdw
+hdw
+njY
+lmd
+snK
+eUj
+eUj
+smK
+ahs
+phk
+uLu
+uLu
+reL
+bJX
+arq
+azA
 azA
 azA
 ner
 tfP
 smK
-smK
-smK
+gTs
+dVN
 sJc
 vFX
 vZb
@@ -116583,73 +119110,73 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+eyn
+taO
+taO
+taO
+igR
+taO
+eyn
+sBb
+taO
+riO
+mhi
+noM
+dzm
 azA
 azA
 azA
 azA
 azA
 azA
+gPI
 azA
 azA
+jWe
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-dej
-azA
-tTP
-dGA
-usy
-sUF
-sMv
-mDN
-lzK
+kNs
+uoy
+prC
+prC
+hAY
+ref
+ref
+ref
 qXs
-lzK
-dzh
-dzh
-lzK
-tEA
-lzK
-iKg
+mjp
+mjp
+mjp
+lxu
+mjp
+mjp
+nrq
+mDN
+wTQ
+wTQ
+ctN
+dsF
+xHI
+naK
+jsS
+wEL
+hGe
 qXn
 fIo
 hdw
-usy
-gLd
-uFK
-lzK
-nGy
-lzK
-ftf
-woZ
-fjK
+njY
+lmd
+vYk
+eUj
+eUj
+lxu
+ahs
+pzp
+uLu
 tzc
-fMA
-uFK
-nrq
-plW
+hgR
+pzp
+arq
+azA
 azA
 azA
 ner
@@ -116883,75 +119410,75 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+igR
+taO
+taO
+taO
+osi
+taO
+taO
+mhi
+taO
+eyn
+eyn
+sBb
+sCR
+oAt
+iQc
+waE
+rDi
+rDi
+qan
+kKA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+ndZ
+rDi
+rDi
+rDi
+rDi
+rDi
+pzp
+tbl
+uHW
+tbl
+pzp
 dej
+wTQ
+wTQ
+wTQ
+wTQ
+gpz
+ctN
 azA
-lkn
-jem
-usy
-xmm
-lzK
-lzK
-lzK
-tEA
-lzK
-odO
-rdo
-lzK
-uFK
-odO
-dzh
-qcl
-arA
-lzK
-vpf
-dzm
-uFK
-mHS
-mEa
-lzK
-vEv
+rAc
+cXl
+eFE
+sqC
+dtm
+sqC
+sqC
+sqC
+sqC
+sqC
 dsF
-lzK
-pMi
-rMM
-uFK
-nrq
-plW
+miQ
+vpf
+lmd
+eit
+jqt
+kds
+smK
+ahs
+pzp
+vdY
+pzp
+pzp
+eLf
+arq
+azA
 azA
 azA
 ner
@@ -117184,76 +119711,76 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+tjM
+taO
+taO
+eyn
+taO
+taO
+taO
+qqM
+taO
+igR
+eyn
+eyn
+igR
+taO
+riO
+hiP
+cla
+wtO
+cBf
+ipg
+uhS
 azA
+aUc
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-dej
-azA
-azA
-azA
-usy
-hON
-fjK
-odO
-lzK
-uFK
+ndZ
+hUC
+cBf
+cBf
+cBf
+cBf
+cBf
+gCd
+dCa
+dCa
+ori
+pzp
+rOi
+uqm
 sqC
-lzK
-lzK
-lzK
-vdg
-lzK
+sqC
+eKQ
+hON
+sqC
+sqC
+sqC
+sqC
+sqC
+sqC
+bsi
+eme
+fvg
+iUZ
 rdo
-xHn
-dzh
-uLu
-uFK
+sqC
+mym
+xAu
+dsF
+lmd
+eit
+jqt
+lxu
+smK
+ahs
+pzp
+pMc
+reL
+xQV
+eLf
+arq
 azA
-uFK
-uFK
-pzv
-pzv
-fRv
-fRv
-sKF
-pzv
-uFK
-uFK
-nrq
-plW
 azA
 azA
 ner
@@ -117487,75 +120014,75 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-azA
-glB
-fpD
-fpD
-fpD
-glB
-fpD
-fpD
-fpD
-fpD
-glB
-fpD
-fpD
-fpD
-fpD
-glB
-fpD
-fpD
-fpD
-fpD
-glB
-glB
-glB
-glB
-glB
-ban
-iPK
-azA
-azA
-vpf
-sUF
-lzK
-dzh
-tzc
-uFK
+igR
+taO
+taO
+taO
+eyn
+bQf
+taO
+taO
+taO
+eyn
+eyn
+eyn
+taO
+taO
 riO
-lzK
+hiP
+rVU
+hjo
+cBf
+fpD
+uhS
+atY
+ndZ
+hUC
+cBf
+pLm
+nDt
+jbl
+cBf
+cBf
+dCa
+fCe
+xsl
+dZk
+pzp
+ban
+fpI
+euA
+glB
+glB
+glB
+glB
+glB
+glB
+glB
+glB
+mve
 dzh
-lzK
-uFK
+vwa
+iQC
 uIC
 odO
-dzh
-qth
+sqC
+xAu
 btr
-uFK
-nlZ
-hmu
-kHa
-uTu
-cBf
-cBf
-cBf
-cBf
-cBf
-cBf
+oWB
+hKZ
+eit
+eUj
+jqt
+eUj
+ahs
+pzp
+eOi
+rOR
+arA
 eLf
-nrq
-plW
+arq
+azA
 azA
 azA
 ner
@@ -117789,75 +120316,75 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-azA
-dXN
+eyn
+eyn
+igR
+opK
+taO
+kBe
+taO
+taO
+qqM
+taO
+igR
+eyn
+sBa
 sCR
-sCR
-sCR
-sCR
-sCR
-sCR
-sCR
-sCR
-sCR
-sCR
-uHW
-uHW
-uHW
-uHW
-uHW
-uHW
-tUI
-syt
+taO
+cIa
+dgx
+ucl
+kKF
+cBf
+kiP
+rDi
+hUC
+pLm
+cBf
+nDt
+ctN
+doc
+cBf
+cBf
 dCa
-vzY
-omH
-syn
+aRO
+umQ
+reL
 gaw
-ban
-iPK
-azA
-azA
-uFK
+qZA
+xRZ
+eKQ
+glB
+jTV
 vMK
 ptI
-lzK
+ptI
 ptI
 eLT
-prC
-gyJ
+glB
+sqC
 eCx
-peG
-uFK
+vwa
+tIu
 oYW
-nUm
-dzh
-dzh
-sBa
-uFK
+muA
+sqC
+sKF
+btr
+spL
+eUj
+eUj
+jqt
+eUj
+lxu
+ahs
+pzp
+rpg
+aiw
+mKW
+pzp
+arq
 azA
-erB
-azA
-oov
-eme
-cBf
-cBf
-cBf
-cBf
-cBf
-gJG
-nrq
-plW
 azA
 azA
 ner
@@ -118091,75 +120618,75 @@ rRz
 rRz
 rRz
 rRz
+eyn
+eyn
+eyn
+igR
+taO
+taO
+taO
+taO
+taO
+taO
+gxQ
+eyn
+igR
+taO
+taO
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-dXN
-sCR
-glB
-glB
-glB
-glB
-glB
-glB
-glB
-glB
-sCR
-lxa
-lxa
-lxa
-lxa
-lxa
-lxa
-jTm
-uHW
-glB
-hBb
+mEG
+tkX
+jbl
+cBf
+ghc
+cBf
+cBf
+nDt
+ctN
+azA
+doc
+cBf
+cBf
+ori
+xsl
 xsl
 oXt
-foT
+pzp
+qZA
+qZA
+sqC
 glB
-xes
-xVQ
-qxs
+naK
+naK
+naK
+ryn
+ryn
+ryn
+glB
+sqC
 uFK
-uFK
-adY
-veV
-veV
-eLT
-uFK
-tEA
-uFK
-uFK
-uFK
-uFK
-uFK
-tEA
-uFK
-uFK
-uFK
+rYX
+mVK
+aMD
+odO
+sqC
+qpv
+naK
+btr
+eUj
+eUj
+lxu
+eUj
+smK
+ahs
+pUH
+uLu
+aiw
+fMA
+pzp
+hKZ
 azA
-azA
-azA
-lWp
-eme
-cBf
-cBf
-cBf
-cBf
-cBf
-lWp
-ctN
-plW
 azA
 azA
 ner
@@ -118397,71 +120924,71 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-sCR
-glB
+igR
+nGy
+taO
+igR
+dBA
+taO
+mhi
+igR
+eyn
+igR
 qqM
-fHT
-vOf
-fic
+taO
+rRz
+rRz
 vzY
-mhi
-glB
-sCR
-lxa
-gCS
-dgx
-mhi
-dKv
-lxa
-jTm
-uHW
-glB
+rvP
+wTQ
+wTQ
+wTQ
+wTQ
+ctN
+azA
+azA
+doc
+cBf
+rjn
+pzp
 ori
-wta
-cQV
+ori
+pzp
 tRw
 tNB
-iPK
-euA
-cyJ
-uFK
-xLO
-sui
-dzh
-dzh
-dzh
-mVK
-dzh
+qZA
+sqC
+glB
+uoW
+uoW
+uoW
+uoW
+ryn
+naK
+glB
+sqC
 oJL
 vwa
-uFK
-lzK
+lWM
+dcW
 aJp
-lzK
-aJp
-lzK
-uFK
+iKg
+qpv
+naK
+btr
+smK
+eUj
+eUj
+lxu
+eUj
+ahs
+pzp
+pMc
+reL
+aiw
+pzp
 azA
 azA
-azA
-dqd
-uqB
-cBf
-cBf
-cBf
-cBf
-uqB
-oep
-azA
-plW
 azA
 azA
 ner
@@ -118700,70 +121227,70 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-sCR
-glB
-qLY
-omH
 tjM
-oWB
-qML
-baQ
-glB
-sCR
-lxa
-rFY
-tdd
-xsl
-fpj
-lxa
-jTm
-uHW
-glB
-rFY
-mAi
-oXt
-vhF
-tNB
-iPK
-euA
-nqa
-uFK
-jyS
-rge
-sMv
-fIo
-fIo
-dzh
-sMv
-rXm
-qtI
-fJi
-lzK
-dzh
-dzh
-lzK
-lzK
-usy
+taO
+kBe
+eyn
+taO
+taO
+hLN
+eyn
+eyn
+taO
+taO
+tjM
+rRz
+rRz
+jwu
+lxf
 azA
 azA
 aUc
-dqd
-uqB
-uqB
-uqB
-uqB
-uqB
-uqB
-xRQ
 azA
-plW
+azA
+azA
+gAg
+wTQ
+hqt
+mcP
+qZA
+mAi
+mAi
+vhF
+fpI
+cjQ
+sqC
+glB
+uoW
+uoW
+uoW
+mLa
+ryn
+naK
+glB
+sqC
+rXm
+xRQ
+fJi
+sKQ
+myo
+oMP
+qpv
+naK
+oWB
+iwB
+eit
+kkW
+kkW
+kkW
+ahs
+tRw
+uLu
+reL
+reL
+pzp
+azA
+azA
 azA
 azA
 ner
@@ -119002,70 +121529,70 @@ yfv
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-sCR
-glB
-ayR
-mhi
-mhi
-lpo
-igR
-xsl
-glB
-sCR
-lxa
-mhi
-mhi
-oWB
-aHQ
-lxa
-jTm
-fCI
-glB
-gfG
-oQR
-oQR
+tjM
+eyn
 kBe
-glB
+kBe
+dUG
+qqM
+taO
+eyn
+eyn
+ayR
+pXG
+taO
+rRz
+rRz
+rRz
+rRz
 azA
+azA
+azA
+azA
+azA
+aUc
+azA
+azA
+fCI
+mcP
+qZA
+oQR
+mCa
+qZA
+xRZ
+ioi
 euA
-dxL
-vdg
-pLm
-odO
-pII
-fIo
-fIo
+glB
+uoW
+uoW
+uoW
+uoW
+ryn
+naK
 dHE
-fIo
-bav
-jZa
-uFK
-iKg
-lzK
-lzK
-mBV
-lzK
-vpf
+sqC
+sqC
+sqC
+hRM
+eal
+eal
+sqC
+xAu
+naK
+sqC
+eUJ
+eit
+smK
+bho
+wsd
+dLj
+pzp
+rpg
+mGx
+mKW
+pzp
 azA
 azA
-azA
-lgp
-cBf
-cBf
-cBf
-cBf
-cBf
-cBf
-cju
-azA
-plW
 azA
 azA
 ner
@@ -119305,69 +121832,69 @@ yfv
 rRz
 rRz
 rRz
+tjM
+rRz
+taO
+taO
+riO
+taO
+taO
+igR
+taO
+taO
+koe
+taO
 rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-sCR
-glB
-daz
-uoW
-uoW
-uoW
-uoW
-wUf
-glB
-sCR
-lxa
-lxa
-lxa
-hoH
-lxa
-lxa
-jTm
-uHW
-glB
-glB
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+baQ
+ssu
+qZA
 lrm
-lrm
+ubM
+qZA
+ioi
+qZA
+sqC
 glB
-glB
-iPK
-euA
-dxL
-uFK
-rvP
-lzK
-peG
-lzK
+uoW
+uoW
+uoW
+uoW
 ryn
-cYh
+naK
+woq
 aDA
-lzK
-lzK
-uFK
-jsS
+ryn
+naK
+xAu
+hbV
 hbV
 obr
-tkX
-rMr
-uFK
+sKF
+naK
+dsF
+sqC
+wUa
+wUa
+sqC
+nXU
+dsF
+dsF
+mEa
+dsF
+pzp
+uTu
 azA
 azA
-jKr
-dqd
-cBf
-cBf
-cBf
-cBf
-cBf
-cBf
-cju
-azA
-plW
 azA
 azA
 ner
@@ -119608,68 +122135,68 @@ yfv
 yfv
 rRz
 rRz
+tjM
+rRz
+taO
+dhM
+taO
+nGy
+taO
+taO
+taO
+taO
+tjM
 rRz
 rRz
 rRz
 rRz
 rRz
-sCR
-glB
-omH
-uoW
-uoW
-uoW
-mLa
-nqB
-qWq
-sCR
+azA
+azA
+azA
+azA
+azA
+azA
 fTz
-fTz
-fTz
-kgs
-fTz
-fTz
-kgs
-fTz
-lIM
-fTz
-iCV
-hjV
-iCV
+mcP
+izU
+qZA
+qZA
+fKQ
 ern
 alK
-jJC
-nqa
-uFK
-uFK
+hON
+glB
+uoW
+uoW
+uoW
+uoW
+ryn
+xAu
+dVd
 pzv
-pzv
-uFK
-uFK
-uFK
-pzv
-pzv
-uFK
-uFK
-uFK
-pzv
-pzv
-pzv
-uFK
-msE
+sKF
+sKF
+xAu
+syn
+syn
+naK
+syn
+btr
+dsF
+rMM
+fIo
+qLY
+jcB
+dsF
+hBb
+rTY
+sKF
+dsF
 azA
-ttF
-azA
-dqd
-cBf
-cBf
-cBf
-cBf
-cBf
-cBf
 rjn
 azA
-plW
+azA
 azA
 azA
 ner
@@ -119911,67 +122438,67 @@ yfv
 yfv
 yfv
 rRz
+tjM
+tjM
+taO
+vuF
+taO
+taO
+qqM
+kBe
+tjM
 rRz
 rRz
 rRz
 rRz
-sCR
+rRz
+rRz
+rRz
+azA
+azA
+azA
+azA
+azA
+drQ
+mcP
+qkH
+gjy
+qkH
+gjy
+vhF
+fpI
+sqC
 glB
-omH
-uoW
-uoW
-uoW
-uoW
-qML
-igR
-tgo
-cwf
-ucl
-igO
-etA
-igO
-igO
-qbf
-mcP
-mcP
-qkH
-mcP
-qkH
-qkH
-qkH
-ioi
-ioi
-nqa
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-ndZ
-rDi
-uhS
+ryn
+naK
+xAu
+xAu
+xAu
+xAu
+glB
+sqC
+sqC
+sqC
+hRM
+vXL
+vXL
+sqC
+vXL
+sqC
+dsF
+oov
+hGe
+fur
 soG
-cBf
-cBf
-cBf
-cBf
-cBf
-cBf
-cju
+dsF
+fIo
+fnV
+fnV
+dsF
+xmm
+sRi
 azA
-plW
+azA
 azA
 azA
 ner
@@ -120215,65 +122742,65 @@ yfv
 rRz
 rRz
 rRz
+tjM
+taO
+taO
+nqB
+omH
 rRz
 rRz
-sCR
-glB
-omH
-uoW
-uoW
-uoW
-uoW
-omH
-doz
-sCR
-utR
-fcP
-utR
-utR
-utR
-utR
-utR
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+azA
+azA
+azA
+azA
+daz
+rjn
 age
 age
 age
 age
-age
-jFR
 eOt
-sZp
-kkW
+xRZ
+sqC
+glB
+sxo
+xVs
+xGS
+ryn
+njF
+uOo
+glB
+sqC
+qkJ
+taL
 vbF
+taL
+taL
+taL
+taL
+obq
+dsF
+qGz
+hGe
+cBt
+fnV
+mEa
+hkD
+fnV
+fIo
+dsF
+uqB
+pII
 azA
 azA
-azA
-dzm
-azA
-azA
-dzm
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-dzm
-azA
-msz
-sXx
-nrq
-lWr
-cBf
-cBf
-cBf
-cBf
-cBf
-cBf
-cju
-azA
-plW
 azA
 azA
 ner
@@ -120518,64 +123045,64 @@ yfv
 yfv
 rRz
 rRz
+tjM
+taO
+kBe
+tjM
 rRz
-sCR
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+lOu
+ioi
+hON
 glB
-daz
-uoW
-uoW
-uoW
-uoW
-dRz
-glB
-sCR
-uHW
-jTm
-uHW
-uHW
-uHW
-uHW
-uHW
-ngu
-ngu
-ngu
-lrm
-lrm
 glB
 glB
-nEf
-nEf
 glB
-fQC
-dzm
-azA
-azA
-ljW
-azA
-azA
-azA
-aUc
-azA
-azA
-dzm
-azA
-azA
-azA
-azA
-azA
-snR
+glB
+glB
+glB
+glB
+sqC
+hwn
+rFY
+vwa
+lXR
+jTC
+iNH
+vwa
+hlh
+hRM
+tgj
 fFs
-nrq
+ezV
 fnV
-vLP
-cBf
-vLP
-pvo
-vLP
-cBf
+dsF
+hIi
+fnV
+whF
+dsF
+uqB
 oep
 azA
-plW
+azA
 azA
 azA
 ner
@@ -120821,63 +123348,63 @@ yfv
 rRz
 rRz
 rRz
-sCR
-glB
-omH
-xrd
-omH
-omH
-iQC
-omH
-glB
-sCR
-lzB
-taL
-syt
-syt
-fEG
-syt
-syt
-oeG
-igR
-xsl
-kOg
-kOg
-kfS
-vhF
-eYY
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+azA
+azA
+azA
+azA
+azA
+azA
+azA
+rjn
+eAw
 eKQ
-oWG
-sxo
-dzm
-azA
-azA
-azA
-azA
-dzm
-azA
-azA
-azA
-azA
-azA
-oAf
-azA
-azA
-azA
-dzm
+euA
+sqC
+sqC
+sqC
+hON
+euA
+eKQ
+sqC
+sqC
+bRp
+rFY
+vwa
+aYP
+nEf
+ftf
+vwa
+woZ
+dsF
 bzH
-wTQ
-ctN
-lWp
-lWp
-lWp
-vdT
-lWp
-lWp
-lWp
-lWp
+hGe
+fur
+fnV
+sjl
+rcc
+naK
+aCZ
+dsF
+uqB
+pII
 azA
-plW
+azA
 azA
 azA
 ner
@@ -121123,63 +123650,63 @@ yfv
 rRz
 rRz
 rRz
-sCR
-glB
-glB
-glB
-glB
-glB
-glB
-glB
-glB
-sCR
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+azA
+azA
+azA
+azA
+azA
+azA
+eaR
+azA
+azA
+snR
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
+sqC
+orz
+sKQ
+fJi
+fJi
+uyK
+pcl
+qtI
 owz
-pmu
-pot
-uHW
-uHW
-uHW
-uHW
-glB
-yeu
-egD
-oXt
-omH
-omH
-omH
-oXt
-drQ
-glB
-iPK
+dsF
+vOr
+fIo
+jOC
+fnV
+sjl
+hGe
+hGe
+fIo
+dsF
+uqB
+pII
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-jKr
-azA
-azA
-azA
-dzm
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-aUc
-plW
 azA
 azA
 ner
@@ -121423,65 +123950,65 @@ yfv
 yfv
 yfv
 yfv
-yfv
 rRz
-sCR
-sCR
-sCR
-sCR
-sCR
-sCR
-sCR
-sCR
-sCR
-sCR
-cGL
-jcB
-hkD
-tbl
-uHW
-uHW
-uHW
-glB
-ydn
-lpg
-pPO
-pPO
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+azA
+azA
+azA
+azA
+azA
+ndZ
 rUi
-rUi
-ezV
-aRO
-glB
-xes
+rDi
+uhS
+snR
+cBf
+cBf
+kOg
+gES
+cBf
+igI
+pvo
+hON
+sqC
+oFf
+tUI
+ouC
+sqC
+sqC
+sqC
+sqC
+dsF
+nUm
+dsF
+qnN
+veV
+dsF
+aTU
+fIo
+fIo
+dsF
+uqB
+qcl
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-ljW
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-plW
 azA
 azA
 ner
@@ -121725,65 +124252,65 @@ upl
 azA
 yfv
 yfv
-yfv
 rRz
-osi
-osi
-osi
-osi
-osi
-osi
-osi
-osi
-osi
-eaR
-cCL
-atY
-hkD
-osi
-osi
-osi
-osi
-glB
-glB
-glB
-glB
-glB
-glB
-glB
-glB
-glB
-glB
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 rRz
 azA
 azA
 azA
 azA
 azA
+snR
+oKR
+cBf
+dEl
+snR
+cBf
+cBf
+cBf
+gES
+cBf
+cBf
+myl
+cBf
+sqC
+cCa
+oUH
+pIs
+ckc
+sqC
+pXX
+cBf
+xWR
+fIo
+eGd
+gdH
+xwj
+dsF
+qth
+fIo
+hGe
+dsF
+uqB
+pII
 azA
 azA
-azA
-azA
-azA
-dzm
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-plW
 azA
 azA
 ner
@@ -122027,8 +124554,6 @@ hKk
 azA
 yfv
 yfv
-yfv
-yfv
 rRz
 rRz
 rRz
@@ -122048,44 +124573,46 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+azA
+azA
+azA
+azA
+azA
+snR
+oKR
+cBf
+dEl
+snR
+cBf
+cBf
+kOg
+gES
+cBf
+cBf
+cBf
+pvo
+sqC
+lzB
+sUF
+dTf
+nal
+sqC
+sXx
+cBf
 udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-udp
-dBI
+btr
+fIo
+fIo
+fIo
+dsF
+dsF
+tcW
+dsF
+dsF
+uqB
+pII
+azA
+azA
 azA
 igU
 ner
@@ -122350,42 +124877,42 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+snR
+sDo
+cBf
+dEl
+gAg
+wTQ
+wta
+wta
+wta
+wta
+wta
+wta
+wta
+sqC
+mhM
+mhM
+mhM
+vTu
+sqC
+pPO
+icW
+dsF
+jzf
+btr
+btr
+jOC
+cyJ
+fRv
+btr
+lOZ
+nUm
+uqB
+qcl
 azA
 azA
 azA
@@ -122653,15 +125180,12 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+azA
+azA
+snR
+bHI
+cBf
+dEl
 azA
 azA
 azA
@@ -122670,24 +125194,27 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+dXN
+sqC
+sqC
+sqC
+sqC
+sqC
+sqC
+win
+cBf
+dsF
+jJC
+fIo
+btr
+fEG
+nOP
+fIo
+btr
+jyS
+nUm
+wta
+gdK
 azA
 azA
 azA
@@ -122956,40 +125483,40 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+azA
+snR
+qVQ
+rnZ
+kiP
+rDi
+rDi
+rDi
+uhS
 azA
 azA
 azA
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+doc
+cBf
+cBf
+cBf
+cBf
+cBf
+iwp
+nDt
+dsF
+nUm
+ryn
+rvt
+eYY
+aRk
+dNx
+btr
+efI
+efZ
+gwF
+eaR
 azA
 azA
 azA
@@ -123258,40 +125785,40 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
 azA
+snR
+xtf
+sMv
+rjn
+sMv
+sMv
+sMv
+aEd
+lNW
+lNW
+lNW
+lNW
+rjn
+gCS
+jZa
+jZa
+jZa
+jZa
+jZa
+wtD
+ctN
+ooG
+dsF
+jLH
+kLg
+dBR
+lXS
+tPj
+fIo
+kWF
+rIs
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+eaR
 azA
 hfT
 hfT
@@ -123560,16 +126087,15 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+azA
+gAg
+wTQ
+wTQ
+wTQ
+wTQ
+wTQ
+wTQ
+ctN
 azA
 azA
 azA
@@ -123581,19 +126107,20 @@ azA
 azA
 azA
 azA
+rjn
 azA
 azA
+dsF
+rPK
+atH
+dZj
+ddL
+gQA
+btr
+gyJ
+nUm
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+wyj
 azA
 hfT
 xng
@@ -123863,21 +126390,14 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
 azA
 azA
 azA
 rRz
+rRz
+rRz
+rRz
+rRz
 azA
 azA
 azA
@@ -123889,13 +126409,20 @@ azA
 azA
 azA
 azA
+kpA
 azA
+ndZ
+dsF
+gnS
+fIo
+fIo
+fIo
+fIo
+cGL
+feg
+dsF
 azA
-azA
-azA
-azA
-azA
-azA
+wNf
 azA
 hfT
 fYv
@@ -124164,19 +126691,17 @@ rRz
 rRz
 rRz
 rRz
+azA
+azA
+rRz
+rRz
 rRz
 rRz
 rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+azA
 azA
 azA
 rRz
@@ -124186,18 +126711,20 @@ azA
 azA
 azA
 azA
+eaR
 azA
+doc
+dsF
+rEX
+rEX
+nUm
+rEX
+mwi
+dsF
+dsF
+dsF
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+lWr
 azA
 hfT
 rjJ
@@ -124482,25 +127009,25 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
 azA
 azA
 azA
 azA
+baQ
 azA
+doc
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
+cBf
+nrq
 azA
+eaR
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-jHW
 hfT
 hfT
 hfT
@@ -124785,23 +127312,23 @@ rRz
 rRz
 rRz
 rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
 azA
 azA
 azA
-azA
-azA
-ljW
-azA
-azA
-azA
-azA
-azA
+daz
+rjn
+gCS
+jZa
+jZa
+jZa
+jZa
+jZa
+jZa
+jZa
+jZa
+qbf
+rjn
+eFl
 azA
 azA
 azA
@@ -125085,17 +127612,17 @@ rRz
 rRz
 rRz
 rRz
+rRz
+rRz
+rRz
 azA
 azA
 azA
 azA
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
-rRz
+azA
+azA
+azA
+azA
 azA
 azA
 azA
@@ -125386,11 +127913,6 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
-azA
 rRz
 rRz
 rRz
@@ -125398,8 +127920,13 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
 azA
 azA
@@ -125685,25 +128212,25 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
 rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
 azA
 azA
@@ -125986,27 +128513,27 @@ rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
 rRz
 rRz
 rRz
 rRz
 rRz
-azA
-azA
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 rRz
 rRz
 azA
@@ -126288,20 +128815,20 @@ azA
 azA
 azA
 azA
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
 azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
-azA
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
+rRz
 azA
 rRz
 rRz
@@ -136574,7 +139101,7 @@ qOC
 slu
 azA
 azA
-azA
+dPj
 xSB
 ndZ
 uhS

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
@@ -50,13 +50,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/sewer/powered)
-"abq" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/dorms)
 "abx" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -96,13 +89,13 @@
 	},
 /area/f13/bunker/bunkersix)
 "ach" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -8
 	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 5
+	},
+/area/f13/brotherhood/reactor)
 "acj" = (
 /obj/structure/destructible/tribal_torch/lit{
 	pixel_y = 18
@@ -144,10 +137,6 @@
 	},
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
-"aeo" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "aes" = (
 /turf/closed/mineral/strong/wasteland,
 /area/f13/caves)
@@ -178,11 +167,13 @@
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/diner)
 "afm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/plantgenes,
+/obj/structure/table,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "afo" = (
 /obj/item/cautery,
 /obj/item/hemostat,
@@ -194,10 +185,16 @@
 	},
 /area/f13/bunker/bunkerfive)
 "afp" = (
+/obj/structure/table/glass,
+/obj/item/pda/chemist{
+	name = "Scribe-Chemist Pip-Boy 3000";
+	pixel_x = 15;
+	pixel_y = 7
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
+/obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/chemistry)
 "afz" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/dark,
@@ -213,16 +210,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
-"afW" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = 30;
-	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "agg" = (
 /obj/machinery/chem_master/condimaster,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -232,12 +219,6 @@
 	},
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerfive)
-"agi" = (
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "agn" = (
 /obj/machinery/computer/security{
 	network = list("vault")
@@ -312,11 +293,19 @@
 	},
 /area/f13/bunker)
 "ahf" = (
-/obj/item/circuitboard/machine/smes,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/reagent_containers/blood/OMinus,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/surgical_drapes,
+/obj/item/stack/sticky_tape/surgical{
+	pixel_x = -11;
+	pixel_y = 8
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
+/area/f13/brotherhood/operating)
 "ahx" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/floor/plasteel/floorgrime,
@@ -350,11 +339,25 @@
 	},
 /area/f13/bunker/bunkerthree)
 "aij" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/item/clothing/under/rank/medical/green,
+/obj/item/clothing/under/rank/medical/purple,
+/obj/item/clothing/under/rank/medical/blue,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
+	},
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 6
+	},
+/area/f13/brotherhood/operating)
 "ait" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -386,11 +389,13 @@
 	},
 /area/f13/sewer/powered)
 "aiA" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/machinery/door/airlock/hatch{
+	name = "Armory";
+	req_access_txt = "120"
 	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	dir = 10;
+	icon_state = "redmark"
 	},
 /area/f13/brotherhood/armory)
 "aiJ" = (
@@ -404,17 +409,6 @@
 /obj/structure/debris/v2,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
-"aiQ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light/fo13colored/Pink{
-	critical_machine = 1;
-	dir = 8;
-	flicker_chance = 0
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
 "aiV" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -488,6 +482,15 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/sewer/powered)
+"akt" = (
+/obj/machinery/power/smes/engineering,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 1
+	},
+/area/f13/brotherhood/reactor)
 "akv" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -495,10 +498,6 @@
 /obj/structure/debris/v2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"akB" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "akL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -609,15 +608,6 @@
 	dir = 5
 	},
 /area/f13/vault/garden)
-"ano" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/simple_door/bunker{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/reactor)
 "anv" = (
 /obj/structure/rack,
 /obj/item/gun/ballistic/revolver/hobo/knifegun,
@@ -771,13 +761,9 @@
 /turf/open/floor/plasteel/vault,
 /area/f13/vault/security/armory)
 "aqG" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_x = 8
-	},
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/structure/sign/directions/engineering,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/armory)
 "aqM" = (
 /obj/structure/table,
 /obj/structure/sign/plaques/long/vault{
@@ -894,13 +880,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/ruin/powered)
-"aul" = (
-/obj/structure/fans/tiny{
-	pixel_y = -33
-	},
-/obj/machinery/light,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "aun" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -1049,23 +1028,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/tunnel)
-"awA" = (
-/obj/structure/sign/painting/library_secure{
-	persistence_id = "brotherhood_secure";
-	pixel_y = 32
-	},
-/obj/item/canvas,
-/obj/item/canvas/nineteenXnineteen,
-/obj/item/canvas/twentythreeXnineteen,
-/obj/item/canvas/twentythreeXtwentythree,
-/obj/item/canvas/nineteenXnineteen,
-/obj/item/canvas/nineteenXnineteen,
-/obj/structure/closet/crate,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/obj/item/toy/crayon/spraycan,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
 "awN" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/indestructible/vaultdoor,
@@ -1117,19 +1079,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building/abandoned/o)
 "axF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/camera_advanced/abductor{
-	desc = "One day, we'll get that dish working. Not today.";
-	name = "Inactive Radar Console";
-	pixel_y = 17
+/obj/machinery/workbench,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/item/wrench/advanced{
-	pixel_x = 2
-	},
-/obj/effect/decal/cleanable/robot_debris/down,
-/obj/item/crowbar/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "axK" = (
 /obj/structure/table,
 /obj/item/trash/tray,
@@ -1137,30 +1092,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"ayB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "ayF" = (
 /obj/machinery/door/airlock/public,
 /turf/open/floor/f13,
 /area/f13/bunker)
-"ayZ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"azd" = (
-/obj/structure/chair/f13chair1,
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/leisure)
 "aze" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/indestructible/ground/inside/subway,
@@ -1250,12 +1185,12 @@
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/vault/security)
 "aBA" = (
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/machinery/light/small{
+	light_color = "green"
+	},
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/operations)
 "aBQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -1307,12 +1242,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/side,
 /area/f13/vault/atrium)
 "aDy" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/structure/chair/sofa,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/dorms)
 "aDJ" = (
 /obj/effect/spawner/lootdrop/f13/blueprintVHigh,
 /obj/structure/lattice,
@@ -1412,14 +1345,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
-"aFw" = (
-/obj/machinery/defibrillator_mount/loaded{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
 "aFz" = (
 /obj/structure/shelf_wood,
 /turf/open/floor/wood_mosaic,
@@ -1455,28 +1380,28 @@
 	},
 /area/ruin/powered)
 "aGf" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/fulltile/store,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
-"aGs" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operating)
+"aGs" = (
+/obj/structure/closet/athletic_mixed,
+/obj/item/clothing/gloves/boxing/blue,
+/obj/item/clothing/gloves/boxing/green,
+/obj/item/clothing/gloves/boxing/yellow,
+/obj/item/clothing/gloves/boxing,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "aGI" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/window/fulltile/store{
-	layer = 2.9
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "aGO" = (
 /obj/effect/turf_decal/bot_red,
@@ -1513,10 +1438,19 @@
 	},
 /area/f13/bunker/bunkerthree)
 "aIc" = (
-/obj/structure/window/reinforced/clockwork/fulltile,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -11;
+	pixel_y = 4
+	},
+/obj/machinery/microwave{
+	density = 0;
+	pixel_y = 11
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "aIg" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks,
@@ -1588,14 +1522,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
-"aJM" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "aJT" = (
 /obj/structure/railing{
 	dir = 1
@@ -1663,11 +1589,18 @@
 	},
 /area/f13/sewer)
 "aLl" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/mining)
+"aLs" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/operating)
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "aLV" = (
 /obj/structure/handrail/g_central{
 	layer = 6;
@@ -1675,20 +1608,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"aLW" = (
-/obj/structure/bed{
-	pixel_y = 7
-	},
-/obj/item/bedsheet{
-	icon_state = "sheetcmo";
-	pixel_y = 7
-	},
-/obj/machinery/iv_drip{
-	pixel_x = 13;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "aMb" = (
 /obj/item/ammo_casing/spent{
 	dir = 1;
@@ -1719,11 +1638,13 @@
 	},
 /area/ruin/powered)
 "aNn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/dorms)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "aNw" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/syndicate,
@@ -1744,12 +1665,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker/bighornbunker)
-"aNH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/circuitboard/machine/pacman/mrs,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "aNR" = (
 /obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/inside/subway,
@@ -1816,14 +1731,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker/bunkerthree)
-"aPq" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/seniorknight,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/brotherhood/armory)
 "aPu" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/f13{
@@ -1839,14 +1746,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "aPD" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_2";
-	layer = 6;
-	pixel_x = -6;
-	pixel_y = 13
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
+/obj/effect/landmark/start/f13/seniorknight,
+/turf/open/floor/plasteel/f13/vault_floor/red/corner,
+/area/f13/brotherhood/armory)
 "aPE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1908,23 +1813,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/indestructible/f13/obsidian,
 /area/f13/caves)
-"aRx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Red{
-	dir = 4
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "aRB" = (
-/obj/structure/sign/departments/medbay,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/green,
+/area/f13/brotherhood/operations)
 "aRF" = (
 /obj/structure/wreck/trash/three_barrels,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1979,10 +1870,13 @@
 	},
 /area/f13/sewer)
 "aRW" = (
-/obj/machinery/jukebox,
-/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/ash/large,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/operating)
 "aSb" = (
 /mob/living/simple_animal/hostile/ghoul{
 	name = "ghoul cannibal"
@@ -1995,29 +1889,16 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/sewer/powered)
-"aSq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
-	},
-/obj/machinery/camera/autoname{
-	dir = 8;
-	name = "Armory Camera";
-	network = list("BoS");
-	pixel_x = -1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/brotherhood/armory)
 "aSA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/railing{
+	layer = 4.1;
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/dorms)
 "aSF" = (
 /obj/structure/simple_door/bunker{
 	name = "Kitchen"
@@ -2266,30 +2147,28 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
 "aYb" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/pda/medical{
-	name = "Scribe-Medic Pip-Boy 3000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
+/area/f13/brotherhood/reactor)
 "aYm" = (
 /obj/effect/gibspawner/human,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
 "aYn" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"aYu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
+/obj/structure/simple_door/bunker,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
+"aYu" = (
+/obj/structure/dresser,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "aYM" = (
 /obj/structure/wreck/trash/three_barrels{
@@ -2317,11 +2196,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
 "aZU" = (
-/obj/structure/simple_door/bunker{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/structure/sign/poster/random,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/dorms)
 "aZV" = (
 /obj/machinery/vending/medical,
 /turf/open/floor/f13{
@@ -2329,12 +2206,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
-"bae" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operating)
 "bar" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2359,10 +2230,15 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "baQ" = (
-/obj/structure/window/reinforced/tinted/frosted,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/dorms)
+/obj/structure/rack/shelf_metal,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/storage/belt/utility/full,
+/obj/item/screwdriver/power,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 8
+	},
+/area/f13/brotherhood/reactor)
 "bbl" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -2450,12 +2326,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/bunker/bunkerfive)
-"bdi" = (
-/obj/machinery/plantgenes,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "bdl" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -2675,10 +2545,6 @@
 /mob/living/simple_animal/hostile/supermutant/legendary,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"biS" = (
-/mob/living/simple_animal/cow/brahmin,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "biZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -2726,9 +2592,6 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/carpet,
 /area/f13/shack)
-"bkL" = (
-/turf/closed/mineral/random/no_caves,
-/area/f13/brotherhood/operations)
 "bll" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -2849,21 +2712,11 @@
 	},
 /area/f13/building/abandoned/o)
 "bol" = (
-/obj/item/toy/figure/warden{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	name = "Knight Action Figure";
-	toysay = "Steel be with you."
+/obj/structure/chair/sofa/left{
+	dir = 1
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
+/obj/effect/landmark/start/f13/Knight,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
 "bom" = (
 /obj/structure/simple_door/bunker/glass{
@@ -2928,36 +2781,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
-"bql" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/item/stock_parts/cell/ammo/ecp,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "bqs" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -2987,12 +2810,16 @@
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerfive)
 "brH" = (
-/obj/structure/simple_door/bunker/glass,
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/brotherhood/rnd)
 "brN" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/indestructible/ground/outside/ruins,
@@ -3163,12 +2990,10 @@
 /turf/open/floor/f13,
 /area/f13/bunker)
 "bxs" = (
-/obj/structure/flora/grass/jungle/b,
-/obj/machinery/light{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 9
 	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operating)
 "bxL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/five_tires,
@@ -3193,11 +3018,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
 "bxZ" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/armory)
 "byl" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3285,13 +3110,9 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/sewer)
 "bAQ" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/fulltile/store,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
 "bAV" = (
 /obj/machinery/light{
@@ -3367,19 +3188,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
 "bCQ" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
 /area/f13/brotherhood/reactor)
-"bCR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "bCV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_mosaic/wood_mosaic_light{
@@ -3415,16 +3235,6 @@
 /obj/machinery/telecomms/server/presets/ncr,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"bDL" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "bDU" = (
 /obj/structure/table,
 /obj/item/storage/belt/medical/surgery_belt_adv,
@@ -3475,11 +3285,6 @@
 	},
 /turf/closed/wall/f13/wood/house,
 /area/f13/bunker)
-"bFE" = (
-/obj/structure/chair/f13chair1,
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/leisure)
 "bFL" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -3527,22 +3332,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/atrium)
 "bGu" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+/obj/machinery/vending/security,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 10
 	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
-"bHg" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light/fo13colored/Red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/armory)
 "bHs" = (
 /obj/structure/lattice{
 	density = 1
@@ -3613,10 +3408,6 @@
 "bIY" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
-"bJc" = (
-/obj/structure/sign/poster/prewar/poster65,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
 "bJh" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/subway,
@@ -3785,19 +3576,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker/bunkerfive)
-"bMT" = (
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 9
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "bMX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -3900,19 +3678,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
-"bQB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors3";
-	name = "brotherhood shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "bQL" = (
 /obj/machinery/pool/drain,
 /turf/open/floor/f13{
@@ -3997,25 +3762,8 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "bRN" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/turf/open/water,
+/obj/effect/landmark/start/f13/Knight,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "bRV" = (
 /mob/living/simple_animal/hostile/handy/assaultron,
@@ -4059,9 +3807,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/bunker/bunkereight)
 "bSQ" = (
-/obj/structure/decoration/smokeold,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "bSV" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe/free,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
@@ -4251,14 +3999,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "bYu" = (
-/obj/structure/bed,
-/obj/item/bedsheet/rd{
-	desc = "A fine quilted blanket, made with purple and yellow fabric.";
-	dream_messages = list("authority","a                                                                silvery                                                                ID","a                                                                bomb","a                                                                mech","a                                                                facehugger","maniacal                                                                laughter");
-	name = "fine bedsheet"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
+"bYx" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/brotherhood/armory)
 "bYS" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/sewer)
@@ -4288,8 +4044,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "bZQ" = (
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/armory)
 "bZW" = (
 /obj/structure/wreck/car,
 /turf/open/indestructible/ground/inside/subway,
@@ -4363,16 +4124,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
-"cbJ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fireaxecabinet{
-	pixel_x = 33
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "cbO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -4399,19 +4150,25 @@
 	},
 /area/f13/enclave)
 "cbX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/reactor)
 "cca" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/rack/large/shelf,
+/obj/item/storage/toolbox/plastitanium{
+	pixel_x = 7;
+	pixel_y = 25
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/item/wirecutters/power,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 1
+	},
+/area/f13/brotherhood/reactor)
 "ccj" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/centaur,
@@ -4460,41 +4217,29 @@
 	},
 /area/f13/vault/storage)
 "cdK" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/leisure)
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/reactor)
 "cea" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_x = -8
-	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_x = -8
-	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_x = -8
-	},
-/obj/item/card/id/dogtag{
-	pixel_x = 4
-	},
-/obj/item/card/id/dogtag{
-	pixel_x = 4
-	},
-/obj/item/card/id/dogtag{
-	pixel_x = 4
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
-"ced" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 9;
-	pixel_x = 7
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
+"ced" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Science";
+	req_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/brotherhood/operations)
 "cee" = (
 /turf/open/floor/f13/wood{
@@ -4589,11 +4334,6 @@
 /obj/structure/falsewall,
 /turf/closed/mineral/random/no_caves,
 /area/f13/caves)
-"cfY" = (
-/obj/structure/table,
-/obj/item/kitchen/fork,
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/leisure)
 "cgb" = (
 /obj/effect/overlay/junk/mirror{
 	pixel_x = -26;
@@ -4762,18 +4502,17 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
-"cjq" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "cju" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
+"cjE" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "cjN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/doorButtons/vaultButton/external,
@@ -4793,15 +4532,11 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "ckn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "cku" = (
 /obj/structure/simple_door/bunker,
@@ -4902,10 +4637,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer/powered)
 "cmM" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
@@ -4919,11 +4653,6 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/bunker/bunkerthree)
-"cnl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "cnm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -4937,13 +4666,6 @@
 /obj/structure/grille/broken,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/abandoned/o)
-"cny" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Head Scribe Office";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "cnY" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -5046,11 +4768,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"csc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "csj" = (
 /obj/structure/closet/crate/trashcart,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -5086,12 +4803,22 @@
 	},
 /area/ruin/powered)
 "csR" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
 	},
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/leisure)
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/item/stock_parts/cell/ammo/ecp,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood/armory)
 "csS" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -5286,28 +5013,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/enclave)
-"cwP" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/operations)
 "cwR" = (
 /obj/machinery/microwave{
 	pixel_y = 16
@@ -5353,10 +5058,17 @@
 	},
 /area/f13/bunker)
 "cxP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
+/obj/structure/closet/radiation{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/brotherhood/reactor)
 "cxR" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/food/drinks/bottle/brown/darkbrown,
@@ -5389,30 +5101,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"cyw" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm8";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/brotherhood/dorms)
 "cyF" = (
-/obj/machinery/camera/autoname{
-	dir = 5;
-	name = "Reactor Camera";
-	network = list("BoS")
-	},
+/obj/machinery/chem_master/advanced,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "cyK" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
@@ -5437,20 +5131,16 @@
 /obj/item/stack/f13Cash/random,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
-"czt" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "czv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/vent{
-	pixel_x = 15;
-	pixel_y = -17
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/armory)
 "czE" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/light_brown,
@@ -5469,16 +5159,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/enclave)
-"czU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "czX" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/armor/tier1,
@@ -5628,15 +5308,16 @@
 /turf/open/floor/f13,
 /area/f13/bunker)
 "cET" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/toy/gun/m41{
-	desc = "A pre-war toy rifle issued to children across the continent.";
-	name = "Toy Pulse Rifle"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/red/corner{
+	dir = 8
+	},
+/area/f13/brotherhood/armory)
 "cEZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/mattress{
@@ -5703,10 +5384,6 @@
 	dir = 1
 	},
 /area/f13/vault/diner)
-"cHR" = (
-/obj/structure/sign/poster/prewar/poster60,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
 "cIf" = (
 /mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/indestructible/ground/inside/subway,
@@ -5753,12 +5430,16 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "cIZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
 	},
-/area/f13/brotherhood/armory)
+/obj/machinery/power/am_control_unit{
+	anchored = 1;
+	dir = 4
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/area/f13/brotherhood/reactor)
 "cJa" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	pixel_y = -10
@@ -5782,27 +5463,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
 "cJo" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
+/obj/structure/sink{
 	dir = 4;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
+	pixel_x = 12
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"cJA" = (
-/obj/structure/lattice{
-	layer = 3
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/armory)
 "cJF" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
@@ -5829,11 +5497,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"cKv" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 9
-	},
-/area/f13/brotherhood/reactor)
 "cKx" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal,
@@ -5878,14 +5541,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
 "cLN" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/machinery/door/airlock/hatch{
+	name = "Science";
+	req_access_txt = "120"
 	},
-/obj/structure/decoration/vent,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/brotherhood/operations)
 "cLQ" = (
 /obj/structure/wreck/trash/halftire,
@@ -5941,19 +5604,6 @@
 /mob/living/simple_animal/hostile/raider/tribal,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"cNn" = (
-/obj/structure/decoration/vent{
-	pixel_x = 32
-	},
-/obj/structure/fence/corner/wooden{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -15
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "cNy" = (
 /turf/closed/indestructible/syndicate,
 /area/ruin/powered)
@@ -5989,16 +5639,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
 "cOK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_x = 32;
-	start_charge = 500
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/dorms)
 "cOS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -6007,15 +5651,11 @@
 	},
 /area/f13/vault)
 "cPd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/chair/sofa/left,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/landmark/start/f13/initiate,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/dorms)
 "cPM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/concrete,
@@ -6150,22 +5790,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered)
-"cSk" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "cSn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6315,13 +5939,79 @@
 	},
 /area/f13/bunker)
 "cWL" = (
-/obj/machinery/smartfridge/food,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/shoes/combat/swat{
+	pixel_x = 7;
+	pixel_y = -9
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/sechailer/swat{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/item/clothing/mask/gas/explorer{
+	pixel_y = 11
+	},
+/obj/structure/closet/anchored,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "red"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/brotherhood/armory)
 "cWO" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -6340,12 +6030,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/storage)
-"cXh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "cXm" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -6378,12 +6062,7 @@
 	},
 /area/f13/sewer/powered)
 "cYb" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood/operations)
 "cYc" = (
 /obj/structure/chair/left,
@@ -6429,14 +6108,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "cZu" = (
-/obj/machinery/sleeper{
-	density = 1;
+/obj/structure/decoration/vent/rusty,
+/obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plating/tunnel,
+/area/f13/brotherhood/mining)
 "cZy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -6492,18 +6169,13 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "daZ" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "twindowold"
-	},
-/obj/structure/toilet{
-	pixel_y = 10
+/obj/machinery/light/small{
+	dir = 1
 	},
 /turf/open/floor/f13{
-	dir = 10;
 	icon_state = "redmark"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/reactor)
 "dbc" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -6518,17 +6190,9 @@
 	},
 /area/f13/bunker/bunkerthree)
 "dbi" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/chair/left{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"dbo" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/chair/sofa/right,
+/obj/effect/landmark/start/f13/initiate,
+/turf/open/floor/carpet/green,
 /area/f13/brotherhood/operations)
 "dbr" = (
 /obj/machinery/door/locked/hard/maybe_trapped,
@@ -6568,58 +6232,6 @@
 /obj/item/bedsheet/grey,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
-"dcm" = (
-/obj/structure/rack,
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 11
-	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 8
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -10;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -6;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -2;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = 2;
-	pixel_y = -10
-	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 13;
-	pixel_y = -8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "dcx" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -6833,16 +6445,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/bunker/bunkerthree)
-"dgQ" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/armory)
 "dgT" = (
 /obj/structure/chair/bench,
 /mob/living/simple_animal/hostile/raider/ranged/junker/scavver,
@@ -6880,21 +6482,23 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"dig" = (
-/obj/structure/flora/grass/wasteland{
-	icon_state = "tall_grass_4";
-	layer = 6;
-	pixel_x = 7
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "diq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light/small{
+	light_color = "green"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
+	},
+/area/f13/brotherhood/leisure)
 "div" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/medsprays{
@@ -6959,27 +6563,17 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
-"dkv" = (
-/obj/structure/bed/pod,
-/obj/item/bedsheet/hos,
-/obj/machinery/iv_drip{
-	pixel_x = 13
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/medical)
 "dkF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
 "dkQ" = (
-/obj/effect/decal/cleanable/generic,
+/obj/structure/chair/stool/retro/black,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "dkR" = (
 /obj/structure/closet/crate{
 	anchored = 1
@@ -7080,15 +6674,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/bunker/bunkerthree)
-"dnk" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 10
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "dno" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/vault)
@@ -7125,20 +6710,14 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "dnT" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/button/door{
-	id = "bosdoors3";
-	name = "Bunker Lockdown Button";
-	pixel_y = 8
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 10
 	},
-/obj/machinery/button/door{
-	id = "bosdoors";
-	name = "Bunker Lockdown Button"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/reactor)
 "dor" = (
 /obj/machinery/light/small{
 	light_color = "red"
@@ -7156,10 +6735,14 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
 "dpa" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "dpi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stock_parts/manipulator/pico,
@@ -7189,12 +6772,6 @@
 "dpJ" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/radiation)
-"dpK" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/leisure)
 "dpU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -7233,19 +6810,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/ruin/powered)
 "dqS" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin,
-/obj/item/pen{
-	pixel_y = -1
+/obj/structure/closet/secure_closet/brig,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 6
 	},
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood/armory)
 "dqY" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7282,15 +6852,12 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "dsc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "dsk" = (
 /obj/structure/rack,
 /obj/item/ammo_box/magazine/garand308,
@@ -7387,19 +6954,16 @@
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
-"dtY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname{
-	dir = 9;
-	network = list("Bos")
-	},
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/armory)
 "dum" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "duA" = (
 /obj/machinery/light{
 	dir = 4
@@ -7461,6 +7025,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/tunnel)
+"dwB" = (
+/obj/machinery/light/small,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/reactor)
 "dwW" = (
 /obj/structure/lattice/clockwork,
 /obj/structure/fence/handrail{
@@ -7568,15 +7138,6 @@
 /obj/item/storage/fancy/cigarettes/cigpack_mindbreaker,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/shack)
-"dzq" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/armory)
 "dzx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -7689,16 +7250,11 @@
 	},
 /area/f13/bunker/bunkerthree)
 "dCo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 8;
-	pixel_y = -9
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/dorms)
 "dCv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/circuitboard/machine/chem_heater,
@@ -7757,71 +7313,23 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/sewer/powered)
-"dDI" = (
-/obj/machinery/rnd/production/protolathe,
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster82";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "dDQ" = (
 /obj/machinery/autolathe/constructionlathe,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker/bunkerfive)
 "dDT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = 11;
-	pixel_y = 22
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 4;
-	pixel_y = 10
-	},
-/obj/machinery/computer/terminal{
-	dir = 4;
-	pixel_y = -6;
-	termtag = "Secret"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/armory)
-"dDY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 6
-	},
-/area/f13/brotherhood/reactor)
-"dEc" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
+"dDY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/armory)
 "dEg" = (
 /obj/machinery/blackbox_recorder,
 /obj/structure/cable{
@@ -7830,13 +7338,6 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/overseer)
-"dET" = (
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 1
-	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood/operations)
 "dFc" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-25"
@@ -7854,13 +7355,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker/bunkersix)
-"dFu" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "dFv" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/reagent_dispensers/barrel/three,
@@ -7902,15 +7396,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "dGq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/dorms)
+/obj/machinery/button/crematorium,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operating)
 "dGW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/trash,
@@ -7922,15 +7410,6 @@
 /obj/structure/grille/broken,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
-"dHf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "dHy" = (
 /obj/effect/spawner/lootdrop/f13/traitbooks,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7953,12 +7432,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
 "dHT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/armory)
 "dHU" = (
 /obj/structure/closet/locker,
 /obj/item/stack/sheet/mineral/plasma,
@@ -7989,8 +7468,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer/powered)
 "dIT" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 8
+	},
+/area/f13/brotherhood/operating)
 "dIU" = (
 /obj/structure/bonfire/prelit,
 /obj/machinery/light/small,
@@ -8034,16 +7516,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
-"dKf" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/structure/mirror{
-	pixel_x = 30
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "dKo" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -8151,13 +7623,6 @@
 /obj/item/trash/f13/k_ration,
 /turf/open/floor/plating/rust,
 /area/f13/bunker/bunkersix)
-"dMo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
 "dMt" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/f13{
@@ -8200,12 +7665,15 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
 "dNx" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/operations)
 "dNy" = (
 /mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/plasteel/dark,
@@ -8504,15 +7972,6 @@
 /obj/structure/decoration/warning,
 /turf/closed/wall/rust,
 /area/f13/caves)
-"dVq" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "dVz" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/inside/subway,
@@ -8548,13 +8007,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
-"dWR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/dorms)
 "dXp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -8591,18 +8043,13 @@
 /turf/open/water,
 /area/f13/radiation)
 "dXC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_x = -8;
+	pixel_y = 8
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 5
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/armory)
 "dXD" = (
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain/human,
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain/human,
@@ -8857,17 +8304,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
-"eeH" = (
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "eeL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -8909,16 +8345,6 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/water,
 /area/f13/bunker/bunkereight)
-"egv" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/leisure)
 "egV" = (
 /obj/structure/girder,
 /obj/effect/decal/cleanable/cobweb,
@@ -9104,13 +8530,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
-"ekh" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/weapons/experimental,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "ekv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier4,
 /turf/open/indestructible/ground/inside/subway,
@@ -9189,10 +8608,6 @@
 /obj/structure/spider/stickyweb,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
-"emk" = (
-/obj/structure/fermenting_barrel,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "emo" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -9224,15 +8639,6 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/plasteel,
 /area/f13/sewer)
-"emH" = (
-/obj/machinery/button/door{
-	id = "bosdorm6";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "emK" = (
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/abandoned/o)
@@ -9314,12 +8720,6 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
-"eor" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/leisure)
 "eoJ" = (
 /obj/effect/decal/remains{
 	icon_state = "remains"
@@ -9349,13 +8749,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
-"epZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "eqc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/computer,
@@ -9363,12 +8756,6 @@
 	dir = 4
 	},
 /area/f13/sewer)
-"eqg" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "eqh" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/storage/belt/durathread,
@@ -9415,17 +8802,12 @@
 	},
 /area/f13/bunker/bunkerfive)
 "erw" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosdorm8";
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
-"erJ" = (
-/obj/item/am_shielding_container,
-/turf/open/floor/plating,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/dorms)
 "erK" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /turf/open/indestructible/ground/inside/mountain,
@@ -9486,10 +8868,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/vault/atrium)
 "eub" = (
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/structure/closet/crate/secure/weapon{
+	anchored = 1
 	},
-/area/f13/brotherhood/leisure)
+/obj/item/grenade/f13/frag,
+/obj/item/grenade/f13/frag,
+/obj/item/grenade/stingbang,
+/obj/item/grenade/stingbang,
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood/armory)
 "eud" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -9500,16 +8891,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/building/abandoned/o)
-"eul" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "euo" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag{
@@ -9557,13 +8938,14 @@
 	},
 /area/ruin/powered)
 "evg" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/spawner/lootdrop/weapons/experimental,
+/obj/structure/guncase,
+/obj/item/gun/energy/laser/aer9,
+/obj/item/gun/ballistic/automatic/marksman/worn,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 5
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/armory)
 "evo" = (
 /obj/structure/table,
 /obj/structure/barricade/bars,
@@ -9580,12 +8962,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
-"evG" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "ewm" = (
 /obj/machinery/workbench/advanced,
 /obj/effect/turf_decal/stripes/line{
@@ -9729,9 +9105,16 @@
 /turf/open/floor/f13,
 /area/f13/vault)
 "ezR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
+/obj/structure/rack/shelf_metal,
+/obj/item/ammo_box/a556,
+/obj/item/ammo_box/a556,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 9
+	},
+/area/f13/brotherhood/armory)
 "ezS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/mecha_part_fabricator,
@@ -9753,24 +9136,21 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
-"ezZ" = (
-/obj/item/papercutter,
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "eAf" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/advboards,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
 "eAi" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/brotherhood/rnd)
 "eAl" = (
 /obj/structure/girder,
 /turf/open/floor/plating/tunnel{
@@ -9791,6 +9171,10 @@
 	},
 /turf/open/water,
 /area/f13/sewer)
+"eAw" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "eAB" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -9862,44 +9246,33 @@
 	},
 /area/f13/bunker/bighornbunker)
 "eCx" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/ash/crematorium,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/photosynthetic,
-/obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/operating)
 "eCA" = (
-/obj/structure/fluff/railing{
-	density = 0;
-	dir = 4;
-	pixel_x = 6
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
+/obj/machinery/flasher,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/armory)
 "eCE" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/reactor)
 "eCH" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/spider/stickyweb,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operations)
 "eCI" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/ncr_c_ration,
@@ -9952,24 +9325,12 @@
 	},
 /area/f13/bunker)
 "eDZ" = (
-/obj/machinery/chem_dispenser/drinks{
-	dir = 4;
-	pixel_x = -20;
-	pixel_y = 0
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/shamblers_juice{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/obj/machinery/light/fo13colored/Pink{
-	critical_machine = 1;
-	dir = 8;
-	flicker_chance = 0
-	},
-/obj/structure/table,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "eEb" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21";
@@ -9985,14 +9346,17 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
 "eEr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/structure/rack/shelf_metal,
+/obj/item/twohanded/sledgehammer/supersledge,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/shield/riot/bullet_proof,
+/obj/item/shield/riot/bullet_proof,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/brotherhood/armory)
 "eEA" = (
 /obj/machinery/vending/dinnerware{
 	force_free = 1
@@ -10009,14 +9373,6 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"eEG" = (
-/obj/structure/mopbucket{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/dorms)
 "eFk" = (
 /obj/structure/lattice{
 	density = 1
@@ -10100,14 +9456,14 @@
 	},
 /area/f13/sewer/powered)
 "eGH" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal{
-	dir = 4;
-	pixel_y = -6;
-	termtag = "Secret"
+/obj/item/kirbyplants/random,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/dorms)
 "eGI" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility/gardener,
@@ -10165,22 +9521,11 @@
 	},
 /area/f13/bunker/bunkerseven)
 "eHY" = (
-/obj/effect/turf_decal/arrows/white,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operating)
-"eIc" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/mining)
 "eIp" = (
 /obj/structure/showcase/mecha/marauder,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -10291,22 +9636,14 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "eLm" = (
-/obj/structure/frame/machine,
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/obj/structure/sign/departments/security,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/armory)
 "eLo" = (
 /obj/item/trash/f13/dandyapples,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_common,
 /area/f13/enclave)
-"eLs" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/firelock_frame,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "eLu" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
@@ -10361,19 +9698,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"eMf" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 9
-	},
-/obj/machinery/radioterminal/bos{
-	dir = 8;
-	pixel_x = 27;
-	pixel_y = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "eMv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/ammo,
@@ -10402,19 +9726,12 @@
 /obj/item/ingot/uranium,
 /turf/open/floor/carpet/green,
 /area/f13/radiation)
-"eNi" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "eNl" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 9
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/reactor)
 "eNo" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress4";
@@ -10457,23 +9774,22 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
 "eNP" = (
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/operations)
 "eNY" = (
 /obj/item/trash/f13/c_ration_1,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "eNZ" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/corner,
+/area/f13/brotherhood/armory)
 "eOb" = (
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/indestructible/ground/inside/subway,
@@ -10504,12 +9820,11 @@
 /turf/open/floor/plasteel,
 /area/f13/sewer)
 "eOY" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/dorms)
 "ePo" = (
 /obj/item/storage/firstaid/regular,
 /obj/structure/table,
@@ -10519,15 +9834,10 @@
 	},
 /area/f13/bunker/bunkerthree)
 "ePu" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = -32
-	},
-/obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("Bos")
-	},
+/obj/structure/chair/stool/retro/black,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/chemistry)
 "ePB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -10571,16 +9881,6 @@
 	icon_state = "housewood1-broken"
 	},
 /area/f13/bunker/bighornbunker)
-"eQa" = (
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_x = 32
-	},
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "eQj" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -10594,10 +9894,6 @@
 /obj/item/ammo_box/magazine/m556/rifle/extended/empty,
 /turf/open/floor/f13,
 /area/ruin/powered)
-"eQz" = (
-/obj/structure/safe/floor,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "eQB" = (
 /obj/machinery/light{
 	dir = 1;
@@ -10618,15 +9914,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
 "eRa" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/lighter,
-/obj/structure/curtain{
-	color = "#5c131b";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "eRb" = (
 /obj/effect/decal/cleanable/generic,
@@ -10635,10 +9925,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker/bunkereight)
-"eRg" = (
-/obj/machinery/rnd/server/bos,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "eRi" = (
 /obj/effect/gibspawner/human,
 /obj/effect/decal/cleanable/dirt,
@@ -10755,26 +10041,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/bunker/bunkereight)
-"eTH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/dorms)
-"eTV" = (
-/obj/machinery/hydroponics/constructable{
-	anchored = 0
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
 "eTY" = (
-/obj/structure/bodycontainer/crematorium,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/dorms)
 "eUd" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -10796,15 +10065,23 @@
 /turf/open/water,
 /area/f13/sewer)
 "eUt" = (
-/obj/structure/table,
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "eUR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/limb,
 /obj/item/gun/energy/laser/wattz/magneto,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/ruin/powered)
+"eVf" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/royalblack,
+/area/f13/brotherhood/operations)
 "eVl" = (
 /obj/structure/table,
 /turf/open/floor/plating/tunnel,
@@ -10825,10 +10102,6 @@
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
-"eWv" = (
-/obj/structure/fence/wooden,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "eWB" = (
 /obj/effect/overlay/junk/oldpipes/end,
 /obj/structure/wreck/trash/three_barrels{
@@ -10846,13 +10119,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
-"eXr" = (
-/obj/item/instrument/guitar,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "eXB" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/f13/raider,
@@ -10878,13 +10144,11 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "eYs" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
+/obj/structure/barricade/concrete,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "eYw" = (
@@ -10911,13 +10175,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/vault/security)
-"eYI" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -15
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "eYP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table_frame,
@@ -10983,14 +10240,16 @@
 	},
 /area/f13/bunker)
 "fat" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/chair/sofa/corp/left{
-	dir = 8
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/vending/wallmed{
+	pixel_y = 30;
+	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/armory)
 "faw" = (
 /obj/structure/wreck/trash/one_barrel{
 	pixel_x = -11;
@@ -11051,11 +10310,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault/garden)
-"fcy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "fcJ" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -11358,15 +10612,13 @@
 /turf/closed/wall/rust,
 /area/f13/sewer)
 "fjz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/vending/wallmed{
+	pixel_y = -29
 	},
-/obj/machinery/light/fo13colored/Red{
-	dir = 1
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 6
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/armory)
 "fjN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -11436,6 +10688,16 @@
 	icon_state = "redmark"
 	},
 /area/f13/sewer/powered)
+"flQ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "flU" = (
 /obj/structure/closet/crate{
 	anchored = 1
@@ -11523,11 +10785,6 @@
 /obj/item/mmi/posibrain,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
-"foe" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
-	},
-/area/f13/brotherhood/operating)
 "foF" = (
 /mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/floor/f13{
@@ -11556,11 +10813,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/sewer/powered)
-"foP" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 1
-	},
-/area/f13/brotherhood/reactor)
 "foU" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -11578,12 +10830,15 @@
 	},
 /area/f13/bunker/bunkerthree)
 "fpr" = (
-/obj/machinery/sleeper{
-	density = 1;
-	dir = 4
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder{
+	layer = 3.3;
+	pixel_x = -1;
+	pixel_y = 15
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/chemistry)
 "fpu" = (
 /obj/item/trash/f13/c_ration_1,
 /turf/open/indestructible/ground/inside/subway,
@@ -11611,22 +10866,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"fqC" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 5
-	},
-/obj/structure/mirror{
-	pixel_x = -30
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "fqD" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -11727,57 +10966,6 @@
 /obj/structure/simple_door/wood,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/shack)
-"fuU" = (
-/obj/machinery/light/small,
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "fuX" = (
 /obj/item/twohanded/fireaxe,
 /obj/effect/decal/waste{
@@ -11832,13 +11020,17 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "fwv" = (
+/obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "boscheckpoint";
-	name = "brotherhood shutters"
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8;
+	pixel_y = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "fww" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
@@ -12007,27 +11199,26 @@
 	},
 /area/f13/vault/security/armory)
 "fAe" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/simple_door/bunker/glass{
+	req_access_txt = "120";
+	req_one_access_txt = "120"
 	},
-/obj/item/cigbutt{
-	anchored = 1;
-	color = "#808080";
-	pixel_x = 17;
-	pixel_y = 1
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "fAg" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/low,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/building/abandoned/z)
 "fAl" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 5
+/obj/structure/closet/crate/bin/trashbin,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
 "fAB" = (
 /mob/living/simple_animal/hostile/handy/protectron{
 	auto_fire_delay = 2;
@@ -12043,14 +11234,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
-"fAC" = (
-/obj/item/statuebust,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "fAD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
@@ -12067,23 +11250,16 @@
 	},
 /area/f13/bunker/bunkerthree)
 "fAK" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/hemostat,
-/obj/item/retractor,
-/obj/item/scalpel,
-/obj/item/circular_saw,
-/obj/item/surgicaldrill,
-/obj/item/cautery,
-/obj/item/bonesetter,
 /obj/machinery/light{
-	dir = 1
+	dir = 1;
+	light_color = "#706891";
+	pixel_y = 5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "fAN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
@@ -12108,16 +11284,6 @@
 /mob/living/simple_animal/hostile/ghoul/scorched/ranged,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bighornbunker)
-"fBc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "fBh" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/corner,
@@ -12132,11 +11298,13 @@
 	},
 /area/f13/building/abandoned/o)
 "fBB" = (
-/obj/machinery/vending/wallmed{
-	pixel_x = -30
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/operating)
 "fBF" = (
 /turf/open/floor/f13{
 	dir = 4;
@@ -12160,6 +11328,15 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
+"fCv" = (
+/obj/item/book/manual/wiki/surgery,
+/obj/item/book/manual/wiki/robotics_cyborgs,
+/obj/item/book/manual/wiki/research_and_development,
+/obj/structure/bookcase/manuals,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 6
+	},
+/area/f13/brotherhood/rnd)
 "fCA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
@@ -12190,24 +11367,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/overseer)
 "fDl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/f13foldupchair{
-	dir = 8
+/obj/machinery/rnd/production/protolathe,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "fDr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/structure/rack,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood,
-/obj/item/clothing/suit/armor/medium/combat/brotherhood,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/leisure)
 "fDw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12217,15 +11392,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/atrium)
-"fDC" = (
-/obj/structure/simple_door/house{
-	icon_state = "room"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "fDX" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /obj/effect/decal/cleanable/dirt,
@@ -12355,16 +11521,6 @@
 	},
 /turf/open/floor/f13,
 /area/ruin/powered)
-"fGX" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operating)
 "fHz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -12391,10 +11547,19 @@
 	},
 /area/f13/bunker/bunkerthree)
 "fHU" = (
-/obj/structure/curtain,
-/obj/effect/turf_decal/loading_area/white,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/mining)
+"fId" = (
+/obj/item/flag/bos,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/operations)
 "fIf" = (
 /obj/structure/stacklifter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -12463,16 +11628,8 @@
 	},
 /area/f13/enclave)
 "fJY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/closed/wall/r_wall,
+/area/f13/caves)
 "fKl" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/dirt,
@@ -12539,10 +11696,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
 "fMp" = (
-/obj/structure/simple_door/bunker{
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "Secuirty Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
 /area/f13/brotherhood/reactor)
 "fMv" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12564,13 +11727,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
-"fNa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "fNj" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
 /turf/open/indestructible/ground/inside/mountain,
@@ -12597,16 +11753,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/vault/atrium)
-"fNt" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
-"fNQ" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operating)
 "fNT" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -12663,13 +11809,8 @@
 	},
 /area/f13/bunker/bunkerthree)
 "fPf" = (
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	desc = "A console that is capable of accessing the whole of the Brotherhood of Steel's archives. A very important aspect of their organization, this machine is not to be tampered with. Unless sabotage is your goal.";
-	name = "archive database"
-	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "fPj" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/waste{
@@ -12765,8 +11906,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood/armory)
 "fRO" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -12843,13 +11985,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/enclave)
 "fTu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 4
 	},
-/obj/structure/simple_door/bunker{
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "fTv" = (
 /obj/structure/lattice,
@@ -12871,9 +12012,22 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/corner,
 /area/f13/vault/atrium)
 "fTO" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
+	},
+/area/f13/brotherhood/leisure)
 "fTQ" = (
 /obj/structure/table/reinforced,
 /obj/item/surgical_drapes,
@@ -12951,20 +12105,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
 "fWs" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "boscheckpoint";
-	name = "brotherhood shutters"
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_x = -7;
+	pixel_y = 4
 	},
-/obj/structure/fence/handrail{
-	density = 0;
-	layer = 4.1;
-	pixel_y = -9
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/machinery/power/apc/auto_name/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
 	},
-/obj/structure/railing{
-	dir = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "fWB" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -12985,17 +12137,13 @@
 /turf/closed/indestructible/rock,
 /area/f13/radiation)
 "fXe" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -11;
-	pixel_y = 4
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/obj/machinery/microwave{
-	density = 0;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "fXB" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -13147,15 +12295,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "gbm" = (
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/structure/closet/crate/freezer/blood/anchored,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
+/area/f13/brotherhood/operating)
 "gbn" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/indestructible/ground/inside/mountain,
@@ -13170,17 +12313,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/enclave)
-"gbQ" = (
-/obj/effect/landmark/start/f13/Knight,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "gbW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
@@ -13198,13 +12330,6 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"gcY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "gdb" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
@@ -13291,11 +12416,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/sewer)
 "gfi" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/wood_worn,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/red/corner{
+	dir = 1
+	},
+/area/f13/brotherhood/reactor)
 "gfl" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/rust,
@@ -13334,11 +12461,15 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/sewer)
 "gfU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/leisure)
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "gfV" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	desc = "A deadly close combat robot developed by RobCo in a vaguely feminine, yet ominous chassis. This one seems sleeker and more dangerous, with a slick red paintjob.";
@@ -13364,48 +12495,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
 "ggl" = (
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
+/obj/structure/spider/stickyweb,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "ggw" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
-"ggG" = (
-/obj/item/clothing/shoes/laceup,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/syndicate/brotherhood,
-/obj/item/storage/briefcase,
-/obj/item/clothing/head/HoS/beret/syndicate{
-	name = "officer's beret"
-	},
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
-	},
-/obj/item/pda{
-	icon_state = "pda-hos";
-	name = "Head Scribe's PipBoy"
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "ggL" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/machinery/autolathe,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/machinery/light/floor{
-	critical_machine = 1;
-	flicker_chance = 0
-	},
-/obj/item/cigbutt{
-	anchored = 1;
-	color = "#808080";
-	pixel_x = 11;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "ggU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -13435,21 +12545,11 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "gho" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood/operations)
-"ghv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet,
-/obj/item/clothing/suit/fire,
-/obj/item/clothing/head/helmet/f13/firefighter,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "ghy" = (
 /obj/structure/fence{
 	dir = 1
@@ -13471,13 +12571,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/vault/atrium)
 "gix" = (
-/obj/machinery/vending/hydroseeds{
-	force_free = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/grille,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
 "giD" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/sewer)
@@ -13676,13 +12773,6 @@
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"goh" = (
-/obj/structure/simple_door/bunker/glass,
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "gok" = (
 /obj/machinery/vending/boozeomat,
 /obj/effect/decal/cleanable/dirt,
@@ -13776,12 +12866,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/enclave)
-"gqy" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "gqI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -13801,11 +12885,12 @@
 	},
 /area/f13/bunker/bunkerthree)
 "gqZ" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/armory)
 "grs" = (
 /obj/structure/sign/warning/nosmoking/circle,
 /turf/closed/wall/rust,
@@ -13833,38 +12918,16 @@
 /mob/living/simple_animal/hostile/ghoul/legendary,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
-"grV" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "gsa" = (
-/obj/structure/decoration/hatch{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/sink/kitchen{
-	dir = 4;
-	pixel_x = -13
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/power/terminal{
+	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
 "gsf" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -13883,11 +12946,20 @@
 	},
 /area/f13/tunnel)
 "gsj" = (
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/item/hemostat,
+/obj/item/retractor,
+/obj/item/scalpel,
+/obj/item/circular_saw,
+/obj/item/surgicaldrill,
+/obj/item/cautery,
+/obj/item/bonesetter,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
+/area/f13/brotherhood/operating)
 "gsv" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/tunnel{
@@ -13909,14 +12981,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/bunker)
-"gsK" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/poster/contraband/space_cube{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "gsM" = (
 /obj/structure/closet/crate{
 	anchored = 1
@@ -14012,14 +13076,30 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/enclave)
+"gvu" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	light_color = "green"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
 "gvE" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
 	dir = 8
 	},
 /area/f13/vault/medical/chemistry)
 "gvF" = (
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/storage/firstaid/regular{
+	pixel_y = 5
+	},
+/obj/item/storage/firstaid/regular,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "gvQ" = (
 /obj/structure/chair/comfy/modern{
 	dir = 1
@@ -14196,14 +13276,12 @@
 	},
 /area/f13/bunker)
 "gzj" = (
-/obj/effect/landmark/start/f13/Knight,
-/obj/structure/chair/f13foldupchair{
-	dir = 4
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plating/rust,
 /area/f13/brotherhood/operations)
 "gzw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14237,26 +13315,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
 "gzW" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "gzY" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/table/wood,
@@ -14318,26 +13381,24 @@
 /turf/open/floor/f13,
 /area/f13/bunker)
 "gBR" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
 "gBV" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/closet{
+	anchored = 1
 	},
-/obj/item/restraints/legcuffs,
-/obj/item/storage/box/handcuffs,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/obj/item/clothing/glasses/sunglasses/blindfold,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
 "gBW" = (
 /obj/effect/gibspawner/human,
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
@@ -14365,12 +13426,10 @@
 	},
 /area/ruin/powered)
 "gCc" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "gCf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
@@ -14412,18 +13471,6 @@
 /mob/living/simple_animal/hostile/renegade/grunt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer/powered)
-"gDy" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = -7
-	},
-/obj/machinery/atmospherics/pipe/manifold{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operating)
 "gDO" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/f13/vault_floor/red,
@@ -14451,10 +13498,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "gFb" = (
-/obj/item/statuebust,
-/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/operating)
 "gFt" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -14466,25 +13519,6 @@
 	dir = 4
 	},
 /area/f13/vault/science)
-"gFA" = (
-/obj/structure/decoration/vent{
-	pixel_y = 32
-	},
-/obj/structure/fence/corner/wooden,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
-"gFR" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/grille,
-/obj/structure/window/fulltile/store{
-	layer = 2.9
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "gFT" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/waste{
@@ -14536,18 +13570,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"gGN" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "gGT" = (
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bighornbunker)
@@ -14816,12 +13838,13 @@
 /turf/closed/wall/rust,
 /area/f13/sewer)
 "gMF" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/vending/wallmed{
+	pixel_y = 30;
+	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "gMM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/prewar/poster72{
@@ -14909,16 +13932,6 @@
 /obj/item/reagent_containers/food/condiment/rice,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault/diner)
-"gPr" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "gPB" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/f13,
@@ -14970,6 +13983,17 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"gRo" = (
+/obj/machinery/camera/autoname{
+	dir = 8;
+	name = "Armory Camera";
+	network = list("BoS");
+	pixel_x = -1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/brotherhood/armory)
 "gRq" = (
 /obj/structure/table/wood,
 /obj/item/trash/plate{
@@ -14994,15 +14018,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security/checkpoint)
 "gRz" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/simple_door/bunker{
+	req_access_txt = "120"
 	},
-/obj/item/cane,
-/obj/item/cane,
-/obj/item/roller,
-/obj/item/roller,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "gRO" = (
 /obj/structure/sign/poster/contraband/pinup_bed,
 /turf/closed/wall/r_wall/rust,
@@ -15015,39 +14035,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
 "gSj" = (
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 4;
-	pixel_x = -20;
-	pixel_y = 3
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -8;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -1;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 6;
-	pixel_y = 11
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = -1;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 6;
-	pixel_y = 3
-	},
-/obj/structure/table,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
+/obj/structure/closet/crate/bin/trashbin,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "gSq" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -15072,14 +14063,6 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/sewer)
-"gSK" = (
-/obj/structure/spider/stickyweb,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "gST" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty,
@@ -15123,16 +14106,32 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "gTI" = (
-/obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
-"gTQ" = (
-/obj/structure/barricade/bars,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/armory)
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
+"gTQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/pda{
+	icon_state = "pda-hos";
+	name = "Head Scribe's PipBoy"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/storage/bag/ore,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "gTS" = (
 /obj/structure/fence/end{
 	dir = 4
@@ -15216,15 +14215,9 @@
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/diner)
 "gVI" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/medical)
+/obj/machinery/mineral/ore_redemption,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "gVM" = (
 /obj/structure/barricade/bars,
 /obj/structure/decoration/rag{
@@ -15284,20 +14277,13 @@
 	},
 /area/f13/bunker/bighornbunker)
 "gXb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/structure/lattice{
-	layer = 3
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"gXc" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "aesculapius"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/operating)
 "gXr" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -15363,12 +14349,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bighornbunker)
 "gYT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/structure/sign/directions/engineering,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/reactor)
 "gYU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/start/f13/vaultscientist,
@@ -15402,16 +14385,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless/floorgrime,
 /area/f13/bunker/bunkerthree)
-"gZp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/item/storage/money_stack{
-	pixel_x = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "gZI" = (
 /obj/structure/window/reinforced{
 	color = "#3e3d42";
@@ -15483,11 +14456,13 @@
 	},
 /area/f13/bunker/bunkerthree)
 "haX" = (
-/turf/open/floor/f13{
-	dir = 1;
-	icon_state = "rampdowntop"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/red/corner{
+	dir = 4
+	},
+/area/f13/brotherhood/reactor)
 "hbg" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
@@ -15552,9 +14527,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "hcr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plating/rust,
 /area/f13/brotherhood/operations)
 "hcs" = (
 /obj/structure/chair/office{
@@ -15564,19 +14538,6 @@
 /mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
-"hcw" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 5
-	},
-/obj/structure/mirror{
-	pixel_x = -30
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "hcx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/kebab/rat/double,
@@ -15585,18 +14546,6 @@
 	icon_state = "bar"
 	},
 /area/f13/bunker/bunkersix)
-"hcK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/plush/nukeplushie{
-	desc = "A stuffed toy that resembles a Chinese spy/ The tag claims operatives to be purely fictitious and not stealing your armory.";
-	name = "Knight-Captain Aryom";
-	pixel_x = 9
-	},
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "hdc" = (
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/indestructible/ground/inside/mountain,
@@ -15663,15 +14612,60 @@
 	},
 /area/f13/bunker/bunkerthree)
 "heh" = (
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -6;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -2;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = 2;
+	pixel_y = -10
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice{
-	density = 1
+/obj/item/storage/box/handcuffs{
+	pixel_x = 13;
+	pixel_y = -8
 	},
-/obj/item/trash/can{
-	color = "#808080"
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
+/obj/structure/rack/shelf_metal,
+/obj/item/pda/warden,
+/obj/item/gun/ballistic/shotgun/police,
+/obj/item/ammo_box/shotgun/rubber,
+/obj/item/ammo_box/shotgun/bean,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood/armory)
 "heG" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall/r_wall/f13vault{
@@ -15701,13 +14695,19 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
 "hfp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/f13{
-	icon_state = "stagestairs"
+/obj/item/cane,
+/obj/item/cane,
+/obj/item/roller,
+/obj/item/roller,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operating)
 "hfu" = (
 /obj/machinery/light{
 	pixel_x = 16
@@ -15719,13 +14719,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"hfw" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall";
-	smooth = 1
-	},
-/area/f13/brotherhood/medical)
 "hfx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/stripes/white/line{
@@ -15738,14 +14731,6 @@
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
-"hfJ" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "hfK" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/subway,
@@ -15768,6 +14753,22 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"hgy" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/button/door{
+	id = "bosengine";
+	name = "Radiation Shutters";
+	pixel_x = -32;
+	pixel_y = 4
+	},
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/reactor)
 "hgA" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -15797,13 +14798,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"hgX" = (
-/obj/effect/decal/remains/robot,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
 "hgY" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -15869,6 +14863,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"hig" = (
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "hir" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -16004,17 +15003,6 @@
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"hmc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/camera/autoname{
-	dir = 9;
-	network = list("Bos")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "hmo" = (
 /obj/structure/closet/wardrobe/botanist,
 /obj/item/reagent_containers/glass/bucket/plastic,
@@ -16029,37 +15017,35 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault/garden)
 "hmq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/gps/computer{
-	desc = "A large, central database of currently-transmitting GPS signals.";
-	name = "GPS Ping Grabber."
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"hmF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/vending/hydroseeds{
+	force_free = 1
 	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
+/area/f13/brotherhood/leisure)
+"hmF" = (
+/obj/item/bedsheet/hos,
+/obj/structure/bed,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
 "hmU" = (
-/obj/structure/janitorialcart,
-/obj/item/mop,
-/obj/structure/sink/kitchen{
-	desc = "Strictly for filling up mop buckets.";
-	name = "Mop Sink";
-	pixel_y = 25
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
 	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
+"hnc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner,
+/area/f13/brotherhood/rnd)
 "hnf" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /turf/open/floor/f13{
@@ -16191,10 +15177,6 @@
 /obj/item/stack/sheet/bone,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"hph" = (
-/obj/structure/decoration/rag,
-/turf/closed/wall/mineral/wood,
-/area/f13/brotherhood/leisure)
 "hpC" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	faction = list("wastebot","junker")
@@ -16365,14 +15347,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"htH" = (
-/obj/structure/rack,
-/obj/item/pda/engineering{
-	name = "Knight-Engineer Pip-Boy 3000"
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "htO" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /obj/effect/decal/cleanable/dirt,
@@ -16510,18 +15484,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/sewer/powered)
-"hyH" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
-"hyI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/armory)
 "hzb" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
@@ -16698,15 +15660,6 @@
 "hCe" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/overseer)
-"hCl" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/armory)
 "hCv" = (
 /obj/machinery/light{
 	dir = 8;
@@ -16758,12 +15711,28 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
 "hEs" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/rnd/server/bos,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_x = 16;
+	pixel_y = 34
+	},
+/obj/item/pickaxe/drill/jackhammer{
+	anchored = 1;
+	buckle_prevents_pull = 1;
+	can_be_z_moved = 0;
+	moving_from_pull = 0;
+	pixel_x = 16;
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/brotherhood/rnd)
 "hED" = (
 /turf/open/floor/f13{
 	dir = 4;
@@ -16818,9 +15787,11 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "hFH" = (
-/obj/structure/lattice/catwalk,
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "hFM" = (
 /obj/structure/simple_door/bunker,
@@ -16886,31 +15857,17 @@
 /obj/structure/junk/cabinet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
-"hIr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	layer = 2.9
+"hIv" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosarmoryacc";
+	name = "Mine";
+	req_access_txt = "120"
 	},
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"hIv" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/surgical_drapes,
-/obj/item/stack/sticky_tape/surgical{
-	pixel_x = -11;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
+/area/f13/brotherhood/mining)
 "hIB" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/cleanable/dirt,
@@ -16939,10 +15896,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"hJm" = (
-/obj/item/megaphone,
-/turf/open/floor/wood_worn,
-/area/f13/brotherhood/operations)
 "hJn" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -16964,14 +15917,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/abandoned/o)
 "hJQ" = (
-/obj/structure/lattice{
-	density = 1
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 1
 	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "hKR" = (
 /obj/structure/closet/crate/trashcart/somemoney,
 /obj/effect/spawner/lootdrop/trash,
@@ -16983,11 +15935,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
 "hLk" = (
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/reactor)
 "hLv" = (
 /obj/structure/table,
 /obj/item/ammo_box/a556,
@@ -17000,16 +15952,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/building/abandoned/o)
-"hLK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname{
-	dir = 6;
-	network = list("Bos")
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "hLP" = (
 /mob/living/simple_animal/hostile/ghoul/soldier/armored,
 /turf/open/floor/f13{
@@ -17060,13 +16002,6 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker)
-"hNe" = (
-/obj/structure/kitchenspike_frame{
-	name = "Power armour frame"
-	},
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "hNp" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/midhigh,
@@ -17118,14 +16053,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess,
 /area/f13/enclave)
 "hPf" = (
-/obj/machinery/shower{
-	pixel_y = 24
+/obj/machinery/computer/operating/bos{
+	dir = 1
 	},
-/obj/structure/decoration/vent,
-/obj/structure/window/reinforced/tinted/frosted,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/operating)
 "hPE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/machine,
@@ -17237,15 +16172,15 @@
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
 "hTr" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/light/floor{
-	critical_machine = 1;
-	flicker_chance = 0
+/obj/machinery/power/apc/auto_name/west,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/armory)
 "hTu" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -17278,11 +16213,8 @@
 	},
 /area/f13/vault/science)
 "hTW" = (
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operating)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/mining)
 "hUc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fence/end/wooden{
@@ -17346,21 +16278,6 @@
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"hUC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light/small,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/newspaper{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "hUK" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/ruins,
@@ -17411,21 +16328,12 @@
 	dir = 8
 	},
 /area/f13/radiation)
-"hWx" = (
-/turf/closed/wall/mineral/wood,
-/area/f13/brotherhood/leisure)
 "hWD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice,
 /obj/effect/overlay/junk/oldpipes/vent,
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
-"hWF" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "hWZ" = (
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/inside/subway,
@@ -17452,6 +16360,13 @@
 /obj/machinery/smartfridge/bottlerack/lootshelf/cans,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"hXs" = (
+/obj/machinery/camera/autoname{
+	name = "Secuirty Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "hXE" = (
 /obj/machinery/computer/terminal,
 /obj/structure/table/reinforced,
@@ -17591,10 +16506,6 @@
 	icon_state = "floordirty"
 	},
 /area/f13/bunker/bunkerthree)
-"ibi" = (
-/obj/structure/sign/poster/prewar/poster72,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
 "ibz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -17662,14 +16573,6 @@
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"idS" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "ieh" = (
 /obj/item/clothing/head/helmet/riot/vaultsec,
 /obj/item/clothing/suit/armor/medium/vest/bulletproof/big,
@@ -17762,26 +16665,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/bunker/bunkerthree)
-"ihg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 31
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/structure/decoration/smokeold{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "ihw" = (
 /obj/structure/decoration/rag{
 	icon_state = "skulls"
@@ -17817,21 +16700,6 @@
 	},
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
-"iiV" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/armory)
-"iiZ" = (
-/obj/structure/chair/stool/f13stool{
-	pixel_x = 10;
-	pixel_y = 12
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/medical)
 "ije" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -17978,9 +16846,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
 "imC" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/structure/rack/shelf_metal,
+/obj/item/pickaxe/drill{
+	pixel_y = 3
+	},
+/obj/item/storage/bag/ore,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operating)
+/area/f13/brotherhood/mining)
 "imO" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/sewer/powered)
@@ -18025,18 +16897,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess/redchess2,
 /area/f13/bunker/bunkerfive)
-"inL" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_x = 28;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/armory)
 "inM" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/f13{
@@ -18107,10 +16967,15 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "ipI" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
+/obj/structure/rack/shelf_metal,
+/obj/item/circuitboard/machine/pacman/super,
+/obj/item/circuitboard/machine/pacman/super,
+/obj/item/circuitboard/machine/recharger,
+/obj/item/circuitboard/cryopodcontrol,
+/obj/item/circuitboard/machine/cryo_tube,
+/obj/item/circuitboard/machine/pipedispenser,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
 "ipW" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
@@ -18131,20 +16996,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"iqg" = (
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/structure/closet/anchored,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/operations)
 "iqm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -18194,16 +17045,25 @@
 	},
 /area/f13/bunker/bunkerfive)
 "iri" = (
-/obj/structure/bookcase/manuals/medical,
-/obj/item/hand_labeler,
+/obj/structure/chair/stool/retro/black,
+/obj/effect/landmark/start/f13/scribe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/operations)
 "irp" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"irU" = (
+/obj/structure/bookcase/manuals,
+/obj/item/book/manual/wiki/engineering_singulo_tesla,
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/book/manual/nuka_recipes,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 10
+	},
+/area/f13/brotherhood/rnd)
 "isv" = (
 /obj/structure/fluff/rails,
 /obj/structure/handrail/g_central{
@@ -18418,10 +17278,6 @@
 /obj/structure/obstacle/barbedwire/end,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
-"iwN" = (
-/obj/structure/sign/poster/prewar/poster73,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "iwT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/step_trigger/message{
@@ -18433,18 +17289,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/bunker/bunkerthree)
-"iwU" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "ixd" = (
 /obj/structure/table/wood,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -18466,9 +17310,17 @@
 	},
 /area/ruin/powered)
 "ixN" = (
-/obj/structure/simple_door/bunker,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operating)
 "ixX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/r_wall/f13vault{
@@ -18626,14 +17478,6 @@
 	icon_state = "greenfull"
 	},
 /area/f13/sewer)
-"iDp" = (
-/obj/effect/decal/cleanable/glass,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "iDB" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
@@ -18662,17 +17506,10 @@
 	},
 /area/f13/vault/garden)
 "iDW" = (
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
-"iED" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "iEH" = (
 /obj/structure/table/reinforced,
 /obj/item/kitchen/rollingpin{
@@ -18731,33 +17568,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"iFX" = (
-/obj/structure/closet/crate/secure/weapon{
-	anchored = 1
-	},
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "iGc" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18778,15 +17588,14 @@
 	},
 /area/f13/bunker/bunkersix)
 "iGM" = (
-/obj/effect/decal/cleanable/shreds,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker{
-	name = "Locker Room"
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood/rnd)
 "iGQ" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -18797,11 +17606,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker/bunkerthree)
-"iHk" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
 "iHq" = (
 /mob/living/simple_animal/hostile/raider/junker,
 /obj/machinery/light,
@@ -18810,13 +17614,6 @@
 "iHr" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel)
-"iHv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "iHz" = (
 /mob/living/simple_animal/hostile/centaur,
 /obj/structure/lattice,
@@ -18831,13 +17628,6 @@
 "iHF" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
-"iHP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "iHX" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -18911,18 +17701,13 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "iKj" = (
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/structure/chair/stool/retro/black,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "iKo" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -18939,16 +17724,15 @@
 	},
 /turf/closed/wall/f13/ruins,
 /area/f13/sewer)
-"iKS" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "iKT" = (
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/armory)
 "iLg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -19009,13 +17793,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"iMu" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "iMw" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plasteel/dark,
@@ -19038,13 +17815,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
-"iOp" = (
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "iOq" = (
 /obj/structure/lattice,
 /obj/machinery/light/floor,
@@ -19083,15 +17853,6 @@
 /obj/structure/table/booth,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
-"iPe" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "iPk" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/f13,
@@ -19134,14 +17895,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/enclave)
 "iPM" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice{
-	density = 1
+	layer = 3
 	},
-/obj/structure/fluff/railing{
-	dir = 1
+/obj/structure/rack,
+/obj/item/reagent_containers/glass/bucket,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
 	},
-/turf/open/floor/plating/tunnel,
+/obj/item/storage/bag/trash,
+/turf/open/floor/plasteel/f13/vault_floor/plating/miasma,
 /area/f13/brotherhood/operations)
 "iQf" = (
 /obj/machinery/light/fo13colored/Red{
@@ -19182,16 +17945,8 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "iRs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/f13/inside,
+/obj/structure/sign/departments/science,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "iRU" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -19224,11 +17979,21 @@
 	},
 /area/f13/bunker)
 "iSH" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/structure/closet,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/obj/structure/sign/flag_america_pristine{
+	pixel_y = 29
+	},
+/obj/item/storage/belt/army/assault,
+/obj/item/storage/belt/army/assault,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood/armory)
 "iSL" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -19240,38 +18005,11 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
-"iTk" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/operations)
-"iTq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall";
-	smooth = 1
-	},
-/area/f13/brotherhood/operations)
 "iTC" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"iTD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice{
-	density = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "iTN" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -19300,15 +18038,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
-"iUB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Pink{
-	critical_machine = 1;
-	dir = 1;
-	flicker_chance = 0
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
 "iUF" = (
 /obj/structure/barricade/tentleatheredge{
 	dir = 1
@@ -19354,10 +18083,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/vault/atrium)
 "iVq" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/kirbyplants/random,
+/obj/machinery/vending/wallmed{
+	pixel_y = 30;
+	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
 	},
-/obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "iVt" = (
@@ -19398,22 +18128,10 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/bunker/bunkerthree)
-"iXe" = (
-/obj/structure/dresser,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "iXi" = (
 /obj/machinery/door/password/enclave,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"iXG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "iXH" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13/wood,
@@ -19500,11 +18218,12 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
 "iZL" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/armory)
 "iZN" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -19530,9 +18249,11 @@
 /turf/closed/indestructible/syndicate,
 /area/ruin/powered)
 "jat" = (
-/obj/structure/decoration/vent,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/obj/machinery/chem_heater,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "jaH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -19597,15 +18318,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"jca" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
 "jcp" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -19644,17 +18356,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
 "jcL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/frame/machine,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
-"jcR" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/dorms)
+"jcM" = (
+/obj/structure/chair/f13chair1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
+"jcR" = (
+/obj/structure/simple_door/bunker/glass{
+	req_access_txt = "120";
+	req_one_access_txt = "120"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operating)
 "jcW" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/floor{
@@ -19724,12 +18446,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "jeP" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/table/reinforced,
+/obj/structure/barricade/concrete,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/storage/fancy/candle_box,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operations)
 "jeW" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
@@ -19836,12 +18560,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "jiB" = (
-/obj/machinery/light/small,
-/obj/structure/lattice/catwalk,
-/obj/structure/chair/right{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/structure/chair/sofa/left,
+/obj/effect/landmark/start/f13/Knight,
+/turf/open/floor/carpet/green,
 /area/f13/brotherhood/operations)
 "jiC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19962,16 +18683,9 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "jnJ" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/obj/structure/filingcabinet,
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/operations)
 "jnR" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -19988,15 +18702,11 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/sewer/powered)
 "joH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/turf_decal/bot_red,
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/dorms)
 "joP" = (
 /obj/effect/gibspawner/robot,
 /obj/structure/table/reinforced,
@@ -20013,10 +18723,12 @@
 	},
 /area/f13/bunker/bunkerthree)
 "joW" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/mineral/equipment_vendor,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "jpo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -20042,33 +18754,21 @@
 	},
 /area/f13/bunker/bunkerthree)
 "jpG" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 4
+	},
+/area/f13/brotherhood/operating)
 "jpJ" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
 	},
 /turf/open/water,
 /area/f13/sewer)
-"jpT" = (
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = -16;
-	pixel_y = -5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	layer = 4.1;
-	pixel_y = -9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "jpW" = (
 /obj/structure/bed/dogbed,
 /mob/living/simple_animal/pet/dog/pug,
@@ -20152,10 +18852,6 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
-"jso" = (
-/obj/effect/decal/cleanable/ash/crematorium,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "jsM" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
@@ -20165,24 +18861,17 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
-"jsU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	anchored = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/dorms)
 "jsV" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosarmoryacc";
-	name = "Armory";
-	req_access_txt = "120"
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/armory)
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "jsX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -20379,13 +19068,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker/bunkerfive)
 "jwK" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowleft"
+/obj/structure/closet/crate/bin,
+/obj/machinery/light/small{
+	pixel_x = -10
 	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "jwU" = (
@@ -20483,30 +19169,23 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jzm" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/item/broken_bottle,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/dorms)
 "jzn" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/enclave)
-"jzo" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "jzw" = (
-/obj/item/multitool,
-/obj/structure/rack,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/item/kirbyplants/random,
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
+	},
+/area/f13/brotherhood/rnd)
 "jzC" = (
 /obj/structure/junk/small/bed2,
 /obj/structure/wreck/trash/autoshaft{
@@ -20545,12 +19224,6 @@
 /obj/structure/chair/sofa/right,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
-"jAD" = (
-/obj/structure/decoration/rag{
-	icon_state = "skin"
-	},
-/turf/closed/wall/mineral/wood,
-/area/f13/brotherhood/leisure)
 "jAJ" = (
 /obj/structure/chair/middle{
 	dir = 4
@@ -20571,29 +19244,12 @@
 /obj/structure/rack,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
-"jBi" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "jBp" = (
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/bunker/bunkereight)
-"jBx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "jBy" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
@@ -20639,14 +19295,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/sewer)
-"jEF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "jEG" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
@@ -20658,20 +19306,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"jEJ" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operating)
 "jEO" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosarmoryacc";
-	name = "Mine";
-	req_access_txt = "120"
+/turf/open/floor/f13{
+	icon_state = "reddirtyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/dorms)
 "jEQ" = (
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 1
@@ -20715,14 +19354,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "jFG" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosarmoryacc";
+	name = "Mine";
+	req_access_txt = "120"
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operating)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/mining)
 "jGo" = (
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/f13{
@@ -20752,11 +19390,11 @@
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerfive)
 "jHy" = (
-/obj/machinery/light/small{
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "jHQ" = (
 /mob/living/simple_animal/hostile/raider/junker/creator,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -20809,11 +19447,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/enclave)
-"jJj" = (
-/obj/effect/decal/cleanable/ash/large,
-/obj/effect/decal/cleanable/ash/crematorium,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "jJM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -20840,16 +19473,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/bunker/bunkerthree)
-"jKo" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowright"
-	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "jKq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human{
@@ -20881,17 +19504,6 @@
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"jKO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 5;
-	pixel_x = -7
-	},
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "jKX" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -20924,32 +19536,17 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"jLC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
-"jLG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/armory)
 "jMb" = (
-/obj/structure/toilet{
-	dir = 4
+/obj/structure/bed,
+/obj/item/bedsheet/hos,
+/obj/machinery/button/door{
+	id = "bosdorm6";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/dorms)
 "jMh" = (
 /turf/open/floor/plasteel/stairs{
 	barefootstep = "woodbarefoot";
@@ -20978,28 +19575,12 @@
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
-"jMA" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
 "jMT" = (
 /mob/living/simple_animal/hostile/raider/sulphite,
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"jMZ" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("Bos")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "jNv" = (
 /obj/structure/fluff/hedge,
 /obj/structure/fluff/railing{
@@ -21013,11 +19594,11 @@
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/diner)
 "jNz" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/sign/flag_america_pristine{
+	pixel_y = 29
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/royalblack,
+/area/f13/brotherhood/operations)
 "jNF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/f13/tentwall,
@@ -21033,12 +19614,6 @@
 /obj/structure/cargocrate,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
-"jNT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/operations)
 "jNY" = (
 /obj/machinery/light{
 	dir = 8;
@@ -21153,11 +19728,19 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
 "jRc" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 5
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle,
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = -8;
+	pixel_y = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operating)
+/area/f13/brotherhood/dorms)
 "jRB" = (
 /obj/structure/simple_door/metal/iron,
 /turf/open/floor/f13/wood,
@@ -21318,21 +19901,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bunkersix)
-"jVN" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/junglebush/b,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "jVU" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/waste,
@@ -21352,25 +19920,9 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
-"jWE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/armory)
 "jWK" = (
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
-"jWQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
 "jXj" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -21387,12 +19939,23 @@
 	},
 /area/f13/bunker)
 "jXt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/lattice/catwalk,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
+	},
+/area/f13/brotherhood/leisure)
 "jXu" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -21419,9 +19982,13 @@
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerfive)
 "jXQ" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/filingcabinet,
-/turf/open/floor/wood_common,
+/obj/machinery/light/small{
+	pixel_x = -10
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "jXW" = (
 /obj/structure/closet/crate{
@@ -21535,19 +20102,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"jZJ" = (
-/obj/structure/chair/left,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
-"jZP" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "kaa" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/bundle/f13/multiplas,
@@ -21575,8 +20129,15 @@
 /turf/open/water,
 /area/f13/sewer)
 "kaE" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 8
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "kaL" = (
 /obj/effect/gibspawner/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -21604,12 +20165,6 @@
 	icon_state = "greenfull"
 	},
 /area/f13/caves)
-"kbx" = (
-/obj/effect/decal/cleanable/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "kbU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/raider,
@@ -21716,17 +20271,6 @@
 "kdv" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/atrium)
-"kdU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "kdV" = (
 /obj/effect/decal/cleanable/blood/gibs/human/core,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -21740,6 +20284,15 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"kev" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "kfa" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -21948,19 +20501,6 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/caves)
-"kkH" = (
-/obj/machinery/power/am_control_unit{
-	anchored = 1;
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "kkJ" = (
 /mob/living/simple_animal/hostile/handy/gutsy{
 	faction = list("hostile")
@@ -22117,21 +20657,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
-"kmz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/clothing/head/helmet/f13/combat/brotherhood/initiate,
-/obj/item/clothing/suit/armor/medium/combat/brotherhood/initiate,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "kmI" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
@@ -22284,15 +20809,11 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/vault/security)
 "kqf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice{
-	density = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/armory)
 "kqg" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /turf/open/water,
@@ -22344,23 +20865,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/sewer/powered)
-"kry" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/terminal{
-	dir = 8;
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/mug/coco{
-	pixel_x = -8;
-	pixel_y = 8
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "krC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -22374,11 +20878,9 @@
 	},
 /area/f13/bunker/bunkerseven)
 "krG" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
+/obj/item/am_shielding_container,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/reactor)
 "krW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -22400,18 +20902,6 @@
 "kse" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"ksl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/grille,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "ksu" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -22498,20 +20988,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "kuz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
+/obj/item/mining_scanner,
+/obj/item/mining_scanner,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"kuN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/mining)
 "kuR" = (
-/obj/structure/chair/f13foldupchair,
-/obj/effect/landmark/start/f13/paladin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/mining)
 "kvc" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
@@ -22600,13 +21093,6 @@
 	},
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/operations)
-"kxm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
 "kxM" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker)
@@ -22678,13 +21164,11 @@
 	},
 /area/f13/bunker/bunkerfive)
 "kzQ" = (
-/obj/item/cigbutt/cigarbutt,
-/obj/effect/decal/cleanable/ash/snappop_phoenix,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/wood_common,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "kzR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22715,21 +21199,14 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
 "kAW" = (
-/obj/structure/chair/office/light{
-	dir = 4
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/obj/machinery/button/door{
-	id = "bosengineaccess";
-	name = "Engineering Lockdown";
-	pixel_x = 34;
-	pixel_y = -4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
 "kAX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -22885,17 +21362,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/caves)
-"kGe" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/dorms)
 "kGk" = (
 /obj/machinery/vending/cola/space_up{
 	force_free = 1
@@ -22958,8 +21424,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkerthree)
 "kIr" = (
-/turf/open/floor/wood_worn,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
 "kIt" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"
@@ -23005,6 +21477,15 @@
 /obj/item/stack/ore/blackpowder/two,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"kKl" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "kKm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window,
@@ -23044,11 +21525,14 @@
 	},
 /area/f13/bunker/bunkerthree)
 "kKQ" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
 /area/f13/brotherhood/operations)
 "kKV" = (
 /obj/structure/bed/old,
@@ -23082,16 +21566,6 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"kLv" = (
-/obj/structure/bed,
-/obj/item/bedsheet/hos,
-/obj/item/toy/figure/warden{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	name = "Head Knight Action Figure";
-	toysay = "Victory is our tradition!"
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "kLy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -23240,12 +21714,6 @@
 /obj/item/stack/ore/blackpowder/twenty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"kOt" = (
-/obj/structure/closet/radiation{
-	anchored = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "kOA" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -23281,12 +21749,12 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "kPi" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "bosshop";
-	name = "brotherhood shutters"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosdorm6";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/dorms)
 "kPm" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23382,13 +21850,6 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/sewer/powered)
-"kQL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "kRb" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/dropper{
@@ -23402,19 +21863,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
 /area/f13/enclave)
 "kRg" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner{
+	dir = 8
+	},
+/area/f13/brotherhood/rnd)
 "kRr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/armory)
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operating)
 "kRs" = (
 /obj/structure/wreck/trash/machinepiletwo{
 	pixel_y = 6
@@ -23461,15 +21920,6 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker/bunkerthree)
-"kSJ" = (
-/obj/machinery/camera/autoname{
-	dir = 9;
-	network = list("Bos")
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "kSU" = (
 /obj/structure/closet/crate/footlocker,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
@@ -23477,14 +21927,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker/bighornbunker)
-"kSV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "kSY" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -23551,16 +21993,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"kUn" = (
-/obj/item/paper/crumpled/ruins,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/armory)
 "kUr" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -23630,25 +22062,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerfive)
-"kWb" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "kWe" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -23782,16 +22195,11 @@
 	},
 /area/ruin/powered)
 "kXV" = (
-/obj/structure/table/reinforced,
-/obj/structure/table/reinforced,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "kYd" = (
 /mob/living/simple_animal/hostile/raider/thief,
@@ -23829,17 +22237,11 @@
 	},
 /area/f13/bunker)
 "kYz" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#d8b1b1"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/plating/miasma,
+/area/f13/brotherhood/operations)
 "kYA" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -23867,29 +22269,21 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/medical/surgery)
-"kZv" = (
-/obj/structure/table{
-	pixel_y = 6
-	},
-/obj/structure/fluff/paper/stack,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "kZB" = (
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault/diner)
 "kZC" = (
-/obj/item/toy/figure/chemist{
-	layer = 2.8;
-	name = "Scribe action figure";
-	toysay = "Ad meliora."
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 8
 	},
-/obj/machinery/chem_dispenser,
-/obj/structure/sign/poster/prewar/poster74{
-	pixel_x = 32
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "kZG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -23897,11 +22291,13 @@
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/building/abandoned/o)
 "kZP" = (
-/obj/machinery/smartfridge,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/leisure)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/brotherhood/rnd)
 "laa" = (
 /turf/open/floor/plasteel/vault/side,
 /area/f13/vault/security/armory)
@@ -24032,15 +22428,14 @@
 	},
 /area/ruin/powered)
 "ldy" = (
-/obj/structure/filingcabinet,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "ldz" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/tunnel,
@@ -24068,15 +22463,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"lee" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "leg" = (
 /obj/structure/table,
 /obj/structure/barricade/bars{
@@ -24092,11 +22478,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/f13/radiation)
-"leX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "lfb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/asteroid/line{
@@ -24136,11 +22517,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"lgw" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "lgC" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall,
@@ -24201,24 +22577,9 @@
 /obj/structure/timeddoor,
 /turf/closed/wall/r_wall/rust,
 /area/f13/sewer/powered)
-"lhV" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/dorms)
 "lhX" = (
 /turf/open/floor/carpet/green,
 /area/f13/radiation)
-"lic" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "lie" = (
 /obj/structure/tires/five,
 /turf/open/floor/f13/wood{
@@ -24249,23 +22610,15 @@
 	},
 /area/f13/bunker/bunkerthree)
 "liJ" = (
-/obj/structure/simple_door/bunker{
-	name = "Cleaning Closet"
+/obj/machinery/conveyor/auto{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operating)
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "ljc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "lju" = (
 /obj/structure/table/reinforced,
@@ -24359,12 +22712,6 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/enclave)
-"lkj" = (
-/obj/structure/simple_door/bunker{
-	req_access_txt = "120"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/medical)
 "lkr" = (
 /obj/structure/junk/small/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24404,14 +22751,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
 "llC" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 6
-	},
-/area/f13/brotherhood/reactor)
+/obj/machinery/smartfridge,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/leisure)
 "llJ" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
@@ -24497,13 +22839,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
-"lnx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/operations)
 "lnK" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -24528,28 +22863,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/medical/surgery)
 "loq" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Dorms";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "lor" = (
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
 "loz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/terminal{
-	icon = 'icons/obj/machines/particle_accelerator.dmi';
-	icon_keyboard = "generic_key";
-	icon_screen = "generic";
-	icon_state = "control_boxp"
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "loM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -24621,9 +22948,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
 "lqk" = (
-/obj/item/circuitboard/machine/smes,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
+/obj/item/kirbyplants/random,
+/turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "lqq" = (
 /obj/machinery/vending/sovietsoda,
@@ -24780,27 +23106,6 @@
 "luB" = (
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"luH" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 8;
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/machinery/computer/terminal{
-	dir = 8;
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/armory)
 "luU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera/autoname{
@@ -25008,15 +23313,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/dormitory)
-"lAl" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "lAr" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -25156,21 +23452,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bighornbunker)
 "lCH" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/coffee{
-	pixel_x = -7;
-	pixel_y = 5
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/reagent_containers/food/drinks/coffee{
-	pixel_x = -2;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/coffee{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/crafting/coffee_pot,
-/turf/open/floor/wood_common,
+/obj/item/storage/box/drinkingglasses,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "lCK" = (
 /obj/item/storage/trash_stack{
@@ -25185,20 +23472,6 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"lDk" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/computer/shuttle/bosentryelevator{
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/operations)
 "lDo" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -25305,24 +23578,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/vault/science)
 "lFO" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/armory)
 "lFW" = (
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/inside/mountain,
@@ -25360,11 +23620,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
 "lGX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operating)
 "lHd" = (
 /obj/structure/chair/f13chair1{
 	dir = 4
@@ -25376,18 +23636,16 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"lHg" = (
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/armory)
 "lHj" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/holosign_creator/security{
+	layer = 3.1;
+	name = "Head Knight's holobarrier projector";
+	pixel_y = 7
 	},
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/royalblack,
+/area/f13/brotherhood/operations)
 "lHB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -25423,13 +23681,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
-"lIG" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "lJe" = (
 /obj/structure/sign/poster/contraband/tools{
 	pixel_y = 32
@@ -25440,24 +23691,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"lJk" = (
-/obj/structure/flora/ausbushes/stalkybush,
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/ausbushes/reedbush,
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/operations)
 "lJw" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -25486,13 +23719,6 @@
 	},
 /turf/open/floor/f13,
 /area/f13/vault)
-"lJP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation{
-	anchored = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "lJY" = (
 /obj/item/weldingtool/experimental,
 /obj/structure/table,
@@ -25501,21 +23727,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker/bunkerthree)
-"lKd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/survival_pod,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"lKm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "lKt" = (
 /obj/structure/table/wood/poker,
 /obj/item/locked_box/weapon/range/unique,
@@ -25523,18 +23734,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"lKu" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
-"lKz" = (
-/obj/machinery/computer/operating/bos{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
 "lKA" = (
 /turf/closed/wall/mineral/wood,
 /area/f13/shack)
@@ -25684,6 +23883,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
 "lNB" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/closet/anchored,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_f,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/under/f13/bosformsilver_m,
+/obj/item/clothing/neck/mantle/bos/left,
+/obj/item/clothing/neck/mantle/bos/right,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/neck/mantle/bos/paladin,
+/obj/item/clothing/neck/mantle/bos/paladin,
+/obj/item/clothing/neck/mantle/bos/paladin,
 /turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "lNL" = (
@@ -25739,9 +23959,9 @@
 	},
 /area/ruin/powered)
 "lPN" = (
-/obj/item/kirbyplants/photosynthetic,
+/obj/structure/chair/stool/retro/black,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/operations)
 "lQc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepiletwo,
@@ -25931,37 +24151,39 @@
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/diner)
 "lTn" = (
-/obj/structure/sign/poster/prewar/poster93,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
-"lTI" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/chemistry)
-"lTM" = (
-/obj/machinery/light/fo13colored/Pink{
-	critical_machine = 1;
-	dir = 1;
-	flicker_chance = 0
+/obj/machinery/processor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
 	},
-/turf/open/floor/wood_common,
 /area/f13/brotherhood/leisure)
-"lUa" = (
-/obj/item/stack/cable_coil,
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
-"lUc" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bossecgear";
-	name = "Internal Security Gear";
-	req_access_txt = "120"
+"lTI" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 9
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/rnd)
+"lTM" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
+"lUc" = (
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosdorm7";
+	req_access_txt = "120"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/dorms)
 "lUl" = (
 /obj/structure/curtain{
 	color = "#845f58"
@@ -25979,25 +24201,6 @@
 "lUt" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/vault)
-"lUv" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
-"lUy" = (
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = 16;
-	pixel_y = 35
-	},
-/obj/structure/simple_door/bunker{
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccessrear";
-	name = "Engine Access Shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "lUG" = (
 /obj/effect/overlay/junk/oldpipes,
 /obj/effect/decal/cleanable/dirt,
@@ -26047,23 +24250,6 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13/wood,
 /area/f13/caves)
-"lWG" = (
-/obj/structure/table/wood/bar,
-/obj/machinery/reagentgrinder{
-	pixel_x = -7;
-	pixel_y = 16
-	},
-/obj/item/crafting/coffee_pot{
-	pixel_x = 8;
-	pixel_y = 6
-	},
-/obj/item/storage/box/drinkingglasses{
-	pixel_x = -9;
-	pixel_y = 2
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "lWI" = (
 /turf/closed/mineral/random/no_caves,
 /area/f13/caves)
@@ -26145,15 +24331,35 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
 "lYb" = (
-/obj/machinery/light/fo13colored/Aqua{
-	dir = 4;
-	name = "light fixture"
+/obj/item/am_containment{
+	pixel_x = 3
 	},
+/obj/structure/table/reinforced,
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/item/am_containment,
+/obj/item/am_containment,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/area/f13/brotherhood/armory)
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 5;
+	pixel_y = 4
+	},
+/obj/structure/window/plasma/spawner/north,
+/obj/machinery/door/window/brigdoor,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 5
+	},
+/area/f13/brotherhood/reactor)
 "lYo" = (
 /obj/effect/gibspawner/robot,
 /obj/structure/fluff/railing{
@@ -26177,26 +24383,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault/medical/breakroom)
 "lYH" = (
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/rnd/science_lab,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/dorms)
 "lYY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fireaxecabinet{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/chemistry)
 "lZc" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/dirt{
@@ -26214,8 +24406,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
 "lZy" = (
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
-/area/f13/brotherhood/reactor)
+/obj/structure/weightmachine/weightlifter,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "lZJ" = (
 /obj/docking_port/stationary/bosaway/two{
 	dir = 1;
@@ -26270,9 +24466,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/vault/dormitory)
 "maM" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/bos,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/armory)
 "maO" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/subway,
@@ -26286,24 +24483,17 @@
 	},
 /area/f13/bunker)
 "maT" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 8;
-	pixel_x = 8
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/f13{
+	dir = 1;
+	icon_state = "rampdowntop"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/dorms)
 "maY" = (
 /turf/open/floor/f13{
 	icon_state = "yellowsiding"
 	},
 /area/f13/bunker/bunkerthree)
-"mba" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/armory)
 "mbp" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /obj/effect/decal/fakelattice,
@@ -26368,11 +24558,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
-"mcQ" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/eightball,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
 "mcT" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -26387,13 +24572,14 @@
 /turf/open/floor/f13,
 /area/f13/bunker)
 "mda" = (
-/obj/machinery/vending/hydronutrients{
-	force_free = 1
+/obj/machinery/light/small{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/brotherhood/reactor)
 "mdd" = (
 /obj/structure/rack/shelf_metal{
 	dir = 4
@@ -26471,11 +24657,15 @@
 	},
 /area/ruin/powered)
 "mfS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/sleeper{
+	density = 1;
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 10
+	},
+/area/f13/brotherhood/operating)
 "mfZ" = (
 /obj/structure/destructible/tribal_torch/wall{
 	dir = 8
@@ -26526,33 +24716,16 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/shack)
 "mgY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/grenades{
-	pixel_x = 5;
-	pixel_y = 9
+/obj/structure/curtain{
+	color = "#5c131b"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "mhj" = (
 /obj/structure/table,
 /turf/open/floor/f13,
 /area/f13/bunker)
-"mho" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/grass/wasteland,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/operations)
 "mhv" = (
 /obj/machinery/light/floor,
 /obj/structure/lattice,
@@ -26592,10 +24765,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"mjq" = (
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "mjy" = (
 /obj/structure/chair/wood,
 /turf/open/floor/f13/wood,
@@ -26610,8 +24779,18 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 8
+	},
+/area/f13/brotherhood/reactor)
 "mkx" = (
 /obj/structure/table/reinforced,
 /obj/machinery/dish_drive,
@@ -26704,20 +24883,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/vault/garden)
 "mnP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/mining)
 "moa" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/structure/mirror{
+	pixel_x = 30
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/operations)
 "mod" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/trash/f13/borscht,
@@ -26792,14 +24974,9 @@
 	},
 /area/f13/sewer/powered)
 "mpS" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/flag/bos,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "mpV" = (
 /obj/structure/cable{
@@ -26840,16 +25017,6 @@
 	icon_state = "rubblepillar"
 	},
 /area/f13/radiation)
-"mrj" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/autolathe,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "mro" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier5,
 /turf/open/indestructible/ground/inside/subway,
@@ -26866,15 +25033,6 @@
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
-"mrL" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/painting/library_secure{
-	persistence_id = "brotherhood_secure";
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "mrX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -26882,14 +25040,12 @@
 	},
 /area/f13/bunker/bunkerfive)
 "mrZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
+/obj/structure/punching_bag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "msv" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -26919,22 +25075,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "msR" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 8
 	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/turf/open/water,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "mti" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/lattice{
@@ -27035,14 +25184,6 @@
 	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/building/abandoned/z)
-"mve" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "mvw" = (
 /obj/machinery/porta_turret/f13/turret_556/hostile,
 /turf/open/floor/f13,
@@ -27071,12 +25212,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/ruin/powered)
 "mwf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operating)
 "mwh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27087,21 +25228,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security/checkpoint)
-"mwj" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/box/lights/tubes,
-/obj/item/storage/box/lights/bulbs,
-/obj/item/storage/fancy/candle_box,
-/obj/item/storage/fancy/candle_box,
-/obj/item/lipstick/black,
-/obj/item/storage/box/bodybags{
-	pixel_x = -9;
-	pixel_y = 12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "mwl" = (
 /obj/effect/turf_decal/big{
 	dir = 6
@@ -27115,11 +25241,27 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "mwx" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/table/reinforced,
+/obj/item/card/id/dogtag{
+	pixel_x = 4
 	},
-/obj/item/flag/bos,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/item/card/id/dogtag{
+	pixel_x = 4
+	},
+/obj/item/card/id/dogtag{
+	pixel_x = 4
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_x = -8
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_x = -8
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_x = -8
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood/operations)
 "mwz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27215,14 +25357,9 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "myz" = (
+/obj/machinery/radioterminal/bos,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood/operations)
 "myG" = (
 /obj/structure/spacevine,
@@ -27257,22 +25394,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
-"mzQ" = (
-/obj/structure/table{
-	pixel_y = 6
-	},
-/obj/item/holosign_creator/security{
-	layer = 3.1;
-	name = "Head Knight's holobarrier projector";
-	pixel_y = 7
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "mAe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/glass,
+/obj/item/kirbyplants/photosynthetic,
+/obj/structure/decoration/smokeold{
+	pixel_y = -31
 	},
-/obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "mAf" = (
@@ -27309,15 +25436,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/enclave)
-"mAP" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm9";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/brotherhood/dorms)
 "mBf" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/ammo/fiftypercent,
@@ -27339,29 +25457,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
-"mBy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "mBC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 1;
-	pixel_x = 16;
-	pixel_y = -4
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	layer = 4.1;
-	pixel_y = -9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/dorms)
 "mBF" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -27554,11 +25655,11 @@
 	},
 /area/f13/building/abandoned/o)
 "mEc" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 5
+	},
+/area/f13/brotherhood/armory)
 "mEe" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/nest/assaultron,
@@ -27586,12 +25687,6 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/abandoned/o)
-"mEW" = (
-/obj/machinery/computer/security/wooden_tv{
-	network = list("BoS")
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "mFj" = (
 /obj/machinery/light/floor{
 	light_color = "#ff4500";
@@ -27608,15 +25703,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/sewer/powered)
-"mFK" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
 "mFW" = (
 /obj/effect/gibspawner/human,
 /obj/effect/decal/cleanable/dirt,
@@ -27638,12 +25724,6 @@
 /obj/item/canvas/twentythreeXtwentythree,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"mGe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
 "mGj" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -27661,10 +25741,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
-"mGV" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "mHk" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/floor/f13{
@@ -27693,15 +25769,15 @@
 /obj/effect/spawner/lootdrop/low_loot_toilet,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
-"mHI" = (
-/obj/item/reagent_containers/glass/bucket/wood,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "mHJ" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "mHN" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhighcargo,
@@ -27751,18 +25827,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
 "mJs" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
+/obj/structure/railing,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/jungle,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/dorms)
 "mJw" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -27790,11 +25860,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
-"mKu" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "mKv" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 4
@@ -27886,20 +25951,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "mMm" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
+/obj/structure/table/glass,
+/obj/item/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "mMn" = (
-/obj/machinery/seed_extractor,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/leisure)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/reactor)
 "mMv" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -27965,6 +26033,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"mNI" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "mNJ" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -28030,12 +26108,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/ruin/powered)
 "mQE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/rnd/science_lab,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 5
+	},
+/area/f13/brotherhood/rnd)
 "mQI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -28065,8 +26146,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
 "mRs" = (
-/mob/living/simple_animal/chicken,
-/turf/open/indestructible/ground/inside/dirt,
+/obj/machinery/vending/dinnerware{
+	force_free = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
 /area/f13/brotherhood/leisure)
 "mRM" = (
 /obj/effect/decal/cleanable/dirt{
@@ -28085,13 +26170,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker/bunkerfive)
-"mSg" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/armory)
 "mSl" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks,
@@ -28178,12 +26256,11 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "mTV" = (
-/obj/structure/fluff/railing{
-	dir = 10;
-	pixel_x = -33
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "mUe" = (
 /obj/effect/overlay/junk/mirror{
 	pixel_y = -32
@@ -28229,17 +26306,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
 "mVt" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 6
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/reactor)
 "mVx" = (
 /obj/structure/table/wood/settler,
 /obj/structure/sign/poster/official/anniversary_vintage_reprint{
@@ -28293,13 +26367,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"mWf" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall";
-	smooth = 1
-	},
-/area/f13/caves)
 "mWi" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28336,10 +26403,11 @@
 	},
 /area/ruin/powered)
 "mXb" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 4
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plating/rust,
 /area/f13/brotherhood/operations)
 "mXu" = (
 /obj/structure/lattice,
@@ -28384,27 +26452,24 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bighornbunker)
 "mYd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"mYx" = (
-/obj/structure/simple_door/bunker{
-	name = "Locker Room"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
-"mYy" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
-	dir = 1
+	brightness = 7;
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/brotherhood/armory)
+"mYy" = (
+/obj/structure/table/reinforced,
+/obj/item/documents/syndicate/blue,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/royalblack,
+/area/f13/brotherhood/operations)
 "mYD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -28493,30 +26558,12 @@
 	},
 /area/f13/bunker/bunkersix)
 "nbK" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 1
 	},
-/area/f13/brotherhood/leisure)
-"nbP" = (
-/obj/structure/table/reinforced{
-	req_access_txt = "120"
-	},
-/obj/structure/table/reinforced,
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "nbW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -28551,10 +26598,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/sewer)
-"ncT" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
 "ncU" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -28566,6 +26609,15 @@
 	},
 /turf/open/floor/f13,
 /area/f13/bunker)
+"ncX" = (
+/obj/machinery/camera/autoname{
+	name = "Secuirty Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/reactor)
 "ndd" = (
 /mob/living/simple_animal/hostile/handy/gutsy/nsb,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28637,8 +26689,12 @@
 /turf/open/water,
 /area/f13/sewer)
 "nfd" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/operating)
 "nfh" = (
 /obj/effect/decal/waste{
 	pixel_x = -4;
@@ -28699,29 +26755,30 @@
 	},
 /area/f13/sewer)
 "ngH" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/structure/flora/junglebush/b,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/operations)
-"nhg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/table,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/obj/item/blueprint/research,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/item/flashlight/lamp{
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
+"nhg" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "nhp" = (
 /turf/closed/indestructible/opshuttle{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -28736,16 +26793,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"nhw" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/table,
-/obj/item/trash/f13/electronic/toaster/atomics,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
 "nhx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -28851,11 +26898,6 @@
 	dir = 1
 	},
 /area/f13/vault/diner)
-"niJ" = (
-/obj/structure/table/wood/poker,
-/obj/item/dice/d20,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
 "niQ" = (
 /obj/effect/overlay/junk/mirror{
 	pixel_y = -32
@@ -28865,16 +26907,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
-"niU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/radiation{
-	anchored = 1
-	},
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "njC" = (
 /obj/effect/decal/waste{
 	pixel_x = -5;
@@ -28882,17 +26914,6 @@
 	},
 /turf/open/water,
 /area/f13/radiation)
-"njH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/sign/painting/library_secure{
-	persistence_id = "brotherhood_secure";
-	pixel_y = 32
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
 "njI" = (
 /obj/structure/table/abductor,
 /obj/item/reagent_containers/hypospray/combat/omnizine,
@@ -28955,12 +26976,7 @@
 /area/f13/building/abandoned/o)
 "nlw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/mug/coco{
-	pixel_x = 4;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
 "nlA" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -28970,9 +26986,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
 "nlB" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/structure/simple_door/bunker/glass{
+	req_access_txt = "120";
+	req_one_access_txt = "120"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "nlJ" = (
 /mob/living/simple_animal/hostile/handy/gutsy{
 	faction = list("hostile")
@@ -29046,24 +27066,14 @@
 	dir = 1
 	},
 /area/f13/vault/atrium)
-"nnE" = (
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_x = 16;
-	pixel_y = 34
+"nnI" = (
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/gun/energy/pulse{
-	anchored = 1;
-	cell_type = null;
-	desc = "A heavy-duty, multifaceted energy rifle with three modes. Preferred by front-line combat personnel. This one is for display, and no longer fires.";
-	name = "display pulse rifle";
-	pin = null;
-	pixel_x = 16;
-	pixel_y = 29
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 8
 	},
-/obj/machinery/computer/card/bos,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "nnM" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -29095,6 +27105,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
+"noV" = (
+/obj/structure/sign/poster/prewar/poster72,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/armory)
 "npd" = (
 /obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/plating/tunnel,
@@ -29120,13 +27134,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
-"nqG" = (
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
-	name = "Head Scribe's Archive Terminal"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "nrd" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/f13{
@@ -29199,13 +27206,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/sewer)
 "nsx" = (
-/obj/structure/window/reinforced/clockwork/fulltile,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/structure/closet/fridge,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "nsD" = (
 /mob/living/simple_animal/hostile/handy/robobrain{
 	auto_fire_delay = 2;
@@ -29270,12 +27282,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/enclave)
-"nut" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
 "nuv" = (
 /obj/structure/rack,
 /turf/open/floor/plasteel/f13/stone,
@@ -29359,11 +27365,6 @@
 /obj/structure/rack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"nvv" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "nvy" = (
 /obj/structure/wreck/trash/two_barrels{
 	pixel_y = 13
@@ -29412,14 +27413,20 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess/whitepurplechess2,
 /area/f13/enclave)
 "nwq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
 	},
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 6
+	},
+/area/f13/brotherhood/armory)
 "nwD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -29520,13 +27527,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security/checkpoint)
-"nym" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "nyu" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -29534,26 +27534,6 @@
 "nyy" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/bunker)
-"nyS" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/machinery/light/small{
-	dir = 4;
-	layer = 2.7;
-	pixel_y = 17
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "nyW" = (
 /obj/structure/simple_door/tentflap_cloth,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -29588,16 +27568,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"nzI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 8
-	},
-/area/f13/brotherhood/reactor)
 "nzX" = (
 /turf/closed/wall/rust,
 /area/f13/bunker/bunkerfive)
@@ -29699,11 +27669,59 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "nCC" = (
-/obj/machinery/atmospherics/pipe/simple,
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
+/obj/machinery/light/small,
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/clothing/neck/stethoscope{
+	pixel_x = 6;
+	pixel_y = 9
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/item/flashlight/pen{
+	pixel_x = -5;
+	pixel_y = -7
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operating)
 "nCU" = (
 /mob/living/simple_animal/hostile/handy/gutsy/nsb,
@@ -29722,6 +27740,15 @@
 	dir = 8
 	},
 /area/f13/vault/atrium)
+"nDr" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/storage/money_stack{
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "nDz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -29761,11 +27788,14 @@
 	},
 /area/f13/bunker)
 "nDM" = (
-/obj/structure/sign/poster/prewar/poster94{
-	icon_state = "poster81"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/obj/machinery/gear_painter,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 10
+	},
+/area/f13/brotherhood/armory)
 "nDO" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/garbagetomid,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -29805,22 +27835,13 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "nEO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
-/obj/item/reagent_containers/glass/rag/towel,
-/obj/machinery/light/small{
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
-	},
-/area/f13/brotherhood/dorms)
-"nER" = (
-/obj/machinery/autolathe/ammo,
-/obj/item/book/granter/crafting_recipe/gunsmith_three,
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
 	},
 /area/f13/brotherhood/armory)
 "nEV" = (
@@ -29916,48 +27937,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
-"nGN" = (
-/obj/structure/flora/rock/jungle{
-	density = 1
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/grassybush{
-	layer = 2.1
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/turf/open/water,
-/area/f13/brotherhood/leisure)
 "nGT" = (
 /obj/structure/frame/machine,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/radiation)
-"nGX" = (
-/obj/machinery/computer/arcade/orion_trail,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
-"nHa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/fence/handrail_end/non_dense{
-	dir = 4;
-	pixel_y = -9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "nHc" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/corner{
 	dir = 4
@@ -29976,23 +27959,10 @@
 /turf/open/water,
 /area/f13/radiation)
 "nHG" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/flora/ausbushes,
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/water,
-/area/f13/brotherhood/operations)
+/obj/structure/table/reinforced,
+/obj/machinery/button/flasher,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/armory)
 "nHO" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel,
@@ -30027,12 +27997,10 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/vault/atrium)
 "nIW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/turf/open/floor/f13{
+	icon_state = "redmark"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/reactor)
 "nJb" = (
 /obj/structure/fence/door,
 /turf/open/indestructible/ground/inside/subway,
@@ -30148,21 +28116,11 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/f13/vault/diner)
-"nND" = (
-/obj/item/flashlight/lamp{
-	pixel_x = -14;
-	pixel_y = 9
-	},
-/obj/item/reagent_containers/food/drinks/mug/tea{
-	name = "bitter black coffee";
-	pixel_x = 4;
-	pixel_y = 7
-	},
-/obj/structure/table{
-	pixel_y = 6
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+"nNC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair1,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operating)
 "nNL" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/greenglow,
@@ -30260,10 +28218,6 @@
 /obj/structure/girder,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"nQi" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "nQv" = (
 /obj/machinery/iv_drip/primitive{
 	pixel_x = 12;
@@ -30508,12 +28462,18 @@
 	},
 /area/f13/vault/atrium)
 "nWa" = (
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	name = "Armoury"
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/obj/item/pda/medical{
+	name = "Scribe-Medic Pip-Boy 3000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operating)
 "nWg" = (
 /obj/structure/junk/small/bed,
 /mob/living/simple_animal/hostile/ghoul/soldier,
@@ -30752,9 +28712,12 @@
 	},
 /area/f13/bunker/bunkerthree)
 "ocx" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
-/area/f13/brotherhood/reactor)
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "ocI" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"
@@ -30765,37 +28728,25 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/dormitory)
 "odh" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/shuttle_manipulator{
-	desc = "You have no idea what this shows.";
-	name = "old hologram";
-	pixel_x = 16;
-	pixel_y = -16
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/machinery/shuttle_manipulator{
-	desc = "You have no idea what this shows.";
-	icon_state = "hologram_ship";
-	name = "old hologram";
-	pixel_x = 14;
-	pixel_y = 9
-	},
-/obj/machinery/shuttle_manipulator{
-	desc = "You have no idea what this shows.";
-	icon_state = "hologram_on";
-	name = "old hologram";
-	pixel_x = 16;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "odp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/simple_door/bunker/glass{
+	req_access_txt = "120";
+	req_one_access_txt = "120"
 	},
-/area/f13/brotherhood/armory)
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operating)
 "odz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/kebab/human{
@@ -30832,9 +28783,9 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "oez" = (
-/obj/effect/landmark/start/f13/Knight,
-/obj/structure/chair/f13foldupchair{
-	dir = 4
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
@@ -30854,19 +28805,6 @@
 /obj/effect/spawner/bundle/f13/marksman,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"ofk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors";
-	name = "brotherhood shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "ofp" = (
 /obj/machinery/vending/cigarette/syndicate,
 /obj/machinery/light{
@@ -30890,11 +28828,11 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "ofQ" = (
-/obj/structure/decoration/smokeold{
-	pixel_y = -31
+/obj/machinery/conveyor/auto{
+	dir = 1
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "ofR" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gibbearcore"
@@ -30906,14 +28844,6 @@
 "ofV" = (
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
-"ofZ" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/dorms)
 "ogf" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor7-old"
@@ -30979,21 +28909,9 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
 "ois" = (
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/blueprint/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/item/flashlight/lamp{
-	light_color = "#00FFFF";
-	pixel_x = -14;
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/sign/departments/examroom,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operating)
 "oiE" = (
 /obj/structure/table,
 /obj/item/trash/f13/c_ration_3,
@@ -31070,19 +28988,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/enclave)
-"oku" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/vending/clothing/bos{
-	density = 0;
-	pixel_x = 32
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "oky" = (
 /obj/structure/wreck/trash/engine,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31176,14 +29081,17 @@
 	},
 /area/f13/bunker/bunkerthree)
 "omW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/generic,
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 5
+	},
+/area/f13/brotherhood/armory)
 "onv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
 /turf/open/indestructible/ground/inside/mountain,
@@ -31200,8 +29108,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/overseer)
 "onR" = (
-/obj/effect/turf_decal/stripes/white/line{
-	pixel_x = -6
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks/beer,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
@@ -31230,20 +29140,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkerthree)
 "ooN" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/door/airlock/grunge{
+	name = "Combat Caste Office";
+	req_access_txt = "120"
 	},
-/obj/item/storage/firstaid/regular{
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/regular,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/operations)
 "opb" = (
 /obj/structure/lattice,
 /obj/structure/chair/stool,
@@ -31375,12 +29278,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker/bighornbunker)
-"oqW" = (
-/obj/effect/landmark/start/f13/Knight,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "oqY" = (
 /obj/machinery/power/terminal,
 /obj/machinery/power/terminal{
@@ -31557,12 +29454,11 @@
 /turf/open/floor/plasteel/airless/floorgrime,
 /area/f13/bunker/bunkerfive)
 "ouH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/left{
-	dir = 4
-	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/dorms)
 "ouS" = (
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/building/abandoned/o)
@@ -31595,13 +29491,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker/bighornbunker)
-"ovy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "ovB" = (
 /obj/structure/table/booth,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -31646,10 +29535,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"owJ" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operating)
 "oxg" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/waste{
@@ -31679,13 +29564,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
-"oxW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "oxY" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -31704,17 +29582,6 @@
 /obj/structure/table_frame/wood,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
-"oyg" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/flag/bos,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "oyr" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
@@ -31773,14 +29640,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bighornbunker)
 "ozU" = (
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 1
-	},
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
 "oAc" = (
 /obj/machinery/light{
 	dir = 8
@@ -31903,10 +29767,17 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
 "oCO" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/leisure)
+/obj/structure/table/glass,
+/obj/item/integrated_circuit_printer,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/integrated_electronics/analyzer,
+/obj/item/integrated_electronics/debugger,
+/obj/item/integrated_electronics/detailer,
+/obj/item/integrated_electronics/wirer,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "oCS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -31922,12 +29793,6 @@
 /obj/structure/barricade/wooden/crude,
 /turf/closed/wall/rust,
 /area/f13/sewer)
-"oDC" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "oDL" = (
 /obj/structure/closet/crate/medical,
 /obj/item/reagent_containers/hypospray/medipen/stimpak{
@@ -31999,16 +29864,13 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "oFJ" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/obj/item/clothing/under/rank/prisoner,
-/turf/open/floor/f13{
-	icon_state = "redmark"
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 1
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/reactor)
 "oFK" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -32066,6 +29928,17 @@
 /obj/effect/spawner/lootdrop/securityloot,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"oHB" = (
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "oHD" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -32112,17 +29985,9 @@
 	},
 /area/f13/building/abandoned/o)
 "oJi" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/recharger,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
+/obj/effect/landmark/start/f13/elder,
+/turf/open/floor/carpet/royalblack,
+/area/f13/brotherhood/operations)
 "oJs" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -32143,14 +30008,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/dormitory)
 "oKj" = (
-/obj/structure/closet/crate/freezer/blood,
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8;
-	pixel_y = 10
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/chemistry)
 "oKs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -32287,9 +30147,17 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "oNz" = (
-/obj/structure/simple_door/bunker/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/structure/curtain,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -15
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operating)
 "oNB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
@@ -32305,12 +30173,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"oNR" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "oOe" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom";
@@ -32482,14 +30344,6 @@
 	icon_state = "greenfull"
 	},
 /area/f13/building/abandoned/o)
-"oRO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/decal/cleanable/robot_debris/old,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "oSc" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/stone,
@@ -32535,18 +30389,12 @@
 /turf/closed/wall/f13/wood,
 /area/f13/sewer/powered)
 "oTo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood/operations)
 "oTG" = (
 /obj/structure/wreck/trash/five_tires{
@@ -32657,12 +30505,6 @@
 /obj/structure/simple_door/metal/iron,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
-"oWp" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operating)
 "oWv" = (
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/inside/subway,
@@ -32748,16 +30590,29 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building/abandoned/o)
 "pae" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
-"pag" = (
 /obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/cell_charger{
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
+"pag" = (
+/obj/item/kirbyplants/random,
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
 /area/f13/brotherhood/rnd)
 "pas" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32765,12 +30620,6 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
-"pav" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/dorms)
 "paD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/fluff/hedge,
@@ -32780,10 +30629,6 @@
 /obj/machinery/telecomms/server/presets/town_pd,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
-"paM" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/dorms)
 "paQ" = (
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -32815,10 +30660,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker/bunkerthree)
-"paZ" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operating)
 "pbb" = (
 /obj/docking_port/stationary/bosaway/four{
 	dir = 1;
@@ -32829,22 +30670,15 @@
 	},
 /area/f13/caves)
 "pbr" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "boscheckpoint";
-	name = "brotherhood shutters"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/operations)
 "pbu" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
 "pbF" = (
-/obj/structure/table/glass,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/poster/contraband/power,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
 "pbI" = (
 /obj/structure/barricade/sandbags,
@@ -32854,33 +30688,32 @@
 	},
 /area/f13/bunker)
 "pcg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/bench,
-/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid{
-	icon_state = "whiterustysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/dorms)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "pcq" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
 "pcy" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/machinery/reagentgrinder{
-	pixel_x = -7;
-	pixel_y = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
 "pcL" = (
-/obj/structure/simple_door/metal/barred{
-	req_one_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
 	},
 /area/f13/brotherhood/armory)
 "pdc" = (
@@ -33015,12 +30848,11 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "phC" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Combat Caste Office";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "phE" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33169,12 +31001,13 @@
 	},
 /area/f13/sewer/powered)
 "pmg" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/janitorialcart,
+/obj/item/mop,
+/turf/open/floor/plasteel/f13/vault_floor/plating/miasma,
+/area/f13/brotherhood/operations)
 "pmm" = (
 /obj/machinery/vending/robotics,
 /turf/open/floor/f13{
@@ -33200,9 +31033,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
 "pmS" = (
-/obj/structure/decoration/rads,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
+/obj/item/kirbyplants/random,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "pnk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink/kitchen{
@@ -33245,17 +31079,11 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker/bunkerthree)
 "pop" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 1
 	},
-/obj/item/paper_bin{
-	pixel_y = 8
-	},
-/obj/item/pen{
-	pixel_y = 9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operating)
 "poF" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /obj/effect/decal/waste,
@@ -33341,18 +31169,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/sewer)
 "ppU" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
 "ppW" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/effect/landmark/start/f13/knightcap,
+/turf/open/floor/carpet/royalblack,
+/area/f13/brotherhood/operations)
 "pqe" = (
 /obj/structure/fluff/hedge,
 /obj/structure/fluff/railing/corner{
@@ -33370,9 +31192,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "pqN" = (
-/obj/machinery/newscaster,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/armory)
 "prq" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -33385,16 +31206,6 @@
 /mob/living/simple_animal/hostile/poison/giant_spider,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
-"prv" = (
-/obj/structure/closet/secure_closet/hydroponics{
-	desc = "A locker that smells of soil.";
-	name = "gardening locker";
-	req_access = list(120)
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "prz" = (
 /obj/effect/landmark/start/f13/vaultdoctor,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
@@ -33442,16 +31253,6 @@
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
-"psU" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "ptl" = (
 /obj/effect/decal/cleanable/blood,
 /mob/living/simple_animal/hostile/raider/ranged,
@@ -33479,13 +31280,6 @@
 "ptU" = (
 /turf/open/floor/plasteel/darkred,
 /area/f13/vault/security)
-"ptW" = (
-/obj/machinery/light,
-/obj/machinery/vending/wardrobe/chem_wardrobe{
-	force_free = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
 "ptZ" = (
 /obj/structure/table,
 /obj/machinery/light/broken,
@@ -33591,14 +31385,13 @@
 	},
 /area/f13/tunnel)
 "pwo" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm6";
-	req_access_txt = "120"
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13{
-	icon_state = "purplefull"
-	},
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operating)
 "pwr" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	icon_state = "floor4-old"
@@ -33611,14 +31404,6 @@
 /obj/machinery/suit_storage_unit/mining,
 /turf/open/floor/plasteel/f13,
 /area/f13/vault/atrium)
-"pwJ" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	layer = 2.7;
-	name = "prewar lounge chair"
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "pwN" = (
 /obj/structure/chair/f13foldupchair,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33643,16 +31428,6 @@
 /obj/structure/barricade/wooden/planks,
 /turf/closed/wall/f13/ruins,
 /area/f13/sewer)
-"pxl" = (
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "pxr" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib2-old"
@@ -33660,10 +31435,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "pxz" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 8
+	},
+/area/f13/brotherhood/operating)
 "pxD" = (
 /obj/effect/decal/waste,
 /turf/open/indestructible/ground/outside/ruins,
@@ -33695,12 +31472,11 @@
 	},
 /area/f13/vault/atrium)
 "pxX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/spider/stickyweb,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "pyr" = (
 /obj/structure/barricade/train,
@@ -33716,13 +31492,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/medical/surgery)
-"pyQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "pza" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -33829,10 +31598,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
-"pBi" = (
-/obj/machinery/button/crematorium,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "pBG" = (
 /obj/structure/fluff/hedge,
 /obj/structure/lattice/catwalk,
@@ -33889,10 +31654,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"pCD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "pCF" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	desc = "A deadly close combat robot developed by RobCo in a vaguely feminine, yet ominous chassis. This one seems sleeker and more dangerous, with a slick red paintjob.";
@@ -33909,15 +31670,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
-"pCJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "pCR" = (
 /turf/closed/wall/r_wall,
 /area/f13/sewer/powered)
@@ -33970,9 +31722,8 @@
 /turf/closed/wall/f13/wood,
 /area/f13/sewer/powered)
 "pEl" = (
-/obj/structure/closet/wardrobe/pjs,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "pEE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/contraband/bountyhunters{
@@ -34047,9 +31798,8 @@
 	},
 /area/f13/sewer/powered)
 "pFU" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/turf/closed/wall/r_wall/rust,
+/area/f13/brotherhood/mining)
 "pFW" = (
 /obj/machinery/porta_turret/f13/turret_shotgun/raider{
 	dir = 5
@@ -34067,13 +31817,6 @@
 	icon_state = "dark"
 	},
 /area/f13/sewer/powered)
-"pGA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate/bin{
-	anchorable = 0
-	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "pGI" = (
 /obj/effect/landmark/start/f13/vaultscientist,
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
@@ -34174,21 +31917,15 @@
 	},
 /area/ruin/powered)
 "pId" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/vault{
-	name = "Engine Access";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
-"pIe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/kirbyplants/photosynthetic,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/vending/wallmed{
+	pixel_y = 30;
+	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/dorms)
 "pIl" = (
 /obj/structure/timeddoor,
 /obj/structure/decoration/warning{
@@ -34197,12 +31934,12 @@
 /turf/closed/wall/r_wall,
 /area/f13/sewer/powered)
 "pIq" = (
-/obj/item/crowbar{
-	pixel_x = 31
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/noticeboard{
-	dir = 8;
-	pixel_x = 33
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
@@ -34294,43 +32031,20 @@
 /obj/machinery/gibber/autogibber,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"pLO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "pLS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/neutral,
 /area/f13/enclave)
-"pLX" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "boscheckpoint";
-	name = "brotherhood shutters"
-	},
-/obj/structure/fence/handrail{
-	density = 0;
-	layer = 4.1;
-	pixel_y = -9
-	},
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "pMe" = (
-/obj/machinery/workbench,
-/obj/structure/sink/kitchen{
-	dir = 8;
-	pixel_x = 12
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/f13{
+	icon_state = "redmark"
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/reactor)
 "pMg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -34373,9 +32087,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "pNK" = (
-/obj/structure/frame/machine,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	dir = 1;
+	pixel_y = -1
+	},
+/obj/machinery/computer/terminal{
+	dir = 4;
+	pixel_x = -3;
+	pixel_y = -3;
+	termtag = "Business"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
 "pNV" = (
 /turf/open/water,
 /area/f13/sewer)
@@ -34448,9 +32176,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
 "pPd" = (
-/obj/structure/sign/poster/prewar/poster61,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 9
+	},
+/area/f13/brotherhood/armory)
 "pPu" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway,
@@ -34505,14 +32237,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"pQp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/toy/xmas_cracker,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
 "pQs" = (
 /obj/structure/girder,
 /obj/structure/grille/broken,
@@ -34592,26 +32316,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"pSq" = (
-/obj/structure/closet,
-/obj/item/storage/box/gloves,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/tank/internals/anesthetic,
-/obj/item/wrench/medical,
-/obj/item/toy/figure/cmo{
-	desc = "A refurbished military action figure made to look like a member of the Brotherhood of Steel.";
-	layer = 2;
-	name = "Head Scribe Action Figure";
-	toysay = "Ad astra per aspera."
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
 "pSr" = (
 /obj/effect/decal/remains/human,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
@@ -34621,17 +32325,12 @@
 	},
 /area/f13/bunker/bunkerthree)
 "pSA" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/computer/rdconsole/core/bos{
-	dir = 4;
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal"
-	},
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/dorms)
 "pSD" = (
 /obj/structure/table,
 /obj/item/megaphone/command{
@@ -34760,12 +32459,10 @@
 	},
 /area/f13/sewer/powered)
 "pWn" = (
-/obj/machinery/light/small{
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/armory)
 "pWw" = (
 /obj/machinery/conveyor/auto{
 	dir = 4
@@ -34773,9 +32470,14 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "pWD" = (
-/obj/structure/bookcase/manuals/engineering,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/structure/sink{
+	pixel_y = 22
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
 "pWF" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -34786,11 +32488,11 @@
 /turf/closed/wall/r_wall,
 /area/f13/enclave)
 "pWN" = (
-/turf/open/floor/f13{
-	color = "#f7e8e1";
-	icon_state = "rampdowntop"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
 "pWT" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/inside/subway,
@@ -34869,13 +32571,6 @@
 	dir = 8
 	},
 /area/f13/vault/atrium)
-"pYB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/rnd/science_lab,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "pYG" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -34887,6 +32582,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/radiation)
+"pYI" = (
+/obj/item/book/manual/nuclear,
+/obj/item/book/manual/wiki/detective,
+/obj/structure/bookcase/manuals,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
+/area/f13/brotherhood/rnd)
 "pYR" = (
 /obj/machinery/plumbing/pill_press,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -34913,10 +32614,6 @@
 	icon_state = "r_wall"
 	},
 /area/f13/bunker/bunkertwo)
-"pZu" = (
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "pZC" = (
 /obj/effect/decal/cleanable/blood/gibs{
 	icon_state = "gibup1"
@@ -34980,22 +32677,18 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/sewer/powered)
 "qaR" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "twindowold"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
+/obj/structure/toilet{
+	pixel_y = 10
 	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/operations)
 "qaU" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
@@ -35099,28 +32792,6 @@
 	dir = 8
 	},
 /area/f13/vault/science)
-"qdj" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "qdv" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -35144,11 +32815,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
 "qdV" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/structure/closet/secure_closet/hydroponics{
+	desc = "A locker that smells of soil.";
+	name = "gardening locker";
+	req_access = list(120)
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/leisure)
 "qej" = (
 /obj/structure/wreck/trash/five_tires{
 	pixel_y = 14
@@ -35188,11 +32865,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"qeB" = (
-/obj/structure/bed,
-/obj/item/bedsheet/brown,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "qeH" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -35322,18 +32994,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
 "qgp" = (
-/obj/structure/lattice{
-	layer = 3
-	},
-/obj/item/cigbutt{
-	anchored = 1;
-	color = "#808080";
-	layer = 2;
-	pixel_x = -4;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/rack,
+/obj/item/trash/f13/electronic/toaster/atomics,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "qgz" = (
 /obj/structure/wreck/trash/machinepile,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35378,15 +33042,15 @@
 	},
 /area/f13/sewer)
 "qhz" = (
-/obj/machinery/light/small{
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 4
 	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/neck/stethoscope,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/reactor)
 "qhL" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -35508,12 +33172,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/white/whitepurplechess,
 /area/f13/enclave)
 "qkl" = (
-/obj/structure/decoration/smokeold{
-	pixel_x = 32
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/chem_lab,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/brotherhood/reactor)
 "qkm" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
@@ -35557,17 +33222,9 @@
 	},
 /area/f13/bunker)
 "qlm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operating)
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
+/area/f13/brotherhood/rnd)
 "qlx" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
 /obj/machinery/light{
@@ -35627,16 +33284,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
 "qmx" = (
-/obj/structure/rack,
-/obj/item/shield/riot/bullet_proof,
-/obj/item/shield/riot/bullet_proof,
-/obj/item/pda{
-	icon_state = "pda-warden";
-	name = "Armory Warden PDA"
+/obj/machinery/door/airlock/hatch{
+	name = "Backup Power";
+	req_access_txt = "120"
 	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/brotherhood/armory)
 "qmH" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
@@ -35717,9 +33370,15 @@
 	},
 /area/f13/bunker/bunkerfive)
 "qoc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 6
 	},
 /area/f13/brotherhood/armory)
 "qoq" = (
@@ -35780,13 +33439,6 @@
 "qpr" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/side,
 /area/ruin/powered)
-"qpy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
 "qpB" = (
 /obj/machinery/hydroponics/constructable,
 /obj/structure/sign/poster/official/hydro_ad{
@@ -35795,11 +33447,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault/garden)
 "qpN" = (
-/obj/machinery/vending/wardrobe/medi_wardrobe{
-	force_free = 1
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosarmoryacc";
+	name = "Mine";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/dorms)
 "qqL" = (
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
@@ -35846,12 +33500,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault/diner)
 "qrv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/weightmachine/stacklifter,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/dorms)
 "qrI" = (
 /obj/machinery/jukebox,
 /turf/open/floor/f13/wood,
@@ -35915,14 +33569,6 @@
 	name = "dirty floor"
 	},
 /area/f13/sewer/powered)
-"qtk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "qtn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -35984,9 +33630,19 @@
 	},
 /area/f13/building/abandoned/o)
 "qui" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/machinery/door/airlock/hatch{
+	name = "Armory";
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/f13{
+	dir = 10;
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/armory)
 "quo" = (
 /obj/docking_port/stationary/bosaway{
 	name = "Location 1"
@@ -36123,15 +33779,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/ruin/powered)
-"qwg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
-/area/f13/brotherhood/reactor)
 "qwt" = (
 /obj/structure/bookcase,
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
@@ -36165,19 +33812,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/overseer)
 "qwS" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
 /obj/machinery/light/small{
-	brightness = 7;
-	dir = 4
+	dir = 4;
+	light_color = "#d8b1b1"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"qxc" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "qxd" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -36232,27 +33878,9 @@
 	},
 /area/ruin/powered)
 "qyz" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/machinery/computer/rdconsole/core/bos{
-	dir = 8;
-	icon_keyboard = "terminal_key";
-	icon_screen = "terminal_on_alt";
-	icon_state = "terminal"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"qyC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/dorms)
 "qyN" = (
 /obj/structure/table,
 /obj/item/storage/belt/military,
@@ -36302,14 +33930,6 @@
 	icon_state = "redmark"
 	},
 /area/f13/enclave)
-"qzi" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "qzx" = (
 /mob/living/simple_animal/hostile/renegade/meister,
 /turf/open/floor/f13{
@@ -36405,14 +34025,6 @@
 	},
 /turf/open/water,
 /area/f13/radiation)
-"qBM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "qBP" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -36443,9 +34055,10 @@
 	},
 /area/ruin/powered)
 "qCz" = (
-/obj/structure/sign/poster/ripped,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/brotherhood/armory)
 "qCF" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -36552,27 +34165,20 @@
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerfive)
 "qFn" = (
-/obj/structure/falsewall/reinforced{
-	layer = 3
+/obj/machinery/suit_storage_unit/mining,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operating)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "qFv" = (
 /obj/effect/spawner/lootdrop/crate_spawner,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "qFJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "qFR" = (
 /obj/structure/nest/ghoul{
@@ -36705,15 +34311,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qIa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/flashlight/lamp,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/reactor)
 "qIe" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/item/export/bottle/rum{
@@ -36878,21 +34484,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/sewer/powered)
-"qLX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	dir = 1;
-	pixel_y = 23;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/chemistry)
 "qMj" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36970,8 +34561,12 @@
 	},
 /area/f13/sewer/powered)
 "qNy" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/obj/effect/landmark/start/f13/initiate,
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "qND" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -37016,15 +34611,14 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "qOS" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosdorm7";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "purplefull"
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 10
 	},
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood/armory)
 "qOV" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/plating/dirt/dark,
@@ -37045,20 +34639,6 @@
 /obj/structure/table,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
-"qPr" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1;
-	layer = 3.1
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/operations)
 "qPx" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 8
@@ -37166,18 +34746,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "qSn" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "qSr" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/dark,
@@ -37190,11 +34764,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/enclave)
 "qSM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "qSP" = (
 /obj/structure/closet/fridge/cannibal,
@@ -37242,12 +34819,6 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"qTY" = (
-/obj/structure/spacevine{
-	name = "vines"
-	},
-/turf/closed/wall/mineral/wood,
-/area/f13/brotherhood/leisure)
 "qUb" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/dark,
@@ -37292,20 +34863,22 @@
 /turf/closed/wall/rust,
 /area/f13/bunker/bighornbunker)
 "qVw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "qVD" = (
-/obj/machinery/light/small{
+/obj/machinery/rnd/destructive_analyzer,
+/obj/item/stack/sheet/mineral/abductor,
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 8
 	},
-/obj/machinery/computer/security/wooden_tv{
-	network = list("BoS")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "qVE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/royalblue,
@@ -37326,12 +34899,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
 "qWo" = (
-/obj/structure/decoration/vent,
-/obj/machinery/atmospherics/pipe/simple{
+/obj/machinery/conveyor/auto{
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operating)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "qWw" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/sewer/powered)
@@ -37458,16 +35030,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/building/abandoned/z)
-"qYW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "qZa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -37494,22 +35056,13 @@
 	},
 /area/f13/building/abandoned/o)
 "qZz" = (
-/obj/structure/filingcabinet,
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_x = 16;
-	pixel_y = 34
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/pickaxe/drill/jackhammer{
-	anchored = 1;
-	buckle_prevents_pull = 1;
-	can_be_z_moved = 0;
-	moving_from_pull = 0;
-	pixel_x = 16;
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "qZJ" = (
 /obj/structure/chair/f13chair2{
 	dir = 1
@@ -37548,22 +35101,17 @@
 /turf/open/floor/plating/f13/inside,
 /area/f13/tunnel)
 "rbu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	desc = "An airtight door, built to withstand a nuclear blast.";
-	max_integrity = 10000;
-	name = "bunker entry";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_x = 8
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "rbw" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -37622,15 +35170,12 @@
 /turf/open/water,
 /area/f13/caves)
 "rcU" = (
-/obj/machinery/msgterminal/brotherhood{
-	dir = 8;
-	pixel_x = 23;
-	pixel_y = -3
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "rcV" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -37668,10 +35213,10 @@
 	},
 /area/ruin/powered)
 "rej" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/mining)
 "rex" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -37713,6 +35258,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"rfL" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/power/apc/auto_name/east,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/leisure)
 "rfM" = (
 /obj/machinery/porta_turret/f13/turret_556/hostile,
 /turf/open/floor/plasteel/f13/vault_floor/red/corner{
@@ -37720,11 +35275,9 @@
 	},
 /area/ruin/powered)
 "rfP" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
 "rfS" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/secretrecipe,
@@ -37798,10 +35351,13 @@
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
-"rhS" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
+"rhU" = (
+/obj/machinery/conveyor/auto{
+	dir = 8
+	},
+/obj/structure/plasticflaps,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "rhV" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -37872,12 +35428,6 @@
 	},
 /turf/open/water,
 /area/f13/sewer)
-"rkR" = (
-/obj/structure/decoration/warning{
-	name = "WARNING: NO MANS LAND AHEAD PVP ZONE"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "rla" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/plaque,
 /area/f13/vault)
@@ -37941,6 +35491,14 @@
 "rmB" = (
 /turf/closed/mineral/ash_rock,
 /area/f13/caves)
+"rmC" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 4
+	},
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/operations)
 "rmD" = (
 /obj/structure/chair/folding{
 	pixel_y = 11
@@ -38099,13 +35657,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
-"rpO" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/obj/structure/decoration/vent,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/operations)
 "rqd" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/disposalpipe/segment{
@@ -38216,13 +35767,6 @@
 "rsA" = (
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/dormitory)
-"rsB" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "rsG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe,
@@ -38246,6 +35790,16 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
+"rsO" = (
+/obj/structure/barricade/bars,
+/obj/machinery/camera/autoname{
+	name = "Secuirty Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/armory)
 "rsW" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/dark,
@@ -38269,17 +35823,19 @@
 	},
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/security)
+"rtw" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "rtG" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/tunnel)
 "rtK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood/operations)
 "rtO" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -38388,11 +35944,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/bar/heaven)
 "rwV" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/table/reinforced,
+/obj/item/kitchen/knife/butcher,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "rwW" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -38425,11 +35983,13 @@
 	},
 /area/f13/building/abandoned/o)
 "rys" = (
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/door/airlock/vault{
+	name = "Engine Access";
+	req_access_txt = "120"
 	},
-/area/f13/brotherhood/dorms)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/brotherhood/reactor)
 "ryt" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/subway,
@@ -38469,29 +36029,6 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker/bunkersix)
-"rzy" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/clipboard{
-	pixel_x = 32
-	},
-/obj/item/clipboard{
-	pixel_x = 34
-	},
-/obj/item/clipboard{
-	pixel_x = 36
-	},
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
-"rzA" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "rzL" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -38505,13 +36042,17 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "rAk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname{
-	dir = 10;
-	network = list("Bos")
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/structure/noticeboard{
+	pixel_y = 32
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "rAv" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'SERVER ROOM'.";
@@ -38551,14 +36092,6 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/medical/surgery)
-"rBL" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/door/airlock/hatch{
-	name = "Dorms";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "rBO" = (
 /obj/structure/handrail/g_central{
 	layer = 2.7;
@@ -38731,12 +36264,16 @@
 	},
 /area/f13/bunker)
 "rEV" = (
-/obj/structure/decoration/vent{
-	pixel_y = 32
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8;
+	pixel_y = 10
 	},
-/obj/structure/flora/ausbushes/reedbush,
-/turf/open/water,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/dorms)
 "rEY" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -38761,11 +36298,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "rFP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "rGi" = (
 /turf/closed/wall/f13/wood/interior,
@@ -38783,15 +36319,9 @@
 /turf/open/floor/plasteel/airless/floorgrime,
 /area/f13/bunker/bunkerfive)
 "rGJ" = (
-/obj/structure/window/fulltile/house{
-	dir = 2;
-	icon_state = "storewindowtop"
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
+/obj/machinery/light/small,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operations)
 "rHe" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger{
@@ -38827,12 +36357,6 @@
 	},
 /turf/open/water,
 /area/f13/sewer)
-"rHL" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "rHW" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -38853,12 +36377,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
 "rIf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/obj/machinery/power/apc/auto_name/north,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood/operations)
 "rIj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38886,10 +36407,20 @@
 	},
 /area/f13/bunker/bunkerseven)
 "rID" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "twindowold"
+	},
+/obj/structure/decoration/vent,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/machinery/shower{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/operations)
 "rIJ" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/sewer/powered)
@@ -38943,11 +36474,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer/powered)
 "rJZ" = (
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "rKt" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -39009,17 +36539,16 @@
 /turf/open/floor/plating/rust,
 /area/f13/bunker/bunkersix)
 "rMQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 32;
-	start_charge = 500
+/obj/structure/table/glass,
+/obj/item/storage/bag/chemistry{
+	pixel_x = 10;
+	pixel_y = 14
 	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "rNg" = (
 /turf/closed/wall/rust,
 /area/f13/bunker/bunkersix)
@@ -39029,14 +36558,14 @@
 	},
 /area/f13/sewer/powered)
 "rNo" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/glasses/meson/night,
-/obj/item/clothing/glasses/meson/night,
-/obj/item/pickaxe/drill,
-/obj/item/pickaxe/drill,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/leisure)
 "rNu" = (
 /obj/structure/railing{
 	dir = 4
@@ -39098,21 +36627,17 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "rOa" = (
-/obj/structure/lattice{
-	density = 1
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_x = -8;
+	pixel_y = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/railing{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing{
-	dir = 1
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
+/obj/item/reagent_containers/food/drinks/dry_ramen,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/reactor)
 "rOe" = (
 /obj/structure/simple_door/metal/iron,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -39130,13 +36655,13 @@
 	},
 /area/f13/bunker)
 "rOH" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/fulltile/store,
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/grille,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/structure/bodycontainer/crematorium,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operating)
 "rOK" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -39267,18 +36792,16 @@
 	},
 /area/ruin/powered)
 "rRp" = (
-/obj/structure/toilet{
-	dir = 1
+/obj/machinery/door/airlock/grunge{
+	name = "Combat Caste Office";
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	pixel_x = -10
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/dorms)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/operations)
 "rRu" = (
 /mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/floor/f13/wood{
@@ -39316,13 +36839,6 @@
 /obj/machinery/light,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer/powered)
-"rSa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
-	dir = 10
-	},
-/area/f13/brotherhood/reactor)
 "rSH" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -39489,21 +37005,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/overseer)
-"rWn" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/workbench/advanced,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "rWq" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/computer/shuttle/bosentryelevator{
+	pixel_y = 2
 	},
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/armory)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "rWC" = (
 /obj/effect/gibspawner/human,
 /obj/effect/decal/cleanable/dirt,
@@ -39541,32 +37049,15 @@
 /obj/item/melee/baton/loaded,
 /turf/open/floor/plasteel/vault,
 /area/f13/vault/security/armory)
-"rYr" = (
-/obj/item/am_containment{
-	pixel_x = 3
+"rYc" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/poddoor/shutters/radiation/preopen{
+	id = "bosengine"
 	},
-/obj/structure/table/reinforced,
-/obj/structure/window/plasma/reinforced{
-	dir = 4
+/turf/open/floor/f13{
+	icon_state = "redmark"
 	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/structure/window/plasma/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1
-	},
-/obj/item/am_containment,
-/obj/item/am_containment,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/item/stack/sheet/mineral/uranium{
-	amount = 5;
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "rYE" = (
 /obj/machinery/workbench/forge,
@@ -39636,11 +37127,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/sewer)
 "rZI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 1
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/operating)
 "rZJ" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -39741,23 +37233,6 @@
 /obj/structure/closet/crate/engineering/electrical,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"sdo" = (
-/obj/item/paper_bin{
-	pixel_y = 6
-	},
-/obj/item/cigbutt,
-/obj/structure/table{
-	pixel_y = 6
-	},
-/obj/item/pen/fourcolor{
-	pixel_y = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
-"sdz" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "sdO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/ladder/unbreakable{
@@ -39809,15 +37284,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/water,
 /area/f13/sewer)
-"seC" = (
-/obj/structure/chair/right,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "seD" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/effect/spawner/lootdrop/f13/advboards,
@@ -39827,6 +37293,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
+"seR" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/pdapainter,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "sfb" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -39885,14 +37361,11 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "sfU" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/storage/toolbox/emergency{
-	pixel_y = 8
-	},
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plating/rust,
 /area/f13/brotherhood/operations)
 "sfV" = (
 /obj/effect/landmark/start/f13/vaultdweller,
@@ -39952,22 +37425,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker/bunkereight)
-"shF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
 "shP" = (
 /obj/structure/bed/oldalt,
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
-"shY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/operations)
 "sid" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -40028,13 +37491,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
 "sjp" = (
-/obj/structure/lattice{
-	layer = 3
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "sjO" = (
 /obj/machinery/computer/security{
@@ -40085,11 +37547,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/vault/science)
 "skA" = (
-/obj/effect/turf_decal/stripes/red/line,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	name = "prewar lounge chair"
 	},
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "skV" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/vault/science)
@@ -40440,29 +37909,23 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker/bunkerthree)
-"sub" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
 "sug" = (
-/obj/machinery/button/door{
-	id = "bosshop";
-	name = "reactor shutters";
-	pixel_x = -32;
-	pixel_y = -4
+/obj/machinery/hydroponics/constructable,
+/obj/structure/lattice/catwalk,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = -32;
-	pixel_y = 7
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	barefootstep = "water";
+	clawfootstep = "water";
+	desc = "Shallow water.";
+	footstep = "water";
+	heavyfootstep = "water";
+	icon = 'icons/turf/floors.dmi';
+	icon_state = "riverwater_motion";
+	name = "water"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/leisure)
 "suj" = (
 /obj/effect/gibspawner/human/bodypartless,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -40574,13 +38037,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"swH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
 "swK" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -40721,10 +38177,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer/powered)
-"sAj" = (
-/obj/machinery/door/window/right/directional/east,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "sAl" = (
 /obj/structure/table/wood,
 /obj/structure/sign/poster/prewar/poster63{
@@ -40735,13 +38187,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
 "sAG" = (
-/obj/effect/decal/remains/robot,
+/obj/machinery/power/apc/auto_name/south,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "sAQ" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	desc = "A deadly close combat robot developed by RobCo in a vaguely feminine, yet ominous chassis. This one seems sleeker and more dangerous, with a slick red paintjob.";
@@ -40770,14 +38220,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/vault/custodial)
 "sBD" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
+/obj/structure/table/optable,
+/obj/machinery/iv_drip{
+	pixel_x = 15;
+	pixel_y = -2
 	},
-/obj/effect/landmark/start/f13/seniorpaladin,
-/turf/open/floor/f13{
-	icon_state = "redmark"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/operating)
 "sBI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -40926,9 +38378,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
 "sFT" = (
-/obj/structure/bookcase/random,
+/obj/structure/chair/left{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "sFV" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -40968,10 +38422,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
-"sGo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/dorms)
 "sGE" = (
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
@@ -40981,13 +38431,6 @@
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"sGJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
 "sGQ" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/radroach{
@@ -41001,40 +38444,22 @@
 /turf/open/floor/plating/rust,
 /area/f13/bunker/bunkersix)
 "sGT" = (
-/obj/machinery/rnd/destructive_analyzer,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	dir = 8;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operating)
 "sGX" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/sewer/powered)
-"sGY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/button/door{
-	id = "bosengineaccessrear";
-	name = "Engineering Lockdown";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "sHi" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "sHj" = (
 /obj/machinery/door/airlock/command{
@@ -41104,33 +38529,32 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/sewer/powered)
 "sJq" = (
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/structure/table/glass,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/right,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/landmark/start/f13/initiate,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"sJN" = (
-/obj/structure/kitchenspike_frame{
-	name = "Power armour frame"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/dorms)
 "sJQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/robot_debris/limb,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
 "sJS" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/vending/snack{
-	force_free = 1
-	},
+/obj/structure/rack/shelf_metal,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/storage/firstaid/radbgone,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/o2,
+/obj/item/storage/box/metalfoam,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood/reactor)
 "sKe" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowbottom"
@@ -41215,9 +38639,16 @@
 	},
 /area/f13/sewer/powered)
 "sMi" = (
-/obj/machinery/chem_master/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/structure/bed,
+/obj/item/bedsheet/runtime,
+/obj/machinery/button/door{
+	id = "bosdorm8";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/dorms)
 "sMN" = (
 /obj/structure/timeddoor,
 /turf/open/floor/f13{
@@ -41242,10 +38673,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
-"sNg" = (
-/obj/structure/sign/warning,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
 "sNr" = (
 /obj/structure/guncase/shotgun,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -41363,15 +38790,6 @@
 /obj/effect/gibspawner/human,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker/bunkernine)
-"sQc" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	name = "prewar lounge chair"
-	},
-/obj/effect/landmark/start/f13/headscribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "sQg" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe,
 /obj/effect/decal/cleanable/dirt,
@@ -41600,9 +39018,12 @@
 /turf/open/floor/plating/rust,
 /area/f13/bunker/bunkersix)
 "sXx" = (
-/obj/structure/ore_box,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/structure/table/wood,
+/obj/machinery/light/small{
+	light_color = "green"
+	},
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/dorms)
 "sXB" = (
 /obj/effect/gibspawner/human,
 /obj/structure/table,
@@ -41745,16 +39166,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/vault)
-"sZN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
 "sZZ" = (
 /obj/structure/flora/rock/jungle{
 	pixel_x = 1;
@@ -41781,16 +39192,14 @@
 /turf/closed/wall,
 /area/f13/tcoms)
 "taH" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/obj/structure/window/fulltile/store,
-/obj/structure/noticeboard{
-	desc = "A large, rusted plaque with carefully forged set of brass letters over it denoting the section of the bunker lays beyond.";
-	layer = 3.3;
-	name = "Medical Lab"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "taK" = (
 /obj/machinery/autolathe/ammo,
 /obj/effect/decal/cleanable/dirt,
@@ -41853,9 +39262,19 @@
 	},
 /area/f13/bunker/bunkerseven)
 "tch" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/structure/rack/shelf_metal,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda,
+/obj/item/pda{
+	icon_state = "pda-warden";
+	name = "Armory Warden PDA"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/brotherhood/armory)
 "tcx" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -41896,16 +39315,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/enclave)
 "tdC" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/obj/machinery/light{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/dorms)
 "tdJ" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -42001,13 +39419,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerthree)
-"tfW" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "tfY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -42068,31 +39479,19 @@
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/security)
 "thW" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/clothing/under/rank/medical/green,
-/obj/item/clothing/under/rank/medical/purple,
-/obj/item/clothing/under/rank/medical/blue,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/mining)
 "tid" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot_red,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
 /turf/open/floor/f13{
-	icon_state = "reddirtyfull"
+	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/armory)
 "tig" = (
@@ -42240,32 +39639,25 @@
 	},
 /area/f13/building/abandoned/o)
 "tkU" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/door/poddoor/shutters/radiation/preopen{
-	id = "bosengine"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/operations)
 "tkW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/wreck/trash/machinepile,
 /turf/open/water,
 /area/f13/sewer)
 "tkZ" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/mirror{
-	pixel_x = 30
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
+/obj/effect/landmark/start/f13/paladin,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood/armory)
 "tlg" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
@@ -42315,19 +39707,30 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
 "tmz" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc{
+	dir = 1;
+	pixel_x = 28;
+	start_charge = 500
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "tmA" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 10
+	},
+/area/f13/brotherhood/armory)
 "tmI" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -42544,33 +39947,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"tqM" = (
-/obj/structure/rack,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/mop,
-/obj/item/storage/bag/trash,
+"tqN" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood/operations)
 "tqW" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
-"tqY" = (
-/obj/machinery/cell_charger{
-	pixel_y = 6
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/recharger,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "tro" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/fermenting_barrel,
@@ -42583,10 +39967,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "trK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "trV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -42640,23 +40025,6 @@
 	},
 /turf/open/water,
 /area/f13/caves)
-"tsJ" = (
-/obj/structure/decoration/smokeold,
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall";
-	smooth = 1
-	},
-/area/f13/brotherhood/operating)
-"tsT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/gun/energy/laser/pistol,
-/obj/item/gun/energy/laser/pistol,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "tte" = (
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
@@ -42715,12 +40083,9 @@
 /turf/open/floor/circuit/f13_blue,
 /area/f13/enclave)
 "ttS" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Meeting room";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/structure/reagent_dispensers/peppertank,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/armory)
 "ttV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepiletwo,
@@ -42862,16 +40227,6 @@
 /obj/structure/wreck/trash/two_tire,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"txT" = (
-/obj/structure/table/reinforced,
-/obj/structure/table/reinforced{
-	req_access_txt = "120"
-	},
-/obj/structure/barricade/bars{
-	layer = 5
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "txU" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -43007,17 +40362,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"tBj" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/armory)
 "tBq" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/bottle/amaretto{
@@ -43052,10 +40396,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"tCU" = (
-/obj/structure/simple_door/metal/ventilation,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/rnd)
 "tCZ" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
@@ -43221,21 +40561,27 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/ruin/powered)
 "tFX" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	dir = 4;
-	layer = 2.7;
-	name = "prewar lounge chair"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"tGj" = (
-/obj/machinery/light/small,
-/obj/structure/curtain{
-	color = "#5c131b";
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/noticeboard{
+	dir = 1;
+	name = "display plate";
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
+/area/f13/brotherhood/rnd)
+"tGj" = (
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/neck/mantle/bos/paladin,
+/obj/item/clothing/neck/mantle/bos/left,
+/obj/item/clothing/neck/mantle/bos/right,
+/obj/item/clothing/neck/mantle/commander,
+/turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "tGk" = (
 /obj/structure/shelf_wood,
@@ -43255,15 +40601,6 @@
 /obj/structure/nest/molerat,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
-"tGX" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/beaker/waterbottle,
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "tGY" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -43753,11 +41090,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
 "tTK" = (
-/obj/machinery/door/airlock/grunge{
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/red/corner{
+	dir = 8
+	},
+/area/f13/brotherhood/armory)
 "tUi" = (
 /obj/structure/table{
 	layer = 2.9
@@ -43821,10 +41160,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
-"tVm" = (
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "tVt" = (
 /turf/closed/indestructible/opshuttle{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -43908,26 +41243,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "tWR" = (
-/obj/effect/decal/fakelattice{
-	layer = 2
+/obj/structure/barricade/bars,
+/obj/structure/table{
+	pixel_y = 6
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/armory)
 "tXl" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"tXp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "tXw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -43952,23 +41279,24 @@
 	name = "dirty floor"
 	},
 /area/f13/sewer/powered)
-"tYE" = (
-/obj/item/paper_bin,
-/obj/structure/table{
-	layer = 2.9
+"tYu" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/item/pen/fountain,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/closet/anchored,
+/obj/item/clothing/under/f13/bosform_f,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/gloves/color/white/bos,
+/obj/item/clothing/under/f13/bosform_m,
+/obj/item/clothing/under/f13/bosform_f,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "tYG" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/cash_random_low,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
-"tYO" = (
-/obj/structure/easel,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
 "tZs" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -44022,14 +41350,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
-"ucf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bookcase/manuals/engineering,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "uco" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/metal/fifty,
@@ -44287,14 +41607,6 @@
 "ugN" = (
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"uhG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/lootdrop/trash,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "uhK" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/fluff/ruins/exp_cloning/log,
@@ -44406,14 +41718,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"uku" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/bedsheetbin,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "ukA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/white,
@@ -44427,10 +41731,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/sewer/powered)
-"ulw" = (
-/obj/structure/fans/tiny,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/medical)
 "ulH" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/vault/dormitory)
@@ -44471,11 +41771,15 @@
 /turf/open/floor/wood_wide,
 /area/f13/vault/diner)
 "umn" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/structure/table/glass,
+/obj/item/storage/box/medsprays,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/chemistry)
 "ums" = (
 /obj/structure/closet/locker{
 	anchored = 1
@@ -44542,12 +41846,16 @@
 /area/f13/sewer)
 "unG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/light/small{
+	light_color = "green"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/machinery/computer/rdconsole/core/bos{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 10
+	},
+/area/f13/brotherhood/rnd)
 "unL" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/under/f13/police/officer,
@@ -44637,14 +41945,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/machinery/camera/autoname{
-	dir = 10;
-	network = list("Bos")
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhdirty_chess2"
-	},
-/area/f13/brotherhood/leisure)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
+/area/f13/brotherhood/reactor)
 "upE" = (
 /mob/living/simple_animal/hostile/handy/protectron{
 	auto_fire_delay = 2;
@@ -44699,13 +42002,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"uqo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/armory)
 "uqs" = (
 /obj/structure/fluff/rails{
 	dir = 4
@@ -44757,17 +42053,28 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/enclave)
 "urv" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/landmark/start/f13/seniorscribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/structure/closet/crate/medical,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/hypospray/medipen/stimpak,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+	dir = 5
+	},
+/area/f13/brotherhood/operating)
 "urF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/cable_coil/cut/red,
-/obj/structure/grille,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
+/area/f13/brotherhood/reactor)
 "urS" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -44856,19 +42163,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "utX" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/rock/jungle,
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
 	},
-/obj/effect/light_emitter,
-/turf/open/water,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/armory)
 "utY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -44903,10 +42204,13 @@
 	},
 /area/f13/bunker)
 "uuv" = (
-/obj/structure/table,
-/obj/item/trash/plate,
-/turf/open/floor/carpet/royalblack,
-/area/f13/brotherhood/leisure)
+/obj/structure/toilet{
+	pixel_y = 13
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/armory)
 "uuB" = (
 /obj/machinery/light{
 	dir = 4
@@ -44976,11 +42280,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "uwi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/right{
+/obj/effect/landmark/start/f13/sentinel,
+/obj/machinery/light/small{
+	brightness = 7;
 	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "uwm" = (
 /obj/structure/rack,
@@ -45170,14 +42475,6 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"uAz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "uAC" = (
 /obj/effect/spawner/lootdrop/glowstick,
 /turf/open/floor/f13{
@@ -45241,8 +42538,15 @@
 	},
 /area/f13/enclave)
 "uBM" = (
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/light/small{
+	pixel_x = -10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood/reactor)
 "uBQ" = (
 /obj/structure/sign/poster/prewar/poster63{
 	pixel_y = -32
@@ -45255,16 +42559,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker/bunkerthree)
-"uBV" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "uBZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -45304,9 +42598,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
 "uCZ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/leisure)
+/obj/machinery/door/window/brigdoor,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/brotherhood/armory)
 "uDf" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -45342,14 +42645,15 @@
 	},
 /area/ruin/powered)
 "uED" = (
-/obj/machinery/button/door{
-	id = "bosdorm9";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
+/obj/structure/table,
+/obj/item/crowbar/advanced,
+/obj/item/wrench/advanced{
+	pixel_x = 2
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "uFc" = (
 /obj/machinery/shuttle_manipulator{
 	desc = "You have no idea what this shows.";
@@ -45426,8 +42730,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "uHp" = (
-/turf/open/water,
-/area/f13/brotherhood/leisure)
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
+	name = "Head Scribe's Archive Terminal"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/brotherhood/rnd)
 "uHu" = (
 /turf/closed/wall/rust,
 /area/f13/bunker)
@@ -45435,20 +42749,6 @@
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"uHP" = (
-/obj/machinery/light/small,
-/obj/structure/lattice/catwalk,
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
-"uHS" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/armory)
 "uIo" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -45502,21 +42802,17 @@
 	},
 /area/f13/bunker/bunkerthree)
 "uJJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters{
-	id = "bosdoors3";
-	name = "brotherhood shutters"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
+/turf/open/floor/plating/rust,
 /area/f13/brotherhood/operations)
 "uJT" = (
-/obj/structure/fans/tiny{
-	pixel_y = -33
-	},
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/headscribe,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "uJU" = (
 /obj/machinery/porta_turret/f13/turret_shotgun/raider{
 	dir = 9
@@ -45661,9 +42957,9 @@
 	},
 /area/f13/sewer/powered)
 "uME" = (
-/obj/machinery/processor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/brotherhood/operations)
 "uMZ" = (
 /obj/structure/wreck/trash/autoshaft,
 /turf/open/indestructible/ground/inside/subway,
@@ -45754,10 +43050,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "uOn" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/middle{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "uOp" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -45878,9 +43175,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "uQE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/armory)
 "uQH" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
@@ -45901,15 +43200,6 @@
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
-"uQS" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
 "uRw" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -11
@@ -46010,6 +43300,18 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
+"uTK" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "uTV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -46071,9 +43373,6 @@
 	icon_state = "greenfull"
 	},
 /area/f13/building/abandoned/o)
-"uUS" = (
-/turf/closed/indestructible/f13vaultrusted,
-/area/f13/bar/heaven)
 "uUY" = (
 /obj/structure/stairs/south,
 /turf/open/floor/plasteel/dark,
@@ -46308,11 +43607,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"vbH" = (
-/obj/item/flag/bos,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "vbW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -46440,22 +43734,13 @@
 	},
 /area/f13/tunnel)
 "veX" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/medsprays,
-/obj/item/pda/chemist{
-	name = "Scribe-Chemist Pip-Boy 3000";
-	pixel_x = 15;
-	pixel_y = 7
+/obj/structure/curtain,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/obj/item/reagent_containers/dropper,
-/obj/machinery/reagentgrinder{
-	layer = 3.3;
-	pixel_x = -1;
-	pixel_y = 15
-	},
-/obj/item/reagent_containers/dropper,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operating)
 "vfc" = (
 /obj/structure/table,
 /obj/item/storage/box/cups{
@@ -46535,23 +43820,16 @@
 /obj/item/paper_bin,
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
-"vhz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "vhI" = (
 /mob/living/simple_animal/hostile/renegade/defender,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
 "vhR" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/obj/item/am_shielding_container,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/reactor)
 "vhT" = (
 /obj/item/storage/trash_stack,
@@ -46717,18 +43995,13 @@
 	},
 /area/f13/bunker)
 "vkW" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 8
+/obj/structure/chair/stool/retro/black,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/window/reinforced{
-	color = "#3e3d42"
-	},
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/grass/jungle,
+/obj/effect/landmark/start/f13/paladin,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operations)
 "vla" = (
 /mob/living/simple_animal/hostile/centaur,
 /obj/effect/decal/cleanable/dirt{
@@ -46766,12 +44039,12 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "vlM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "vlT" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -46785,19 +44058,10 @@
 	},
 /area/f13/bunker/bunkerthree)
 "vma" = (
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/fluff/railing{
-	dir = 8
-	},
-/obj/structure/fluff/railing{
-	dir = 4
-	},
-/obj/structure/fluff/railing,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/operations)
+/obj/structure/table/reinforced,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood/armory)
 "vmj" = (
 /obj/structure/fluff/hedge,
 /obj/structure/sign/poster/prewar/vault_tec{
@@ -46950,15 +44214,6 @@
 /obj/structure/barricade/tentclothedge,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"vqu" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/armory)
 "vqB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/grille,
@@ -46976,9 +44231,11 @@
 	},
 /area/f13/brotherhood/armory)
 "vrw" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
+/area/f13/brotherhood/rnd)
 "vrA" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -47081,17 +44338,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/bunker/bunkereight)
-"vtK" = (
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operating)
 "vtM" = (
 /mob/living/simple_animal/hostile/radscorpion/black,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
-"vtS" = (
-/obj/item/stack/sheet/hay,
-/turf/open/indestructible/ground/inside/dirt,
-/area/f13/brotherhood/leisure)
 "vtU" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -47130,13 +44380,6 @@
 /obj/structure/grille,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"vur" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redrustyfull"
-	},
-/area/f13/brotherhood/armory)
 "vus" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/barricade/wooden/planks,
@@ -47253,10 +44496,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless/floorgrime,
 /area/f13/bunker/bunkerthree)
-"vxX" = (
-/obj/machinery/chem_master/condimaster,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
 "vxZ" = (
 /obj/structure/table,
 /obj/machinery/light/broken,
@@ -47275,13 +44514,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
 "vyf" = (
-/obj/effect/decal/cleanable/glass,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/armory)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/operations)
 "vyk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47290,10 +44525,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "vyu" = (
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "vyv" = (
 /obj/structure/closet/toolcloset{
 	anchored = 1
@@ -47392,10 +44625,6 @@
 /obj/structure/flora/rock/pile/largejungle,
 /turf/closed/indestructible/rock,
 /area/f13/sewer)
-"vAr" = (
-/obj/effect/spawner/lootdrop/grille_or_trash,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "vAs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/weather/dirt{
@@ -47434,14 +44663,16 @@
 "vBd" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer/powered)
-"vBl" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+"vBk" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "vBr" = (
 /obj/effect/gibspawner/robot,
 /obj/effect/gibspawner/robot,
@@ -47466,17 +44697,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"vCa" = (
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/stairs,
-/area/f13/brotherhood/operations)
 "vCd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -47508,11 +44728,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
-"vDc" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operations)
 "vDk" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -47564,13 +44779,6 @@
 /obj/item/clothing/under/lawyer/blacksuit,
 /turf/open/floor/f13,
 /area/f13/vault)
-"vET" = (
-/obj/structure/fluff/railing{
-	dir = 6;
-	pixel_x = 33
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
 "vFe" = (
 /obj/structure/table/wood/settler,
 /obj/effect/spawner/lootdrop/trash,
@@ -47598,11 +44806,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"vGi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "vGw" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/r_wall/rust,
@@ -47722,20 +44925,18 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker/bunkertwo)
 "vJu" = (
-/obj/structure/chair/wood{
-	dir = 8;
-	layer = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"vJB" = (
-/obj/effect/decal/fakelattice{
-	layer = 2
-	},
-/obj/structure/lattice/catwalk,
+/obj/machinery/rnd/science_lab,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
+/obj/machinery/light/small{
+	light_color = "green"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 6
+	},
+/area/f13/brotherhood/rnd)
+"vJB" = (
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/armory)
 "vJF" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /obj/effect/decal/cleanable/dirt,
@@ -47795,15 +44996,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"vKC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -32
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "vKK" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
@@ -47902,9 +45094,12 @@
 /area/ruin/powered)
 "vMH" = (
 /obj/structure/table/glass,
+/obj/structure/frame/machine,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/pickaxe/drill,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/item/circuitboard/machine/ore_silo,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
+	},
 /area/f13/brotherhood/rnd)
 "vMI" = (
 /obj/structure/table,
@@ -47972,11 +45167,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
-"vNP" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
 "vNW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/bodypart/l_leg/robot/surplus,
@@ -47990,14 +45180,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/atrium)
-"vNZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/painting/library_secure{
-	persistence_id = "brotherhood_secure";
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
 "vOa" = (
 /mob/living/simple_animal/hostile/ghoul/soldier,
 /turf/open/indestructible/ground/inside/subway,
@@ -48059,11 +45241,7 @@
 	},
 /area/f13/bunker/bighornbunker)
 "vQs" = (
-/obj/effect/landmark/start/f13/Knight,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/item/flag/bos,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "vQu" = (
@@ -48096,14 +45274,9 @@
 /turf/open/floor/plasteel/airless/floorgrime,
 /area/f13/bunker/bunkerfive)
 "vRp" = (
-/obj/machinery/autolathe,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "neutralrustyfull"
-	},
-/area/f13/brotherhood/leisure)
+/obj/structure/decoration/rads,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/reactor)
 "vRs" = (
 /obj/item/trash/popcorn,
 /mob/living/simple_animal/hostile/raider/ranged/boss,
@@ -48111,13 +45284,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
-"vRM" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "vRS" = (
 /obj/structure/fluff/empty_cryostasis_sleeper,
 /obj/structure/window{
@@ -48249,22 +45415,9 @@
 	},
 /area/f13/sewer)
 "vUO" = (
-/obj/structure/rack,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/item/pda,
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
+/obj/structure/sign/directions/science,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operations)
 "vVv" = (
 /obj/machinery/iv_drip,
 /obj/structure/table/rolling,
@@ -48308,15 +45461,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault/reactor)
-"vWQ" = (
-/obj/machinery/shower{
-	dir = 1;
-	pixel_y = -2
-	},
-/obj/structure/decoration/vent,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/dorms)
 "vXm" = (
 /obj/machinery/vending/dinnerware{
 	force_free = 1
@@ -48334,17 +45478,18 @@
 	},
 /area/f13/bunker/bunkerfive)
 "vXE" = (
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/pdapainter,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
-"vXM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/armory)
 "vXN" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -48395,10 +45540,18 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
 "vZC" = (
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/suit_storage_unit/radsuit,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/structure/decoration/hatch{
+	dir = 8
+	},
+/obj/structure/sink/kitchen{
+	dir = 4;
+	pixel_x = -13
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
+	icon_state = "tealwhrusty_chess2"
+	},
+/area/f13/brotherhood/leisure)
 "vZI" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -48428,13 +45581,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/vault/science)
-"waK" = (
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/washing_machine,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "waM" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -48488,17 +45634,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
 "wcC" = (
-/obj/structure/bookcase/random,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	dir = 1;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/sign/departments/medbay,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operations)
 "wcT" = (
 /obj/structure/destructible/tribal_torch/lit,
 /obj/effect/decal/cleanable/dirt,
@@ -48557,19 +45695,12 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
 "wec" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/structure/lattice{
-	layer = 3
-	},
 /obj/machinery/light/small{
-	dir = 4
+	dir = 1;
+	pixel_x = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"weg" = (
-/obj/structure/sign/poster/prewar/poster71,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
 "wer" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -48733,13 +45864,12 @@
 	},
 /area/f13/bunker)
 "wit" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/simple_door/bunker/glass{
+	req_access_txt = "120";
+	req_one_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor{
-	icon_state = "floordirty"
-	},
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/dorms)
 "wiv" = (
 /obj/structure/closet/cabinet{
 	anchored = 1
@@ -48853,15 +45983,6 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/sewer)
-"wjB" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/anniversary_vintage_reprint{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "wjO" = (
 /obj/structure/lattice/catwalk,
 /obj/item/storage/trash_stack,
@@ -48947,16 +46068,16 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "wmt" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_y = -7
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/leisure)
 "wmz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/step_trigger/message{
@@ -48968,23 +46089,21 @@
 	},
 /area/f13/bunker/bunkerthree)
 "wmG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/closet/crate/medical,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operating)
 "wmL" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "wmP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/survival_pod,
-/obj/item/clothing/suit/armor/light/duster/bos/scribe/field_coat,
-/obj/item/clothing/suit/armor/light/duster/bos/scribe/field_coat,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/structure/frame/machine,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "wmX" = (
 /obj/machinery/autolathe/ammo/unlocked_basic,
 /obj/machinery/light,
@@ -49023,13 +46142,17 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "wnm" = (
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/structure/closet/anchored,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/operations)
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 9
+	},
+/area/f13/brotherhood/armory)
 "wnF" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/randomraiderhead,
@@ -49118,13 +46241,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker/bighornbunker)
-"wqf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
 "wql" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
 	dir = 4
@@ -49166,13 +46282,6 @@
 /obj/structure/barricade/bars,
 /turf/open/water,
 /area/f13/sewer)
-"wrp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
 "wrD" = (
 /obj/structure/sign/poster/prewar/poster80{
 	pixel_x = 32
@@ -49233,24 +46342,14 @@
 	},
 /area/f13/bunker)
 "wsX" = (
-/obj/structure/bed{
-	pixel_y = 7
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosarmoryacc";
+	name = "Mine";
+	req_access_txt = "120"
 	},
-/obj/item/bedsheet{
-	icon_state = "sheetcmo";
-	pixel_y = 7
-	},
-/obj/machinery/iv_drip{
-	pixel_x = 13;
-	pixel_y = 2
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8;
-	pixel_y = 10
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/medical)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/dorms)
 "wsY" = (
 /obj/structure/debris/v1,
 /obj/structure/debris/v3{
@@ -49283,14 +46382,14 @@
 	},
 /area/f13/bunker/bunkerthree)
 "wtD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/structure/sink/kitchen{
+	dir = 8;
+	pixel_x = 12
 	},
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/leisure)
 "wtT" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowdirtyfull"
@@ -49369,12 +46468,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "wvA" = (
-/obj/structure/curtain{
-	color = "#5c131b"
+/obj/machinery/power/smes/engineering,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "red"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 10
+	},
+/area/f13/brotherhood/reactor)
 "wvF" = (
 /obj/structure/lattice,
 /obj/structure/simple_door/bunker,
@@ -49383,12 +46485,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker/bunkernine)
-"wvL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/f13/seniorscribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "wvP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/grill,
@@ -49459,25 +46555,27 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/radiation)
 "wym" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/computer/card/bos,
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_x = 16;
+	pixel_y = 34
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/item/gun/energy/pulse{
+	anchored = 1;
+	cell_type = null;
+	desc = "A heavy-duty, multifaceted energy rifle with three modes. Preferred by front-line combat personnel. This one is for display, and no longer fires.";
+	name = "display pulse rifle";
+	pin = null;
+	pixel_x = 16;
+	pixel_y = 29
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
 	},
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood/operations)
-"wyr" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "wyv" = (
 /obj/structure/closet/crate{
 	anchored = 1
@@ -49512,15 +46610,14 @@
 	},
 /area/f13/sewer/powered)
 "wyY" = (
-/obj/structure/table/glass,
-/obj/item/storage/bag/chemistry{
-	pixel_x = 10;
-	pixel_y = 14
+/obj/structure/curtain,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operating)
 "wzh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -49543,10 +46640,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/sewer)
-"wzL" = (
-/obj/structure/grille,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "wAb" = (
 /turf/open/floor/plating/dirt,
 /area/f13/sewer/powered)
@@ -49566,6 +46659,18 @@
 "wAm" = (
 /turf/closed/wall/rust,
 /area/f13/building/abandoned/z)
+"wAC" = (
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/rack,
+/obj/item/airlock_painter,
+/obj/item/airlock_painter/decal,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "wAG" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -49648,19 +46753,6 @@
 /obj/effect/landmark/start/f13/vaultengineer,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/vault/reactor)
-"wBV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/power/port_gen/pacman/super{
-	anchored = 1
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "wBW" = (
 /obj/machinery/light/floor{
 	pixel_x = -17;
@@ -49708,10 +46800,6 @@
 "wDh" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/enclave)
-"wDn" = (
-/obj/structure/dresser,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "wDS" = (
 /obj/structure/sign/poster/prewar/poster70,
 /turf/closed/indestructible/f13vaultrusted,
@@ -49810,11 +46898,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "wHI" = (
-/obj/structure/chair/f13foldupchair{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/operations)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood/reactor)
 "wHM" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /obj/effect/decal/cleanable/greenglow,
@@ -49868,33 +46957,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
 "wIG" = (
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_x = 40;
-	pixel_y = 7
-	},
-/obj/machinery/button/door{
-	id = "bosaccesscontrol";
-	normaldoorcontrol = 1;
-	pixel_x = 40;
-	pixel_y = -8;
-	specialfunctions = 4
-	},
-/obj/item/radio/intercom{
-	desc = "Is there anyone on the other end? Who's in there?";
-	frequency = 1291;
-	name = "Mysterious Intercom";
-	pixel_x = 26;
-	pixel_y = -3
-	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
-	},
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
 "wIN" = (
 /obj/structure/disposalpipe/segment{
@@ -50002,13 +47069,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/bunker/bunkereight)
 "wKD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/clothing/under/f13/combat,
-/obj/item/clothing/under/f13/combat,
-/obj/item/clothing/under/f13/combat,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
+/obj/structure/ore_box,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/mining)
 "wKJ" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -50017,14 +47080,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bunkersix)
-"wKO" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 5
-	},
-/turf/open/floor/f13{
-	icon_state = "reddirtyfull"
-	},
-/area/f13/brotherhood/armory)
 "wKV" = (
 /obj/structure/table{
 	layer = 2.9
@@ -50074,13 +47129,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault/medical/breakroom)
 "wLP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/vending/hydronutrients{
+	force_free = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/leisure)
 "wLY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -50218,14 +47276,6 @@
 	icon_state = "floordirty"
 	},
 /area/f13/bunker/bunkerthree)
-"wOB" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor5"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "wOC" = (
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -8
@@ -50351,20 +47401,19 @@
 	},
 /area/f13/bunker/bunkersix)
 "wQM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/button/door{
-	id = "bosengine";
-	name = "Radiation Shutters";
-	pixel_x = -32
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
+/obj/structure/table/reinforced,
+/obj/item/multitool,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/brotherhood/reactor)
 "wQP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/rack,
-/obj/item/storage/toolbox/emergency/old,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/obj/structure/table{
+	layer = 2.9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "wQW" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/ncr_k_ration,
@@ -50395,15 +47444,18 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bighornbunker)
 "wRE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 1
+/obj/structure/toilet{
+	pixel_y = 13
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
 "wRM" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/ballistic/automatic/m1carbine/compact,
@@ -50413,13 +47465,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"wRN" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/armory)
 "wRO" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -50430,13 +47475,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bighornbunker)
-"wRS" = (
-/obj/structure/fluff/railing{
-	dir = 4;
-	pixel_x = -29
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
 "wSp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -50517,16 +47555,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
-"wVr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	name = "Dorms";
-	req_access_txt = "120"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
 "wVC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -50563,10 +47591,6 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
-"wWH" = (
-/obj/structure/decoration/warning,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/reactor)
 "wWZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -50593,12 +47617,10 @@
 	},
 /area/ruin/powered)
 "wXq" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operating)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/scribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "wXx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -50627,13 +47649,6 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
-"wYi" = (
-/obj/machinery/flasher/portable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/armory)
 "wYx" = (
 /obj/structure/table,
 /obj/item/trash/plate,
@@ -50706,6 +47721,14 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"wZw" = (
+/obj/machinery/camera/autoname{
+	dir = 10;
+	name = "Secuirty Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "wZI" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plating/dirt,
@@ -50729,19 +47752,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "xaM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 8;
-	pixel_x = 7;
-	pixel_y = 8
+/obj/structure/table,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe/drill{
+	pixel_y = 3
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
+/obj/item/storage/bag/ore,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "xaQ" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/book/granter/crafting_recipe/gunsmith_one,
@@ -50777,17 +47797,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault/reactor)
-"xbk" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "xbs" = (
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/dorms)
 "xbv" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowrustyfull"
@@ -50866,30 +47882,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
 "xde" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "bosengineaccess";
-	name = "Engine Access Shutters"
+/obj/machinery/shower{
+	dir = 1;
+	pixel_y = -2
 	},
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
-"xdr" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	pixel_x = 32;
-	start_charge = 500
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/leisure)
+/obj/structure/decoration/vent,
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
 "xdt" = (
 /obj/structure/timeddoor,
 /turf/open/indestructible/ground/inside/mountain,
@@ -50963,12 +47965,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker/bighornbunker)
-"xfe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/grille/broken,
-/turf/open/floor/plating/f13/inside,
-/area/f13/brotherhood/operations)
 "xfm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51038,11 +48034,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker/bunkerfive)
-"xfP" = (
-/obj/effect/turf_decal/caution/stand_clear/white,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "xfX" = (
 /mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -51099,12 +48090,16 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "xhB" = (
-/obj/structure/closet/crate/medical,
-/obj/structure/sign/poster/prewar/poster74{
-	pixel_y = 32
+/obj/structure/bed,
+/obj/item/bedsheet/syndie,
+/obj/machinery/button/door{
+	id = "bosdorm9";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/dorms)
 "xhI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
@@ -51159,10 +48154,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
-"xiK" = (
-/obj/machinery/rnd/production/protolathe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "xiL" = (
 /obj/structure/sign/warning/radiation,
 /turf/closed/indestructible/f13vaultrusted,
@@ -51187,15 +48178,13 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "xjl" = (
-/obj/effect/decal/cleanable/shreds{
-	pixel_x = -6;
-	pixel_y = -12
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operating)
 "xjm" = (
 /obj/structure/debris/v1,
 /obj/structure/debris/v2,
@@ -51221,7 +48210,10 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "xjC" = (
-/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "xjG" = (
@@ -51308,18 +48300,9 @@
 	},
 /area/f13/radiation)
 "xmd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"xmE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/stool/retro/backed{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "xmL" = (
 /obj/machinery/workbench/forge{
 	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
@@ -51341,11 +48324,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/enclave)
 "xnb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/armory)
+/obj/structure/sign/poster/contraband/pinup_ride,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/dorms)
 "xni" = (
 /obj/structure/simple_door/bunker,
 /obj/machinery/door/poddoor/shutters/radiation,
@@ -51395,21 +48376,11 @@
 	},
 /area/f13/sewer/powered)
 "xoQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/chair/right{
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"xoT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood/operations)
 "xpd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -51447,12 +48418,9 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/shack)
 "xpI" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
+/area/f13/brotherhood/rnd)
 "xpR" = (
 /obj/structure/toilet{
 	dir = 4
@@ -51568,10 +48536,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
-"xsN" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/brotherhood/armory)
 "xsQ" = (
 /obj/machinery/porta_turret/f13/turret_556/hostile,
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
@@ -51623,8 +48587,14 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "xuQ" = (
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
 "xvo" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /obj/effect/decal/cleanable/dirt,
@@ -51682,18 +48652,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "xwz" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/turf_decal/loading_area/white,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/sign/directions/medical,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "xwJ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/grille,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "bosengine"
 	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/brotherhood/reactor)
 "xxc" = (
@@ -51725,10 +48692,6 @@
 /obj/item/clothing/accessory/medal/gold/captain,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/overseer)
-"xxF" = (
-/obj/structure/barricade/wooden,
-/turf/closed/wall/mineral/wood,
-/area/f13/brotherhood/leisure)
 "xxI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/lootdrop/trash,
@@ -51818,13 +48781,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/rust,
 /area/f13/bunker/bunkerseven)
-"xzv" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall";
-	smooth = 1
-	},
-/area/f13/brotherhood/armory)
 "xzA" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 4
@@ -51902,16 +48858,6 @@
 	icon_state = "greenfull"
 	},
 /area/f13/sewer)
-"xAH" = (
-/obj/structure/table/optable,
-/obj/machinery/iv_drip{
-	pixel_x = 15;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
 "xAO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack/shelf_metal,
@@ -51987,14 +48933,16 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "xBS" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/bed,
+/obj/item/bedsheet/rd,
+/obj/machinery/button/door{
+	id = "bosdorm7";
+	normaldoorcontrol = 1;
+	pixel_x = 28;
+	specialfunctions = 4
 	},
-/obj/structure/table/reinforced,
-/obj/item/kitchen/rollingpin,
-/obj/item/kitchen/knife/butcher,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
-/area/f13/brotherhood/leisure)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/dorms)
 "xBZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -52042,12 +48990,6 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/sewer/powered)
-"xCL" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
 "xCW" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
@@ -52055,19 +48997,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
 "xDh" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/mineral/ore_redemption,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"xDm" = (
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/medical)
+/area/f13/brotherhood/leisure)
 "xDw" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -52114,13 +49050,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/whiteredchess,
 /area/f13/enclave)
 "xFd" = (
-/obj/structure/simple_door/metal/ventilation,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/closet/firecloset/full,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/chemistry)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 6
+	},
+/area/f13/brotherhood/reactor)
 "xFj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/mountain,
@@ -52201,18 +49139,9 @@
 	},
 /area/ruin/powered)
 "xHG" = (
-/obj/structure/window/reinforced{
-	color = "#3e3d42";
-	dir = 4
-	},
-/obj/structure/lattice{
-	density = 1
-	},
-/obj/structure/fluff/railing{
-	dir = 10
-	},
-/turf/open/floor/plating/tunnel,
-/area/f13/brotherhood/leisure)
+/obj/machinery/light/floor,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/armory)
 "xHL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepile,
@@ -52221,12 +49150,9 @@
 	},
 /area/f13/sewer)
 "xHM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/leisure)
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/armory)
 "xIq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -52344,39 +49270,19 @@
 	},
 /area/f13/bunker/bighornbunker)
 "xLy" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall";
-	smooth = 1
-	},
-/area/f13/brotherhood/operating)
-"xLD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/hatch{
-	name = "Backup Power";
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosarmoryacc";
+	name = "Mine";
 	req_access_txt = "120"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "xLE" = (
 /obj/structure/bonfire/prelit{
 	grill = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"xLK" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosaccesscontrol";
-	req_access_txt = "120"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
 "xLR" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier5,
 /obj/structure/closet/crate/footlocker,
@@ -52437,31 +49343,6 @@
 	},
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/sewer/powered)
-"xNB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
-"xND" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/hydroponics/constructable,
-/obj/structure/decoration/smokeold{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	barefootstep = "water";
-	clawfootstep = "water";
-	desc = "Shallow water.";
-	footstep = "water";
-	heavyfootstep = "water";
-	icon = 'icons/turf/floors.dmi';
-	icon_state = "riverwater_motion";
-	name = "water"
-	},
-/area/f13/brotherhood/leisure)
 "xNJ" = (
 /turf/open/water,
 /area/f13/bunker/bunkereight)
@@ -52536,13 +49417,6 @@
 /obj/effect/gibspawner/human,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
-"xPj" = (
-/turf/closed/indestructible/opshuttle{
-	icon = 'icons/turf/walls/reinforced_wall.dmi';
-	icon_state = "r_wall";
-	smooth = 1
-	},
-/area/f13/brotherhood/operations)
 "xPD" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
@@ -52564,36 +49438,23 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
 "xQt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13/wood,
-/area/f13/brotherhood/leisure)
-"xQC" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
-/area/f13/brotherhood/operations)
-"xQD" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/fo13colored/Aqua{
-	brightness = 3;
-	critical_machine = 1;
-	flicker_chance = 0;
-	icon_state = "bulb";
-	name = "Light Bulb"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/rnd/science_lab,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/brotherhood/rnd)
+"xQC" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/royalblack,
+/area/f13/brotherhood/operations)
 "xQI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_wide,
@@ -52615,14 +49476,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkerthree)
 "xRy" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
+/obj/structure/reagent_dispensers/cooking_oil,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
-/area/f13/brotherhood/reactor)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "xRz" = (
 /obj/structure/fence{
 	dir = 8
@@ -52664,15 +49523,8 @@
 	},
 /area/f13/enclave)
 "xSj" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
+/obj/effect/landmark/start/f13/seniorpaladin,
+/turf/open/floor/carpet/royalblack,
 /area/f13/brotherhood/operations)
 "xSs" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -52912,11 +49764,17 @@
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/security)
 "xYo" = (
-/obj/effect/turf_decal/caution/stand_clear/white{
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "neutralrustyfull"
+	},
+/area/f13/brotherhood/leisure)
 "xYr" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -52940,13 +49798,16 @@
 /turf/open/floor/f13,
 /area/f13/vault)
 "xZa" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/rack/shelf_metal,
+/obj/item/pda/engineering{
+	name = "Knight-Engineer Pip-Boy 3000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria{
-	icon_state = "tealwhrusty_chess2"
+/obj/item/lightreplacer,
+/obj/item/stack/sheet/mineral/concrete/ten,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 5
 	},
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/reactor)
 "xZc" = (
 /obj/effect/gibspawner/human,
 /obj/effect/decal/cleanable/dirt,
@@ -53013,15 +49874,12 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "ybq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/door/airlock/grunge{
+	id_tag = "bosdorm9";
+	req_access_txt = "120"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/carpet/black,
+/area/f13/brotherhood/dorms)
 "ybR" = (
 /obj/structure/fluff/hedge,
 /obj/machinery/light{
@@ -53041,6 +49899,14 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"ycc" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/operations)
 "ycf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -53087,16 +49953,6 @@
 /obj/item/clothing/under/misc/stripper/green,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
-"ydp" = (
-/obj/machinery/button/door{
-	id = "boscheckpoint";
-	name = "Research Checkpoint Button";
-	pixel_y = -32;
-	req_one_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/brotherhood/reactor)
 "ydE" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -53114,11 +49970,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/sewer/powered)
-"ydY" = (
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/ore_silo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/rnd)
 "yeb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -53139,10 +49990,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
 "yeo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plating/f13/inside,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "yeD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -53152,22 +50010,20 @@
 /area/ruin/powered)
 "yeV" = (
 /obj/structure/rack,
-/obj/item/soap/deluxe,
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
-"yfa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/f13{
-	icon_state = "rampdowntop"
-	},
+/turf/open/floor/plating/f13/inside,
 /area/f13/brotherhood/operations)
+"yfa" = (
+/obj/machinery/chem_dispenser,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/chemistry)
 "yfc" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/costume,
@@ -53219,17 +50075,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/abandoned/o)
 "ygM" = (
-/obj/structure/window/fulltile/store{
-	layer = 2.9
-	},
-/obj/structure/grille{
-	layer = 2.8
-	},
-/obj/structure/grille{
-	layer = 2.8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/chemistry)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operating)
 "ygQ" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
@@ -53270,15 +50119,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/bunker/bunkerthree)
-"yig" = (
-/obj/machinery/door/window/right/directional/east{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
 "yik" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/table,
@@ -53297,15 +50137,6 @@
 /obj/item/stack/sheet/cloth/thirty,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"yiv" = (
-/obj/machinery/button/door{
-	id = "bosdorm8";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
 "yiF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/secure_closet/armory1,
@@ -53335,18 +50166,24 @@
 	},
 /area/f13/bunker)
 "yjV" = (
-/obj/machinery/button/door{
-	id = "bosdorm7";
-	normaldoorcontrol = 1;
-	pixel_x = 28;
-	specialfunctions = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
+/obj/structure/sign/poster/contraband/pinup_vixen,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operations)
 "yjZ" = (
 /turf/closed/indestructible/f13/obsidian,
 /area/f13/bunker)
+"ykg" = (
+/obj/structure/closet{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
 "ykm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/questing/people{
@@ -81096,7 +77933,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -81701,7 +78538,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -82003,7 +78840,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -85935,7 +82772,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -86239,7 +83076,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -86542,8 +83379,8 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -86845,8 +83682,8 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -87148,7 +83985,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -87463,8 +84300,8 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -87727,6 +84564,16 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -87753,17 +84600,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -88029,6 +84866,16 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -88062,18 +84909,8 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -88330,6 +85167,15 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -88341,6 +85187,12 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
+yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -88351,6 +85203,7 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -88361,24 +85214,8 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -88631,33 +85468,8 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -88682,8 +85494,33 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -88933,6 +85770,21 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -88945,22 +85797,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -88982,7 +85819,7 @@ oEb
 oEb
 oEb
 oEb
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -89234,6 +86071,20 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -89249,28 +86100,14 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -89534,6 +86371,24 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -89548,32 +86403,14 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -89857,30 +86694,26 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -89894,14 +86727,18 @@ yhR
 yhR
 yhR
 oEb
+yhR
+yhR
+yhR
 oEb
 oEb
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -90132,6 +86969,36 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -90145,37 +87012,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -90203,7 +87040,7 @@ oEb
 yhR
 yhR
 yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -90437,6 +87274,7 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -90454,6 +87292,7 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -90465,6 +87304,7 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -90473,14 +87313,11 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -90504,8 +87341,8 @@ oEb
 oEb
 yhR
 yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -90733,57 +87570,18 @@ yhR
 yhR
 yhR
 yhR
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -90808,6 +87606,45 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
+oEb
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -91035,57 +87872,47 @@ yhR
 yhR
 yhR
 yhR
-bgK
-lWI
-lWI
-lWI
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-ueC
-ueC
-ueC
-ueC
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-bgK
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+vOm
+vOm
+vOm
+vOm
+vOm
+vOm
+vOm
+vOm
+vOm
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -91110,6 +87937,16 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -91337,56 +88174,39 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+vOm
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+vOm
+yhR
 bgK
-lWI
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-lNB
-lNB
-lNB
-lNB
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
 bgK
 yhR
 yhR
@@ -91406,11 +88226,28 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -91639,61 +88476,60 @@ yhR
 yhR
 yhR
 yhR
-bgK
-lWI
-tnL
-tnL
-tqM
-eEG
-cOK
-jzm
-eTH
-abq
-eTH
-iED
-dMo
-dMo
-dMo
-jMA
-xdr
-hgX
-mGe
-mGe
-mGe
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+vOm
+ueC
+kKl
+kKl
+oHB
+loq
 eCH
-jnJ
-dMo
-dMo
-pQp
-qIa
-eTV
-qVw
-qVw
-qVw
-qVw
-rHL
-uDl
-unG
-sGY
-qYW
-xLD
-oxW
-diq
-dNx
-wQM
-dNx
-pCD
-pId
-qui
-iHv
-qui
-rYr
-shF
+ueC
+vOm
+vOm
+vOm
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+vOm
+vOm
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+bgK
+bgK
+bgK
+bgK
 bgK
 yhR
 yhR
 yhR
 yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -91703,18 +88539,19 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
+oEb
 yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -91941,61 +88778,60 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+vOm
+ueC
+flQ
+kKl
+kKl
+kKl
+loq
+loq
+eCH
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+vOm
+yhR
 bgK
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-paM
-tnL
-tnL
-tnL
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-iSH
-pHi
-pHi
-pHi
-pHi
-pHi
-lUv
-pHi
-ueC
-ueC
-ueC
-ueC
-iRs
-nut
-dEc
-qyC
-gPr
-uDl
-mYd
-wrp
-oxW
-diq
-vGi
-qtk
-fJY
-mve
-mve
-vhR
-uDl
-shF
+bgK
+bgK
 bgK
 yhR
 yhR
 yhR
 yhR
+vOm
+vOm
+vOm
+vOm
+vOm
+vOm
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -92006,6 +88842,7 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -92013,12 +88850,12 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -92243,60 +89080,61 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
 bgK
-tnL
-tnL
-dWR
-ofZ
-baQ
-jsU
-nEO
-aNn
-fDC
-rRp
-tnL
-hWx
-hph
-qTY
-jAD
-xxF
-qTY
-pHi
-mEc
-cjq
-nhg
-pZu
-akB
-pHi
-msR
-uqW
-vMM
-vMM
-uqW
-kWb
+vOm
 ueC
-yeo
-uDl
-erw
-iKj
-wBV
-uDl
-pId
-xwJ
-xwJ
-kkH
-xwJ
-ksl
-shF
-niU
-lJP
-tXp
-kxm
-uDl
+loq
+ueC
+ueC
+ueC
+ueC
+loq
+kKl
+cjE
+msR
+loq
+loq
+loq
+msR
+loq
+taH
+ueC
+vOm
+vOm
+vOm
+fJY
+vOm
+vOm
+yhR
+bgK
+bgK
+bgK
+vOm
+tnL
+tnL
+tnL
+tnL
+vOm
+bgK
 bgK
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -92316,8 +89154,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -92545,61 +89382,61 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 bgK
-tnL
-tnL
-vWQ
-tnL
-hPf
-jsU
-pcg
-aNn
-tnL
-lKu
-tnL
-xxF
-ggl
-eYI
-mRs
-ggl
-ggl
-pHi
-pmg
-dum
-dum
-dum
-eNZ
-lUv
-vMM
-eCE
-gfU
-eCE
-eCE
-vMM
+fJY
 ueC
-yeo
-uDl
-wWH
-lUy
-sNg
-uDl
-pCD
-csc
-erJ
-erJ
-erJ
-cyF
+loq
+ueC
+pmg
+iPM
+ueC
+dum
+kKl
 uDl
 uDl
 uDl
-eIc
 uDl
 uDl
+uDl
+ueC
+cjE
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+vOm
+vOm
+vOm
+fJY
+fJY
+vOm
+tnL
+ykg
+gBV
+tnL
+vOm
+vOm
+fJY
 bgK
 yhR
 yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -92847,60 +89684,62 @@ kgC
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 bgK
-tnL
-tnL
-dWR
-ach
-sGo
-czv
-lhV
-aNn
-fDC
-rRp
-tnL
-qTY
-ggl
-ggl
-aPD
-ggl
-uJT
-pHi
-kYz
-dum
-dum
-dum
-dum
-pHi
-qaR
-gfU
-nIW
-gfU
-eCE
-nbK
+fJY
 ueC
+loq
+gRz
+kYz
+kYz
+ueC
+tYu
+lNB
+uDl
+ncX
+nIW
+nIW
+nIW
+nIW
+ueC
+uTK
 yeo
-uDl
-uDl
-xuQ
-uDl
-uDl
-mYy
-csc
-erJ
-erJ
-erJ
-kdU
-uDl
-jzw
-qBM
-tXp
-xuQ
-uDl
+kKl
+loq
+vyu
+msR
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+tnL
+tnL
+ozU
+ozU
+tnL
+tnL
+tnL
+fJY
 bgK
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -92920,9 +89759,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -93149,56 +89986,57 @@ kgC
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
 bgK
-tnL
-tnL
-dWR
-ofZ
-sGo
-lhV
-lhV
-xoT
-tnL
-lKu
-tnL
-gFA
-ggl
-biS
-ggl
-aPD
-ggl
-goh
-nQi
-dum
-gTI
-vxX
-dum
-oNz
-eCE
-eCE
-gfU
-eCE
-eCE
-vMM
+fJY
 ueC
-gqy
-ano
-cXh
-cXh
-tkU
-gMF
-uAz
-csc
-erJ
-erJ
-erJ
-wRE
+ggl
+ueC
+ueC
 uDl
-ucf
+uDl
+uDl
+uDl
+uDl
+daZ
+krG
+krG
+krG
+dwB
+woS
+woS
+woS
+woS
+woS
+sHi
+kKl
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+wRE
+aYn
+xuQ
 xuQ
 kAW
-ydp
-uDl
+xde
+tnL
+fJY
 bgK
 yhR
 yhR
@@ -93220,8 +90058,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -93451,63 +90288,63 @@ kgC
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
 bgK
-tnL
-tnL
-vWQ
-tnL
-hPf
-jsU
-pcg
-nvv
-fDC
-rRp
-tnL
-bxs
-aPD
-ggl
-vtS
-ggl
-aul
-pHi
-pHi
-hLk
-pHi
-pHi
-wvA
-pHi
-xND
-eCE
-gfU
-eCE
-gfU
-vMM
+fJY
+fJY
 ueC
-lNB
+eCH
+seR
+ueC
+hLk
+mkj
+baQ
+wvA
 uDl
-kOt
-xuQ
-uDl
-uDl
-evG
-vhz
+nIW
+krG
+krG
+krG
+nIW
+woS
+mQE
+nnI
+jzw
+irU
+sHi
+kKl
+kKl
+kKl
+loq
+kZC
 xRy
-xRy
-xRy
-bCQ
-uDl
+ueC
+tnL
+tnL
 pWD
-kry
-xaM
-xuQ
-uDl
+ozU
+tnL
+tnL
+tnL
+fJY
+bgK
+bgK
 bgK
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -93753,60 +90590,64 @@ kgC
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 bgK
-tnL
-tnL
-dWR
-sGo
-baQ
-jsU
-dGq
-nvv
-tnL
-tnL
-tnL
-eWv
-ggl
-mHI
-ggl
-dig
-ggl
-pHi
-fXe
-xZa
+fJY
+ueC
+ueC
+eCH
+wAC
+ueC
+akt
 gsa
 ppU
-foH
-pHi
-qaR
-gfU
-eCE
+urF
+uDl
+nIW
+vhR
 krG
-eCE
-nbK
-ueC
-ueC
-uDl
-uDl
-fMp
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-uDl
-grV
-qdj
+krG
+nIW
+woS
+uHp
+skA
+xpI
+pYI
+woS
+qlm
+woS
+woS
+woS
+wIG
+kzQ
+yjV
+wRE
+aYn
+xuQ
+xuQ
+kAW
 xde
-uDl
+tnL
+fJY
+fJY
+fJY
 bgK
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -93817,6 +90658,7 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -93824,12 +90666,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -94055,56 +90892,59 @@ qYA
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
 bgK
-tnL
-tnL
-sGo
-sGo
-tnL
-tnL
-tnL
-xoT
-fqC
-hcw
-tnL
-rEV
-uHp
-ggl
-aPD
-biS
-ggl
-pHi
+fJY
+ueC
+loq
+loq
+taH
 uME
-foH
+oFJ
 pcy
 gBR
-ipI
-lUv
-vMM
-gfU
-gfU
-gfU
-gfU
-vMM
-pHi
-qfW
-qfW
+aYb
+uDl
+cbX
+rYc
+cIZ
+xwJ
+uDl
+woS
+hEs
+eDZ
+xpI
+kRg
 jHy
-qfW
-ueC
+iGM
 qVD
-qfW
-qfW
-jHy
+unG
+woS
+wIG
 yeV
 ueC
-qfW
-wDn
-uDl
-cKv
-nzI
-rSa
-uDl
+tnL
+tnL
+pWD
+gvu
+tnL
+tnL
+aZU
+tnL
+tnL
+fJY
 bgK
 yhR
 yhR
@@ -94118,12 +90958,9 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -94357,61 +91194,65 @@ kgC
 qYA
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
 bgK
-tnL
-tnL
-kGe
-kGe
-tnL
-hLK
-moa
-aNn
-nvv
-idS
-tnL
-uHp
-jBi
-cNn
-ggl
-eqg
-emk
-uCZ
-aqG
+fJY
+ueC
+kaE
+ueC
+ueC
+ueC
 xZa
 ipI
 rfP
-foH
-pHi
+upz
+gYT
 gzW
 eCE
-eCE
-eCE
-eCE
-nGN
-pHi
+bCQ
+cdK
+wQM
+woS
+pag
 xpI
-qfW
-qfW
-qfW
-ueC
+gTQ
+fDl
+pae
+eDZ
 qZz
 tFX
-vrw
-qfW
-qfW
-dbo
-qfW
+woS
+wIG
+yeV
+ueC
+wRE
 aYn
-uDl
-lHj
-qwg
+xuQ
+xuQ
+tnL
 ocx
-uDl
+dCo
+jcL
+tnL
+fJY
 bgK
 yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -94419,24 +91260,20 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -94659,56 +91496,60 @@ tuT
 kgC
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 bgK
-tnL
-tnL
-tnL
-tnL
-tnL
-nvv
-nvv
-nvv
-nvv
-pyQ
-tnL
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
-jZP
-ppU
-nhw
-rfP
-upz
-pHi
-dsc
-eCE
-mMn
-bdi
-eCE
-kZP
-pkh
-maM
-qfW
-qfW
-qfW
+fJY
 ueC
+eUt
+tee
+tee
+tee
+tee
+tee
+cca
+upz
+rys
+dsc
+mMn
+mMn
+hgy
+dsc
+kZP
+eAi
+aNn
+xaM
+ngH
+uED
+qZz
 rJZ
 vrw
-vrw
-qfW
-qfW
+woS
+wIG
+yeV
 ueC
-dbo
 ueC
-uDl
+ueC
+ueC
 ozU
-wit
+tnL
 lZy
-uDl
+dCo
+mrZ
+tnL
+fJY
+bgK
 bgK
 yhR
 yhR
@@ -94734,11 +91575,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -94961,61 +91798,66 @@ tuT
 kgC
 kgC
 kgC
-uUS
-tnL
-bJc
-tfW
-hyH
-tnL
-iGM
-mYx
-tnL
-tkZ
-tkZ
-pav
-tYO
-kaE
-lWG
-pGA
-eDZ
-gSj
-pHi
+kgC
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+bgK
+fJY
+ueC
+loq
+tee
+ezR
 eEr
-ppU
-ppU
-foH
-ipI
-pHi
+nDM
+tee
+ach
+mVt
+uDl
 mda
 eCE
 eCE
+mMn
 gfU
-gfU
-gfU
+woS
 brH
-maM
-qfW
-qfW
-qfW
+xQt
+iDW
+uJT
+iDW
+hnc
 phC
-qfW
 vJu
-qfW
-qfW
-hNe
+woS
+wIG
+taH
+loq
+yeo
+kKl
 ueC
-sAj
-iMu
-uDl
-foP
+ozU
 wit
-llC
-uDl
+mBC
+dCo
+jRc
+tnL
+fJY
+fJY
 bgK
 yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -95027,19 +91869,14 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
+oEb
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -95263,56 +92100,60 @@ tuT
 qYA
 nVk
 tuT
-uUS
-tnL
-tnL
-tyq
-emH
-pwo
-nvv
-xoT
-tnL
-tnL
-tnL
-tnL
-lTM
-seC
-aJM
-xQt
-rZI
-rAk
+kgC
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+oEb
+yhR
+bgK
+fJY
+ueC
+loq
+tee
 iSH
-xBS
-foH
-ppU
-foH
-foH
-pHi
+kqf
+tkZ
+tee
+aqG
+qmx
+tee
 gix
-eCE
+gix
 vRp
 pMe
-prv
-qpy
-pkh
-qfW
-qfW
-qfW
+uDl
+woS
+lTI
+dpa
+oCO
+vMH
 mMm
-ueC
+fCv
+woS
+woS
+woS
 kKQ
-qfW
-qfW
-kKQ
-sJN
 ueC
-cLN
-jca
-uDl
+ueC
+ueC
+loq
+ueC
 fAl
-dDY
-uDl
-uDl
+tnL
+qrv
+dCo
+lZy
+tnL
+tnL
+fJY
 bgK
 yhR
 yhR
@@ -95330,11 +92171,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 oEb
@@ -95565,67 +92402,67 @@ tuT
 tqd
 kSm
 tuT
-uUS
-tnL
-tnL
-tnL
-tnL
-tnL
-nvv
-aNn
-tnL
-nGX
-uQS
-aiQ
-mkj
-jZJ
-vNP
-cxP
-vNP
-vXM
-pHi
-pHi
+kgC
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+bgK
+fJY
+ueC
+loq
+tee
+csR
+kqf
 tTK
 cWL
 tch
-pHi
+qOS
+tee
+eNl
+qkl
+qkl
+dnT
 ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-bYs
+vUO
 ced
-maT
-woS
-woS
-woS
-woS
-woS
-woS
-woS
-woS
-woS
-woS
-woS
+iRs
+pHi
+pHi
+pHi
+pHi
+pHi
+vMM
+uqW
+odh
+fDr
+tnL
+tnL
+qyz
+tnL
 aZU
-fTu
-ueC
+tnL
+pId
+dCo
+dCo
+aGs
+tnL
+fJY
+bgK
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -95867,77 +92704,77 @@ tuT
 kgC
 eCn
 dTf
-uUS
-tnL
-pPd
-tfW
-qeB
-tnL
-qzi
-aNn
-tnL
-awA
-bZQ
-mkj
-bZQ
-kaE
-xmE
-xmE
-eeH
-rej
+kgC
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+bgK
+fJY
+ueC
+loq
+tee
 eub
-eAi
-kaE
-kaE
-kaE
+kqf
+kqf
+dHT
+dHT
 fRI
 wnm
 gfi
 kIr
-gfi
-iqg
-uBM
-iKS
-ueC
-maM
-xwz
-qNy
+pWN
+wHI
+cLN
+cCi
+cCi
+iKj
+trK
+vZC
 fwv
-fTO
+pHi
 sug
 wmt
 xDh
 xYo
-sGT
-xbs
+vMM
+tnL
 pSA
-xiK
-woS
-qfW
-fNa
-ueC
+dCo
+rEV
+mBC
+mBC
+dCo
+aSA
+gTI
+aSA
+tnL
+fJY
+bgK
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
+oEb
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -96169,60 +93006,62 @@ qsz
 qYA
 kgC
 kgC
-uUS
-tnL
-tnL
-tyq
-yjV
-qOS
-xoT
-nvv
-tnL
-njH
-iHk
-iHk
-jLC
-kaE
-kaE
-kaE
-kaE
-kaE
-evg
-kaE
-oDC
-kaE
-kaE
-pHi
-uBM
-haX
-hJm
-pWN
-uBM
-uBM
-tGX
-jwK
-maM
-jKO
-qNy
-fWs
-sFT
-fTO
-fTO
-fTO
-fTO
-fTO
-fTO
-hWF
-fTO
-woS
-qfW
-kuz
+kgC
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+fJY
+fJY
 ueC
-ohv
-ohv
-ohv
+kaE
+tee
+evg
+qCz
+qCz
+pcL
+gRo
+qoc
+omW
+haX
+kIr
+pWN
+wHI
+dNx
+cCi
+cCi
+iri
+trK
+mTV
+fWs
+pHi
+fTO
+wmt
+rNo
+xYo
+diq
+tnL
+nDr
+mBC
+dCo
+dCo
+dCo
+mJs
+joH
+jEO
+jEO
+tnL
+fJY
+bgK
 yhR
-ohv
 yhR
 yhR
 yhR
@@ -96238,9 +93077,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 oEb
@@ -96471,60 +93308,61 @@ tuT
 kgC
 yhR
 yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 bgK
-tnL
-tnL
-tnL
-tnL
-tnL
-afW
-nvv
-tnL
-mrL
-mcQ
-ncT
-iHk
-bZQ
-cdK
-cdK
-mkj
-kaE
-pHi
-pHi
-pHi
-pHi
-pHi
-pHi
+fJY
+fJY
+fJY
+fJY
+fJY
+ueC
+ueC
+loq
+tee
+tee
+eLm
+aiA
+qui
+tee
+tee
+tee
+qIa
+pNK
+rOa
 uBM
-uBM
-uBM
-uBM
-uBM
-shY
+ueC
 lCH
-jKo
-maM
-xjC
-mGV
-mTV
-wcC
-fTO
-xNB
-wLP
-ybq
-afm
-jXt
-wLP
-xQD
-woS
+cCi
 qfW
-kuz
-ueC
-ueC
-ueC
-dET
-ohv
-ohv
+mRs
+mTV
+mTV
+llC
+fTO
+wmt
+wLP
+xYo
+afm
+tnL
+hmU
+dCo
+tnL
+tnL
+aZU
+mJs
+jEO
+jEO
+eOY
+tnL
+fJY
+bgK
 yhR
 yhR
 yhR
@@ -96543,15 +93381,14 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -96773,60 +93610,66 @@ qYA
 qYA
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
 bgK
-tnL
-cHR
-tfW
-bYu
-tnL
-aNn
-nvv
-tnL
-mrL
-rID
-niJ
-iHk
-azd
-cfY
-uuv
-egv
-kaE
-pHi
-eGH
-oNR
+fJY
+ueC
+ueC
+ueC
+ueC
+ueC
+vBk
+eUt
+tee
+vXE
+iKT
+bxZ
 iZL
 bxZ
-pHi
-iTk
-wHI
-uBM
-wHI
-wHI
+vJB
+tee
+sJS
+bYu
+pWN
+fMp
 ueC
-ueC
-ueC
+onR
+cCi
 qfW
-xjC
-qNy
-woS
-sFT
-fTO
-cbX
+foH
+mTV
+mTV
+fAe
+xDh
+wmt
 hmq
-fTO
+wmt
 axF
-pag
-uOn
+aZU
 dCo
-woS
-iOp
-kuz
-qfW
-qfW
+dCo
+maT
+nbm
+tnL
+tdC
 jEO
-ohv
-ohv
-ohv
+jEO
+jEO
+tnL
+fJY
+bgK
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -96846,13 +93689,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -97075,61 +93912,61 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
 bgK
-tnL
-tnL
-tyq
-yiv
-cyw
-aNn
-nvv
-tnL
-vNZ
-ppW
-gsK
-ezR
-bFE
+fJY
+ueC
+kaE
+loq
+loq
+loq
 eUt
-eUt
-eor
+loq
 xHM
-pHi
+bxZ
 iKT
-oDC
-kaE
-kaE
-pHi
-uBM
-uBM
-uBM
-uBM
-uBM
-ixN
+iKT
+czv
+gqZ
+lFO
+tee
+lYb
+qhz
+cxP
+xFd
+ueC
+cea
+cCi
 qfW
-qfW
-qfW
-onR
-qNy
+trK
+mTV
 lTn
-eRg
-fTO
-xoQ
+pkh
+sug
+wmt
 rNo
-gXb
+wmt
 ggL
-vMH
-qNy
+tnL
 mBC
-woS
-qfW
-kuz
-qfW
-qfW
+mBC
+maT
+nbm
+tnL
+mJs
 jEO
-ohv
-ohv
-ohv
-yhR
+jEO
+cOK
+tnL
+fJY
+bgK
 yhR
 yhR
 yhR
@@ -97142,10 +93979,10 @@ oEb
 oEb
 oEb
 yhR
+oEb
 yhR
 yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -97377,64 +94214,64 @@ kgC
 kgC
 kgC
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
 bgK
-tnL
-tnL
-tnL
-tnL
-tnL
-aNn
-nvv
-tnL
-pHi
-pHi
-pHi
-bZQ
-azd
-eUt
-oCO
-eor
-sdz
+fJY
+ueC
+loq
+tee
+tee
+tee
+tee
+tee
+tee
 ttS
-kaE
-eNi
-eQa
+tee
+tee
+tee
 fat
-pHi
-wHI
-wHI
-shY
-wHI
-wHI
+lFO
+tee
+ueC
+ueC
+ueC
+ueC
 ueC
 iVq
-maM
-maM
+cCi
+iri
 trK
-cca
+mTV
 nsx
-pYB
+pHi
 jXt
 wtD
 loz
-odh
+rfL
 qdV
-aBA
-fTO
-aSA
-eul
-wmG
-dFu
-ueC
-ueC
-ueC
-dET
-ohv
-ohv
+tnL
+rtw
+lYH
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+fJY
+bgK
 yhR
 yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -97444,7 +94281,7 @@ oEb
 oEb
 oEb
 yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -97679,66 +94516,66 @@ xcY
 xcY
 kgC
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
 bgK
-tnL
-weg
-tfW
-hyH
-tnL
-iPe
-aNn
-uku
-dqS
-waK
-tnL
-iUB
+fJY
+ueC
+loq
+tee
+uuv
+vqY
+pWn
 bZQ
-csR
-dpK
-bZQ
-xHM
+pPd
 uCZ
-uCZ
+hTr
 bGu
-bGu
-pHi
-pHi
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
+noV
+ljc
+qfW
+cmM
+uJJ
+uJJ
+qfW
+qfW
+eNP
 bRN
-maM
-dHT
-mAe
+cCi
+lPN
+trK
 rwV
 aIc
-nqG
-sQc
-fTO
-fTO
-qdV
-qdV
-ois
-fTO
-xoQ
+pHi
+pHi
+pHi
+qVw
+pHi
+pHi
+aZU
+bSQ
+lYH
 kPi
-qfW
-qfW
-ueC
-ohv
-ohv
-ohv
-ohv
+eTY
+tyq
+tnL
+fJY
+fJY
+fJY
+fJY
+fJY
+bgK
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -97750,6 +94587,7 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -97757,10 +94595,9 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -97981,55 +94818,61 @@ nMz
 tuT
 kgC
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 bgK
-tnL
-tnL
-tyq
-uED
-mAP
-nvv
-aNn
-nvv
-nvv
-nvv
-ibi
+fJY
+ueC
+aGI
 eCA
-qSn
+pWn
 xHG
 vJB
-vJB
-xHM
+bfF
+utX
 dXC
 kqf
+heh
+tee
 hJQ
-hJQ
-hJQ
-pHi
+sfU
 gzj
 oez
 oez
 mXb
-ueC
-ueC
-vbH
-maM
-rFP
-cSk
-vkW
-aIc
-fPf
-fTO
-wvL
-loz
-qgp
-fAe
-sJq
-fTO
-xoQ
-kPi
+cCi
 qfW
-sXx
+qfW
+pbr
+ldy
+cCi
+vkW
+pbr
+fPf
+bol
 ueC
+xmd
+qgp
+ueC
+sJq
+bSQ
+pEl
+tnL
+jMb
+sXx
+aZU
+fJY
+bgK
+bgK
+bgK
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -98056,13 +94899,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -98283,55 +95120,65 @@ wVU
 jdK
 kgC
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 bgK
-tnL
-tnL
-tnL
-tnL
-tnL
-aNn
-aNn
-xoT
-xoT
-aNn
+fJY
+ueC
 loq
-gXc
+tee
+pWn
+cJo
+vJB
+tWR
+utX
 maM
-maM
-maM
-maM
-maM
-maM
-qfW
-maM
-maM
+aPD
+dqS
+tee
 hcr
-gho
-maM
-maM
-maM
+cCi
+ueC
+ueC
+ueC
+mNI
 qfW
-myz
-gXc
+cCi
+cCi
+aLs
+uJJ
+cCi
+cCi
 qfW
-maM
-rFP
-jVN
-mJs
-nDM
-pxz
+fPf
 qNy
-fTO
-wyr
-hIr
-hTr
+ueC
+xmd
+epV
+ueC
 aDy
-fTO
-jpT
-woS
-ueC
-ueC
-ueC
+lYH
+eAw
+tnL
+tnL
+tnL
+tnL
+fJY
+bgK
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -98349,17 +95196,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -98585,52 +95422,56 @@ dTf
 jdK
 kgC
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 bgK
-tnL
-nbm
-rys
-nvv
-vKC
-aNn
-nvv
-aNn
-aNn
-aNn
-rhS
-lJk
-vma
+fJY
+ueC
+aGI
+tee
+rsO
 tWR
-rOa
-lFO
+bfF
+tWR
 utX
 nHG
 vma
-tWR
-rOa
-cwP
-gho
-maM
+uQE
+tee
+hcr
+cCi
+ueC
+ueC
+ueC
+jeP
 qfW
-qfW
-maM
-gXc
-gho
-qfW
-maM
+eYs
+ueC
+ueC
 rFP
 xjC
-qNy
-woS
-sFT
-qNy
-fTO
+cCi
+pbr
+qfW
+jwK
+ueC
 xmd
 wmP
-lKd
+ueC
 cPd
-uOn
-nHa
-woS
+lYH
+pEl
+lUc
+eTY
+tyq
+tnL
+fJY
 bgK
 yhR
 yhR
@@ -98657,13 +95498,9 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -98887,52 +95724,56 @@ kgC
 kgC
 kgC
 yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
 bgK
-tnL
-nbm
-rys
-aNn
-lic
-kSJ
-nvv
-nvv
-kSV
-aNn
-wVr
-gXc
-maM
-maM
+fJY
+ueC
+kaE
+tee
+vJB
+tid
 pWn
-maM
-maM
-qfW
-maM
-pWn
-maM
-maM
-gXc
-wjB
+tWR
+dDY
+kqf
+cET
+nEO
+tmA
+tkU
+cCi
+ueC
 pIq
-ayZ
-jzo
-gXc
-gXc
+oez
+oez
 qfW
-maM
-rFP
-xjC
-mGV
-vET
+uJJ
+qfW
+cCi
+ueC
+ueC
+cCi
+cCi
 wcC
-qNy
-xNB
-wLP
-jXt
-jXt
-wLP
-tdC
+ueC
+ueC
+qFJ
+ueC
+ueC
+pmS
 lYH
-woS
+lYH
+tnL
+xBS
+sXx
+xnb
+fJY
 bgK
 yhR
 yhR
@@ -98940,6 +95781,7 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -98949,22 +95791,17 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -99189,56 +96026,61 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
 bgK
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
-tnL
+fJY
 ueC
-ueC
-ueC
-wRS
-ueC
-ueC
-ueC
+loq
+eCA
+vJB
+xHG
+pWn
+bfF
+dDY
 pqN
-ueC
-ueC
 pqN
+eNZ
+nwq
+hFH
+pbr
 ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-vDc
+rWq
+pbr
 qfW
-rFP
-ced
-qNy
-pLX
+qfW
+cCi
+qfW
+uJJ
+jXQ
+ueC
+qfW
+cCi
 sFT
 uOn
 xoQ
-qNy
-fTO
-qNy
-qNy
-mKu
-fTO
-woS
+ljc
+mAe
+ueC
+gSj
+pEl
+lYH
+tnL
+tnL
+tnL
+tnL
+fJY
 bgK
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -99247,6 +96089,7 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -99254,18 +96097,12 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -99491,52 +96328,56 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
+fJY
 ueC
+loq
+tee
+uuv
+vqY
+pWn
+bZQ
+mEc
+mYd
+bYx
+fjz
+tee
+hFH
+uJJ
 ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-qCz
-ueC
-ueC
-ueC
-ueC
-gqZ
-gqZ
-gqZ
-cET
-gqZ
-ueC
-bRN
-maM
-rFP
+hXs
+beH
+rZJ
+rZJ
+rZJ
+rZJ
+beH
+wZw
 xwz
-qNy
 pbr
-qwS
-fTO
-xbk
-sFT
-ydY
-cJo
+cCi
+cCi
+qfW
+qfW
+ljc
+cCi
+cCi
 xbs
-qyz
-dDI
-woS
+dCo
+dCo
+erw
+eTY
+tyq
+aZU
+fJY
 bgK
 yhR
 yhR
@@ -99546,6 +96387,9 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -99555,19 +96399,12 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -99793,64 +96630,68 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
+fJY
 ueC
-vSU
-vSU
-vSU
-vSU
+aGI
+tee
+tee
+tee
+tee
+tee
 ueC
-cJA
-cJA
-mwx
+ueC
+ueC
+ueC
+ueC
+ljc
+uJJ
+ueC
+bYs
 beH
-oyg
+vSU
+vSU
+vSU
+vSU
 beH
-mwx
-cJA
+rGJ
 ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-vDc
-maM
-vQs
-uHP
-woS
-woS
-woS
-tCU
-xCL
-woS
-woS
-woS
-woS
-woS
-woS
-woS
-gvF
-gvF
-gvF
-gvF
-ulw
-ulw
-hfw
+qfW
+qfW
+cCi
+cCi
+qfW
+ljc
+ljc
+ljc
+ouH
+pEl
+eAw
+tnL
+sMi
+sXx
+tnL
+fJY
 bgK
 yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+oEb
+yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -99860,16 +96701,12 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -100095,59 +96932,56 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
+fJY
 ueC
+aGI
+loq
+loq
+aGI
+ueC
+myz
+cYb
+gho
+cYb
+vsQ
+ueC
+ljc
+uJJ
+ueC
+fId
+beH
 vSU
 vSU
 vSU
 kxh
-aGI
-rIf
-myz
-gho
-gho
-yfa
-gho
-myz
-ljc
-uJJ
-myz
-gXc
-vRM
-jMZ
-gXc
-czU
-maM
-maM
+beH
 vQs
-ngH
-gvF
-gvF
-ghv
-nlB
+ueC
+wec
+qfW
+aFE
+kpo
 wQP
 gvF
 nlB
-gvF
-pmS
+lor
+eGH
 pEl
-vXE
-iwN
-mwj
-lIG
-aeo
-pae
-xDm
-gRz
-hfw
+pEl
+tnL
+tnL
+tnL
+tnL
+fJY
 bgK
 yhR
 yhR
@@ -100157,6 +96991,9 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -100170,7 +97007,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -100397,59 +97234,56 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
+fJY
+ueC
+ueC
+ueC
+ueC
+rbu
+ueC
+wym
+xQC
+oTo
+rtK
+vsQ
+ueC
+rAk
+cCi
+ueC
+ueC
 ueC
 vSU
 vSU
 vSU
 vSU
-rbu
-hmF
-wym
-xQC
-oTo
-rtK
-xQC
-wym
-xQC
-bQB
-rtK
-rtK
-mwf
-cmM
-rtK
-ofk
-joH
-mwf
-gbQ
-mho
-gvF
-vZC
+ueC
+ueC
+ueC
+qfW
+qfW
 lYY
 rMQ
 dkQ
 gCc
 sAG
-gCc
-gCc
-swH
-nlB
-gvF
+lor
+gMF
+pEl
+pEl
+ybq
 eTY
-jJj
-xDm
-xDm
-xDm
-fuU
-hfw
+tyq
+aZU
+fJY
 bgK
 yhR
 yhR
@@ -100459,6 +97293,9 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -100697,61 +97534,58 @@ kgC
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
 yhR
 yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
+fJY
+fJY
+fJY
+fJY
+ueC
+aGI
+ueC
+cYb
+xSj
+lHj
+rtK
+vsQ
+ueC
+hJQ
+cCi
+ueC
+ueC
 ueC
 vSU
 vSU
 vSU
 vSU
-gFR
-lDk
-cYb
-xSj
-xSj
-cYb
-xSj
-cYb
-cYb
-uJJ
-myz
-gXc
-maM
-xfP
-gXc
-gGN
-cCi
-maM
-rFP
+ueC
+ueC
 dbi
-gvF
-bSQ
-gvF
-gvF
+aRB
+pbr
+lor
+kev
+wXq
+oKj
 jat
-gvF
-jat
-gvF
+pbF
 bSQ
-hEs
-gvF
-gvF
+lYH
+lYH
+tnL
 xhB
-jso
-xDm
-xDm
-xDm
-aYb
-hfw
+sXx
+tnL
+fJY
 bgK
 yhR
 yhR
@@ -100761,19 +97595,22 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -101000,82 +97837,82 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
 yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
+bgK
+bgK
+bgK
+fJY
 ueC
-vSU
-vSU
-vSU
-vSU
+loq
 ueC
-wec
-beH
+rIf
 mwx
-beH
-mpS
-beH
-mwx
+mYy
+eVf
+kXV
+rRp
 sjp
 mHJ
-kXV
-kXV
-txT
-kXV
+rcU
+wIG
 ueC
-czt
-hFH
-maM
-rFP
+vSU
+vSU
+vSU
+vSU
+ueC
+ueC
 jiB
 aRB
-iri
-ooN
+qfW
+lor
 fpr
 oKj
 ePu
+afp
+lor
 wsX
-agi
-wsX
-eNP
+tnL
 qpN
-gvF
-gvF
-pBi
-gvF
-fNt
-gvF
-gvF
-hfw
-bgK
+tnL
+tnL
+tnL
+tnL
+fJY
+vOm
+vOm
+vOm
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -101303,60 +98140,61 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
+fJY
 ueC
+loq
 ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-tqY
-dnT
-sBD
-tYE
-htH
-rOH
-sJS
-maM
-rFP
-tXl
-taH
-lPN
-dIT
-dIT
-dIT
-dIT
-umn
-mnP
-mnP
 jNz
-ptW
-gvF
+oJi
+ppW
+mpS
+udd
+ueC
+jcM
+qfW
+ueC
+wIG
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+tXl
+qfW
+lPN
+lor
+yfa
+fXe
+cyF
+umn
+lor
+mnP
+eHY
+aLl
+wKD
 imC
-jRc
-uVv
 hTW
-uVv
-uVv
-xLy
-bgK
+hTW
+hTW
+hTW
+hTW
+pFU
+yhR
+ohv
 yhR
 yhR
 yhR
@@ -101368,8 +98206,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -101605,60 +98442,61 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
+fJY
 ueC
+loq
 ueC
+jnJ
+uwi
+vyf
+rmC
+eRa
 ueC
-eQz
-ueC
-ueC
-ueC
-tmA
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-sHi
-qFJ
-mFK
-wqf
-kuR
-nbP
-rZJ
-maM
-rFP
+jcM
 qfW
+ueC
+rcU
+ueC
+ueC
+uVv
+uVv
+uVv
+uVv
+uVv
+uVv
 jcR
-dIT
-dIT
-dIT
-dIT
-dIT
-mfS
-dIT
-dIT
-dIT
-dIT
-fHU
+uVv
+uVv
+kRr
+jcR
+uVv
+uVv
+uVv
+mnP
+kuR
+thW
+thW
 eHY
-jEJ
-vyu
-joW
-cZu
-pSq
 xLy
-bgK
+eHY
+cZu
+cZu
+eHY
+pFU
+nbK
+ohv
 yhR
 yhR
 yhR
@@ -101669,9 +98507,8 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -101907,78 +98744,78 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
+fJY
+ueC
+loq
 ueC
 ueC
-iXe
-kzQ
-ggG
 ueC
-cea
-rsB
-udd
-pxl
-fBB
-qPr
+ooN
 ueC
-pIe
-ouH
-uwi
-nym
 ueC
-ihg
+ueC
+ueC
+ueC
+ueC
 wIG
-jWQ
-rcU
-sfU
+aGI
+aGI
+uVv
 rOH
 aRW
-qfW
-gYT
-bDL
+pwo
+uVv
+nNC
 aGf
-lPN
-dIT
-dIT
+oNz
+bxs
+pxz
 dIT
 dIT
 mfS
-aLW
-dIT
-dIT
-dIT
+uVv
+qSn
+lTM
+eHY
 fHU
 eHY
 jFG
-vyu
-joW
-joW
-joW
+aLl
+aLl
+eHY
+eHY
 xLy
-bgK
+ohv
+ohv
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -102209,66 +99046,66 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
+fJY
+ueC
+kaE
 ueC
 ueC
-kLv
-vsQ
-vsQ
-dbo
-vsQ
-udd
-ezZ
-mzQ
-maM
 eRa
-bAQ
-maM
+mpS
+nlw
 nlw
 mgY
-maM
+udd
+lqk
 ueC
-ueC
-ueC
-xLK
-ueC
-ueC
-ueC
+wIG
+aGI
+aGI
+dGq
+mwf
 eCx
-qfW
-maM
-hUC
-aFE
-rGJ
+nCC
+uVv
+nNC
+aGf
+veX
 pop
-jeP
-kpo
-lor
+nfd
+lGX
+lGX
 gbm
-lor
-lor
-lkj
+uVv
+rhU
+hTW
 gVI
-gvF
+hTW
 liJ
-fNQ
+hTW
 fAK
-foe
-lKz
+aLl
+aLl
 aLl
 xLy
-bgK
+ohv
+ohv
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -102511,67 +99348,67 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
+fJY
 ueC
+loq
+loq
 ueC
-ueC
-ueC
-dbo
-ueC
-nnE
-udd
-vsQ
-kZv
-qfW
 tGj
 bAQ
-maM
-maM
-maM
-maM
-maM
-maM
+bAQ
+fPf
+ueC
+rID
+aBA
+ueC
 vlM
 tmz
-mwf
-sub
+vBk
+uVv
 hfp
 mwf
 wmG
-wmG
-fBc
-ygM
+uVv
+nNC
+aGf
 veX
-nfd
-nfd
-nfd
+pop
+gXb
+hPf
 lGX
 gsj
-vBl
-lor
-iiZ
-ofQ
-gvF
-hmU
+uVv
 qWo
+ofQ
+ofQ
+ofQ
+ofQ
+hTW
 hIv
-joW
-xAH
-joW
-xLy
-bgK
+rej
+hTW
+hTW
+pFU
+nbK
+ohv
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -102813,60 +99650,59 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+oEb
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
+vOm
 ueC
 ueC
-rpO
-yig
-vsQ
+aGI
 ueC
-mEW
-vsQ
-pwJ
-nND
-rzA
 aYu
-bAQ
-maM
-maM
-maM
-maM
-maM
-maM
-maM
-vlM
-afp
+fTu
+dDT
+hmF
 ueC
+qaR
+moa
+ueC
+qFJ
+ueC
+ueC
+uVv
 nWa
 gFb
-rZJ
-qfW
-fAC
+ixN
+odp
+ygM
 ygM
 wyY
+rZI
 nfd
-nfd
-nfd
-nfd
-nfd
-gcY
-lor
-qhz
-dkv
-gvF
-fGX
-fNQ
+sBD
+lGX
+ahf
+uVv
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+thW
+thW
 thW
 joW
-aFw
-joW
-tsJ
-bgK
+pFU
 yhR
 yhR
 yhR
@@ -102875,7 +99711,8 @@ yhR
 yhR
 yhR
 yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -103115,60 +99952,60 @@ yhR
 yhR
 yhR
 yhR
-bgK
-bkL
-bkL
-bkL
-bkL
-bkL
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+vOm
+vOm
+ueC
+aGI
 ueC
 ueC
-daZ
-vsQ
-dKf
 ueC
-jXQ
-cbJ
-vsQ
-sdo
-qfW
-maM
-cny
-ayB
-hmc
-fDl
-eYs
-gZp
-iHP
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
 qSM
-qSM
-qSM
-ueC
-ueC
-ueC
-rkR
-rBL
-lee
-lor
-pbF
+taH
+loq
+uVv
+uVv
+xjl
+uVv
+uVv
+uVv
+ois
+uVv
 urv
-nfd
+fBB
 jpG
-nfd
+sGT
 aij
-sGJ
-lor
 uVv
-paZ
-uVv
-uVv
-oWp
-aGs
-uVv
-uVv
+pxX
+pxX
+nhg
+loq
+loq
+cjE
+eHY
+kuz
+thW
 qFn
-xLy
-bgK
+pFU
+yhR
 yhR
 yhR
 yhR
@@ -103412,65 +100249,64 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
 yhR
 yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
+vOm
 ueC
-tee
-tee
-eNl
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-dDT
-mSg
+qwS
+loq
+loq
+loq
+loq
+nhg
+aGI
+aGI
+aGI
+aGI
+qSM
+qSM
 jsV
-tee
-tee
-ueC
-gSK
+wIG
+wIG
+pcg
+loq
 pxX
 ckn
-lor
-kZC
-sMi
-rzy
-qkl
-pNK
-lTI
-xFd
-lor
-bae
-bae
-bae
+pxX
 uVv
-owJ
-gDy
-wXq
 uVv
-qlm
-iTq
-bgK
+uVv
+uVv
+uVv
+uVv
+uVv
+beH
+beH
+ueC
+ueC
+ueC
+ueC
+hTW
+hTW
+hTW
+hTW
+pFU
 yhR
 yhR
 yhR
@@ -103489,6 +100325,7 @@ yhR
 yhR
 yhR
 yhR
+oEb
 oEb
 oEb
 oEb
@@ -103715,71 +100552,71 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-tee
-vqY
-uHS
-gTQ
-jMb
-vqY
-tee
-lHg
-lHg
-wYi
-lHg
-lHg
-kuN
-uqo
-uqo
-bql
-iFX
-ldy
-aPq
-xsN
-xsN
-lKm
-tid
+vOm
 ueC
-bol
-qfW
-iXG
-lor
-lor
-lor
-lor
-lor
-lor
-lor
-qLX
-lor
-uVv
-uVv
-vtK
-uVv
-uVv
-nCC
-uVv
-uVv
-mQE
-xPj
-bgK
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+pxX
+nhg
+loq
+loq
+loq
+loq
+nhg
+beH
+beH
+vyu
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+vOm
+vOm
+vOm
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -104018,62 +100855,60 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+oEb
+oEb
+oEb
 yhR
 yhR
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-tee
-hCl
-mba
-bfF
-odp
-qxc
-tee
-oFJ
-jWE
-vur
-jWE
-xnb
-kuN
-qoc
-qoc
-qoc
-qoc
-cIZ
-xsN
-xsN
-xsN
-aiA
-iwU
+vOm
+vOm
+vOm
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+vOm
+vOm
 ueC
-tVm
-bHg
-iDp
-qfW
-dHT
-mwf
-uhG
-wmG
-mwf
-bCR
-lAl
-vCa
-dHf
-wmG
-eXr
-jNT
-omW
-mwf
-hfJ
-lnx
-oRO
-xPj
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+ueC
+tqN
+ycc
+hig
+fJY
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
 bgK
 yhR
 yhR
@@ -104081,12 +100916,14 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -104322,62 +101159,55 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
+oEb
 yhR
+yhR
+oEb
+yhR
+oEb
+yhR
+yhR
+oEb
+yhR
+oEb
+oEb
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-tee
-dgQ
-odp
-gTQ
-tBj
-odp
-tee
-gBV
-vur
-vqu
-jWE
-iiV
-kuN
-uqo
-uqo
-tsT
-qoc
-mrj
-xsN
-xsN
-xsN
-dVq
-vUO
-tee
-jEF
-ovy
-xjl
-ueC
-pLO
-bMT
-jBx
-sZN
-ueC
-ueC
-pFU
-ueC
-ueC
-ueC
-eLs
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-xPj
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+oEb
+vOm
+vOm
+vOm
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
+fJY
 bgK
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -104394,6 +101224,13 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 oEb
 oEb
@@ -104625,60 +101462,53 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-tee
-dzq
-pcL
-gTQ
-jLG
-pcL
-tee
-rWq
-luH
-kUn
-xnb
-wRN
-tee
-oqW
-oqW
-oqW
-iDW
-rWn
-xsN
-xsN
-aSq
-aiA
-ekh
-tee
-vyf
-tee
-tee
-ueC
-mBy
-iPM
-heh
-iTD
-ueC
-wKD
-lNB
-dpa
-cnl
-ueC
-mBy
-uQE
-lUa
-kbx
-wzL
-lgw
-uQE
-xPj
 bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -104690,6 +101520,13 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -104927,64 +101764,64 @@ yhR
 yhR
 yhR
 yhR
-bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-tee
-jWE
-dtY
-lYb
-jWE
-jWE
-jWE
-mrZ
-jWE
-jWE
-jWE
-jWE
-jWE
-jWE
-jWE
-qoc
-qoc
-nER
-pCJ
-wKO
-kuN
-lUc
-mVt
-eNl
-kRg
-hyI
-hyI
-eOY
-epZ
-aRx
-iTD
-ueC
-ueC
-epV
-uQE
-lNB
-fcy
-ueC
-fjz
-kQL
-nwq
-xfe
-urF
-lqk
-eLm
-xPj
-bgK
+oEb
+yhR
+oEb
 yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -105229,74 +102066,74 @@ yhR
 yhR
 yhR
 yhR
-bgK
-bkL
-bkL
-bkL
-bkL
-bkL
-bkL
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-tee
-aiA
-qoc
-qoc
-qoc
-qoc
-qoc
-iDW
-qoc
-iDW
-skA
-kuN
-qoc
-hcK
-tee
-qrv
-kRr
-kRr
-ueC
-ueC
-ueC
-ueC
-ueC
-ueC
-mjq
-uQE
-uQE
-vAr
-ueC
-jcL
-aNH
-wOB
-fcy
-ahf
-uQE
-leX
-xPj
-bgK
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+oEb
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+oEb
+oEb
+oEb
+oEb
+oEb
+oEb
+oEb
+oEb
+oEb
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -105531,60 +102368,32 @@ yhR
 yhR
 yhR
 yhR
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-xzv
-dnk
-fDr
-kmz
-uBV
-psU
-uBV
-oJi
-nyS
-oku
-eMf
-tee
-dcm
-qmx
-xzv
-inL
-kRr
-kRr
-ueC
-bgK
-bgK
-bgK
-bgK
-mWf
-mWf
-mWf
-mWf
-mWf
-mWf
-mWf
-mWf
-mWf
-mWf
-mWf
-mWf
-mWf
-mWf
-bgK
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -105598,6 +102407,34 @@ yhR
 yhR
 yhR
 yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -105835,6 +102672,33 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -105847,46 +102711,19 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
 yhR
-bgK
-xzv
-xzv
-xzv
-xzv
-xzv
-xzv
-xzv
-xzv
-xzv
-xzv
-xzv
-xzv
-xzv
-xzv
-xzv
-tee
-tee
-tee
-ueC
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -106137,6 +102974,33 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
+yhR
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+oEb
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -106148,34 +103012,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -106189,9 +103026,9 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -106440,6 +103277,18 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+oEb
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -106448,36 +103297,24 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -106491,9 +103328,9 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -106743,29 +103580,29 @@ yhR
 yhR
 yhR
 yhR
+oEb
+yhR
+yhR
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -106793,9 +103630,9 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -107046,6 +103883,18 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -107057,19 +103906,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
 yhR
 yhR
 yhR
@@ -107095,9 +103932,9 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -107349,6 +104186,17 @@ yhR
 yhR
 yhR
 yhR
+oEb
+oEb
+oEb
+oEb
+oEb
+yhR
+yhR
+yhR
+yhR
+yhR
+oEb
 yhR
 yhR
 yhR
@@ -107362,6 +104210,7 @@ yhR
 yhR
 yhR
 yhR
+oEb
 yhR
 yhR
 yhR
@@ -107371,21 +104220,9 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -107397,9 +104234,9 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR
@@ -107677,14 +104514,14 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+oEb
+oEb
+oEb
+oEb
+oEb
+oEb
+oEb
+oEb
 yhR
 yhR
 yhR


### PR DESCRIPTION
## About The Pull Request
The current bunker, while nothing is wrong with it. Feels far too...large and it's very...generous with it's space. I've decided to be less so. There-fore I've shrank it down. It should feel cramped. Claustrophobic and most importantly run down and rusting.
Files and images for public perusal. 
Hopefully brings a breath of fresh-air and makes people not want to hide underground all round....maybe. But also leaves this outpost open to more expansion.
Sky- 
<img width="2859" height="1577" alt="image" src="https://github.com/user-attachments/assets/0b056861-f06c-4c56-b451-847e8308e273" />
Surface-
<img width="1999" height="1273" alt="image" src="https://github.com/user-attachments/assets/f347f3db-d183-4e2c-8d29-a542f69da06d" />
Underground-
<img width="1667" height="1568" alt="image" src="https://github.com/user-attachments/assets/d09973fa-313c-4c06-a4ad-22475339188a" />




## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
wH0_T00Kthejam made the following changes: 
Shrank down the Brotherhood bunker and allotted a generous amount of cubic space to each member of the brotherhood.
Added a new surface area's for the brotherhood to inhabit. A small garage to 'work' on any power armour that comes their way
Added some ballistic options to the starting armoury for the less energy inclined folks.
Moved the ghouls to the upper level. 
Changed the deathclaw nest. It now looks better and is harder.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
