### PR TITLE
Town update #2, BoS bunker revamp

### DIFF
--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Sky.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Sky.dmm
@@ -14004,13 +14004,12 @@
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/wasteland)
 "RW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/item/binoculars,
+/obj/item/reagent_containers/food/drinks/bottle/sunset,
+/obj/structure/table/wood/bar,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
-/area/f13/building/abandoned/m)
+/area/f13/building/abandoned/n)
 "RY" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -14144,11 +14143,10 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "Su" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/turf/open/floor/f13{
-	icon_state = "floordirtysolid"
+/obj/structure/railing{
+	dir = 5
 	},
+/turf/open/transparent/openspace,
 /area/f13/building/abandoned/m)
 "Sv" = (
 /obj/structure/campfire/barrel,
@@ -15859,14 +15857,12 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar)
 "XZ" = (
-/obj/structure/chair/f13chair2{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
+/obj/item/binoculars,
 /turf/open/floor/f13{
 	icon_state = "floordirtysolid"
 	},
-/area/f13/building/abandoned/n)
+/area/f13/building/abandoned/m)
 "Ya" = (
 /obj/item/card/id/rusted/brokenholodog/enclave,
 /obj/effect/decal/cleanable/dirt,
@@ -16351,6 +16347,12 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/ncr)
+"ZV" = (
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/transparent/openspace,
+/area/f13/building/abandoned/m)
 "ZW" = (
 /obj/structure/closet/wardrobe/cargotech,
 /turf/open/floor/f13{
@@ -44061,8 +44063,8 @@ xm
 xm
 xm
 xm
-xm
 pm
+Yj
 Yj
 Yj
 Yj
@@ -44363,9 +44365,9 @@ xm
 xm
 xm
 xm
-xm
 Ce
 LM
+ND
 ND
 DQ
 ND
@@ -44665,9 +44667,9 @@ xm
 xm
 xm
 xm
-xm
 Ce
 LM
+ND
 ND
 DQ
 DQ
@@ -44967,9 +44969,9 @@ xm
 xm
 xm
 xm
-xm
 Ce
 LM
+ND
 DQ
 jy
 DQ
@@ -45269,9 +45271,9 @@ xm
 xm
 xm
 xm
-xm
 Ce
 Uo
+ND
 DQ
 ND
 DQ
@@ -45571,9 +45573,9 @@ xm
 xm
 xm
 xm
-xm
 Ce
-eh
+RW
+ND
 DQ
 ND
 LM
@@ -45873,10 +45875,10 @@ xm
 xm
 xm
 xm
-xm
 Ce
 AD
-XZ
+MR
+DQ
 DQ
 LM
 YC
@@ -46175,8 +46177,8 @@ xm
 xm
 xm
 xm
-xm
 Ce
+ND
 ND
 ND
 ND
@@ -46477,8 +46479,8 @@ xm
 xm
 xm
 xm
-xm
 ZF
+yX
 yX
 yX
 yX
@@ -46780,7 +46782,7 @@ xm
 xm
 xm
 xm
-xm
+lw
 lw
 lw
 lw
@@ -47081,8 +47083,8 @@ xm
 xm
 xm
 xm
-xm
 pm
+pk
 pk
 pk
 pk
@@ -47383,8 +47385,8 @@ xm
 xm
 xm
 xm
-xm
 Ce
+ND
 ND
 ND
 DQ
@@ -47685,10 +47687,10 @@ xm
 xm
 xm
 xm
-xm
 Ce
 eh
 MR
+ND
 DQ
 DQ
 YC
@@ -47987,9 +47989,9 @@ xm
 xm
 xm
 xm
-xm
 Ce
 jX
+ND
 DQ
 ND
 DQ
@@ -48042,8 +48044,8 @@ xm
 xm
 Ce
 Li
-jz
-fU
+Li
+Su
 Ug
 YC
 xm
@@ -48289,9 +48291,9 @@ xm
 xm
 xm
 xm
-xm
 Ce
 Uo
+ND
 DQ
 ND
 DQ
@@ -48344,8 +48346,8 @@ xm
 xm
 Ce
 Li
-PE
-PE
+jz
+Li
 Ug
 YC
 xm
@@ -48591,9 +48593,9 @@ xm
 xm
 xm
 xm
-xm
 Ce
 LM
+ND
 DQ
 zj
 LM
@@ -48644,12 +48646,12 @@ xm
 xm
 xm
 xm
-ZF
-yX
-yX
-yX
-yX
-sU
+Ce
+Li
+PE
+PE
+Ug
+YC
 xm
 xm
 xm
@@ -48893,9 +48895,9 @@ xm
 xm
 xm
 xm
-xm
 Ce
 LM
+ND
 DQ
 DQ
 LM
@@ -48946,12 +48948,12 @@ xm
 xm
 xm
 xm
-xm
-lw
-lw
-lw
-lw
-xm
+ZF
+yX
+yX
+yX
+yX
+sU
 xm
 xm
 xm
@@ -49195,9 +49197,9 @@ xm
 xm
 xm
 xm
-xm
 Ce
 LM
+ND
 ND
 ND
 LM
@@ -49497,8 +49499,8 @@ xm
 xm
 xm
 xm
-xm
 ZF
+yz
 yz
 yz
 yz
@@ -49550,12 +49552,12 @@ xm
 xm
 xm
 xm
-xm
-lw
-lw
-lw
-lw
-xm
+pm
+pk
+pk
+pk
+pk
+eK
 xm
 xm
 xm
@@ -49852,12 +49854,12 @@ xm
 xm
 xm
 xm
-pm
-pk
-pk
-pk
-pk
-eK
+Ce
+Li
+PE
+XZ
+Ug
+YC
 xm
 xm
 xm
@@ -50156,8 +50158,8 @@ FY
 FY
 Ce
 Li
-Su
-RW
+uK
+XC
 Ug
 YC
 xm
@@ -50458,8 +50460,8 @@ BU
 FY
 Ce
 Li
-uK
-fU
+XC
+ZV
 Ug
 YC
 xm

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
@@ -1471,9 +1471,7 @@
 /area/f13/bar)
 "ayI" = (
 /obj/structure/table/reinforced,
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/barricade/bars,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/x)
 "ayJ" = (
@@ -3449,6 +3447,8 @@
 	dir = 1;
 	flickering = 1
 	},
+/obj/item/hand_labeler,
+/obj/item/stack/sheet/cardboard/twenty,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/x)
 "bdX" = (
@@ -9814,7 +9814,7 @@
 /area/f13/bar)
 "dcU" = (
 /obj/structure/bed,
-/obj/item/bedsheet/grey,
+/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/z)
 "dcV" = (
@@ -11252,6 +11252,7 @@
 /area/f13/brotherhood)
 "dAB" = (
 /obj/structure/wreck/trash/one_tire,
+/obj/structure/tires/two,
 /turf/open/floor/plating/f13/inside/gravel,
 /area/f13/wasteland/town)
 "dAD" = (
@@ -12438,6 +12439,10 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
+"dTo" = (
+/obj/structure/wreck/trash/engine,
+/turf/open/floor/plating/f13/inside/gravel,
+/area/f13/wasteland/town)
 "dTu" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -13334,7 +13339,6 @@
 	id = "townunderupperright";
 	height = 2
 	},
-/obj/effect/landmark/start/f13/deputy,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/n)
 "ejo" = (
@@ -13926,9 +13930,6 @@
 /area/f13/ambientlighting/building/w)
 "esI" = (
 /obj/structure/window/fulltile/house,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/x)
 "esJ" = (
@@ -16707,6 +16708,17 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/wasteland)
+"fll" = (
+/obj/structure/ladder/unbreakable{
+	height = 2;
+	icon_state = "manhole_open";
+	id = "town_lair"
+	},
+/obj/structure/reagent_dispensers/barrel/four{
+	pixel_y = 4
+	},
+/turf/open/floor/plating/f13/inside/gravel,
+/area/f13/wasteland/town)
 "flu" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/f13/wood,
@@ -21736,9 +21748,8 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/tribal)
 "gMk" = (
-/obj/structure/window/fulltile/house,
 /obj/structure/curtain{
-	color = "#808080"
+	pixel_y = -32
 	},
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/z)
@@ -23364,9 +23375,7 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland/town)
 "hjG" = (
-/obj/machinery/door/window{
-	dir = 4
-	},
+/obj/structure/simple_door/metal/barred,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/x)
 "hjI" = (
@@ -34105,6 +34114,11 @@
 /obj/effect/overlay/desert_side,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
+"kyb" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/effect/landmark/start/f13/deputy,
+/turf/open/floor/f13/wood,
+/area/f13/building/abandoned/n)
 "kyc" = (
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaltopbordertop3"
@@ -34193,6 +34207,10 @@
 "kzG" = (
 /obj/structure/chair/sofa/left{
 	dir = 1
+	},
+/obj/structure/curtain{
+	color = "#845f58";
+	pixel_y = -32
 	},
 /turf/open/floor/wood_fancy,
 /area/f13/building/abandoned/x)
@@ -36419,7 +36437,7 @@
 /area/f13/ambientlighting/building/r)
 "lil" = (
 /obj/structure/bed,
-/obj/item/bedsheet/blue,
+/obj/item/bedsheet/gondola,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/z)
 "lio" = (
@@ -38648,7 +38666,6 @@
 	id = "townunderupperleft";
 	height = 2
 	},
-/obj/effect/landmark/start/f13/deputy,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/n)
 "lTG" = (
@@ -49403,6 +49420,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ambientlighting/building/o)
+"plB" = (
+/obj/structure/curtain{
+	pixel_x = 32
+	},
+/turf/open/floor/wood_common,
+/area/f13/building/abandoned/z)
 "plC" = (
 /obj/structure/window/fulltile/wood,
 /turf/open/floor/f13/wood{
@@ -53134,8 +53157,8 @@
 	},
 /area/f13/wasteland)
 "qse" = (
-/obj/structure/wreck/trash/engine,
 /obj/structure/sign/brotherhoodcardboard,
+/obj/item/storage/trash_stack,
 /turf/open/floor/plating/f13/inside/gravel,
 /area/f13/wasteland/town)
 "qsh" = (
@@ -60955,6 +60978,13 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/ambientlighting/building/f)
+"sPn" = (
+/obj/structure/curtain{
+	color = "#808080";
+	pixel_x = 32
+	},
+/turf/open/floor/wood_common,
+/area/f13/building/abandoned/z)
 "sPu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/junk,
@@ -61232,10 +61262,6 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/ambientlighting/building/o)
-"sTH" = (
-/obj/structure/wreck/trash/one_barrel,
-/turf/open/floor/plating/f13/inside/gravel,
-/area/f13/wasteland/town)
 "sTJ" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plating/rust,
@@ -62013,9 +62039,6 @@
 /area/f13/wasteland)
 "tfm" = (
 /obj/structure/window/fulltile/house,
-/obj/structure/curtain{
-	color = "#808080"
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/z)
@@ -64024,8 +64047,11 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/building/abandoned/n)
 "tMm" = (
-/obj/structure/simple_door/metal/iron,
 /obj/effect/mapping_helpers/network_builder/power_cable/auto,
+/obj/machinery/door/airlock/engineering{
+	req_one_access_txt = "25";
+	name = "Maintenance Only"
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/workshop)
 "tMo" = (
@@ -66013,6 +66039,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/maintenance/bar)
 "uqz" = (
@@ -66592,7 +66619,11 @@
 	},
 /area/f13/wasteland)
 "uAo" = (
-/obj/structure/tires/two,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -6;
+	pixel_x = 1
+	},
 /turf/open/floor/plating/f13/inside/gravel,
 /area/f13/wasteland/town)
 "uAp" = (
@@ -66881,6 +66912,13 @@
 /obj/machinery/door/unpowered/secure_NCR,
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
+"uEw" = (
+/obj/structure/curtain{
+	color = "#808080";
+	pixel_y = 32
+	},
+/turf/open/floor/wood_common,
+/area/f13/building/abandoned/z)
 "uEy" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/barricade/wooden,
@@ -67811,8 +67849,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/clinic)
 "uRz" = (
-/obj/item/bedsheet/black,
 /obj/structure/bed,
+/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood_mosaic,
 /area/f13/building/abandoned/x)
 "uSd" = (
@@ -70916,6 +70954,11 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/wasteland)
+"vPd" = (
+/obj/structure/table,
+/obj/machinery/processor/chopping_block,
+/turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
+/area/maintenance/bar)
 "vPF" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13,
@@ -73417,7 +73460,6 @@
 /area/f13/followers)
 "wCq" = (
 /obj/structure/window/fulltile/house,
-/obj/structure/curtain,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/z)
 "wCL" = (
@@ -76088,8 +76130,11 @@
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
 "xpX" = (
-/obj/machinery/door/airlock/engineering,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering/glass{
+	req_one_access_txt = "25";
+	name = "N.T. Workshop"
+	},
 /turf/open/floor/plasteel,
 /area/engine/workshop)
 "xqb" = (
@@ -105094,7 +105139,7 @@ apD
 apD
 gDa
 ncr
-voV
+fll
 chT
 dAB
 voV
@@ -105397,8 +105442,8 @@ aGd
 aGd
 aGd
 qse
+dTo
 pvq
-sTH
 voV
 apD
 voV
@@ -105698,9 +105743,9 @@ oPT
 dsJ
 rJQ
 aGd
-pwE
-xxa
 uAo
+voV
+xxa
 voV
 rPm
 voV
@@ -106019,13 +106064,13 @@ dJe
 xDy
 voV
 tfm
-bto
+uEw
 dbU
 xoT
 pSE
 qIt
 szx
-bto
+gMk
 wCq
 kDF
 oks
@@ -107530,11 +107575,11 @@ tGg
 slp
 pSE
 voR
-bto
+sPn
 rBh
 pSE
 rBh
-bto
+plB
 voR
 pSE
 kDF
@@ -107832,7 +107877,7 @@ tGg
 slp
 pSE
 pSE
-gMk
+wCq
 pSE
 pSE
 pSE
@@ -108393,7 +108438,7 @@ azA
 azA
 dIZ
 lpd
-ftp
+kyb
 dkX
 gIs
 apD
@@ -110809,7 +110854,7 @@ azA
 azA
 dIZ
 lpd
-ftp
+kyb
 dkX
 dIZ
 apD
@@ -116267,7 +116312,7 @@ rQh
 pAW
 rQh
 uqr
-rQh
+vPd
 qEt
 pGU
 pGU

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
@@ -71,6 +71,18 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/sewer/powered)
+"abo" = (
+/obj/machinery/door/airlock/research{
+	name = "Brotherhood R&D";
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
 "abx" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -217,7 +229,8 @@
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/diner)
 "afm" = (
-/turf/open/floor/carpet/purple,
+/obj/effect/decal/cleanable/flour,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
 "afo" = (
 /obj/item/cautery,
@@ -230,18 +243,16 @@
 	},
 /area/f13/bunker/bunkerfive)
 "afp" = (
-/obj/structure/table/glass,
-/obj/item/pda/chemist{
-	name = "Scribe-Chemist Pip-Boy 3000";
-	pixel_x = 15;
-	pixel_y = 7
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#c1caff"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operations)
 "afz" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/plasteel/dark,
@@ -257,6 +268,25 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
+"afY" = (
+/obj/item/flashlight/lantern{
+	on = 1;
+	light_on = 1;
+	icon_state = "lantern-on";
+	pixel_x = -11;
+	pixel_y = 18
+	},
+/obj/item/defibrillator/primitive{
+	desc = "A Delco-brand pre-war car battery, with alligator clips and jumper cables to match. This could probably work as a makeshift defibrillator, in a pinch.";
+	name = "car battery";
+	pixel_x = -8;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "agg" = (
 /obj/machinery/chem_master/condimaster,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -301,16 +331,12 @@
 /turf/open/floor/carpet/orange,
 /area/f13/vault/security)
 "agI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/oil,
+/obj/machinery/door/poddoor/shutters/preopen,
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "agO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human{
@@ -354,8 +380,19 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"ahe" = (
+/obj/machinery/chem_lab,
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "ahf" = (
 /obj/machinery/workbench/advanced,
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS");
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 1
 	},
@@ -403,11 +440,11 @@
 	},
 /area/f13/bunker/bunkerthree)
 "aij" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/chair/sofa/right{
+	dir = 8
 	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "ait" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -442,8 +479,8 @@
 /obj/structure/lattice{
 	layer = 3
 	},
-/turf/closed/mineral/random/low_chance,
-/area/f13/caves)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/mining)
 "aiJ" = (
 /obj/machinery/door/airlock/command{
 	name = "Coordinators Office";
@@ -529,9 +566,11 @@
 	},
 /area/f13/sewer/powered)
 "akt" = (
-/obj/machinery/microwave/stove,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/obj/item/book/granter/crafting_recipe/blueprint/trapper,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood/reactor)
 "akv" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "storewindowright"
@@ -716,6 +755,14 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/ruin/powered)
+"anW" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood/operations)
 "anY" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench/advanced,
@@ -815,16 +862,24 @@
 /turf/open/floor/plasteel/vault,
 /area/f13/vault/security/armory)
 "aqG" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 8
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
 	},
-/area/f13/brotherhood/operating)
-"aqH" = (
-/obj/machinery/radioterminal/bos,
+/obj/structure/lattice{
+	layer = 3
+	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/leisure)
+"aqH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/armory)
 "aqM" = (
 /obj/structure/table,
 /obj/structure/sign/plaques/long/vault{
@@ -1111,12 +1166,17 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
 "avX" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/dead{
+	desc = "A mummified potted plant.";
+	name = "very dead potted plant";
+	pixel_x = -1;
+	pixel_y = 11
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken3"
+	},
 /area/f13/brotherhood/operations)
 "awa" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -1195,11 +1255,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building/abandoned/o)
 "axF" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/computer/libraryconsole/bookmanagement{
+	pixel_y = 8
 	},
-/obj/structure/closet/crate/engineering/electrical,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/rnd)
 "axK" = (
 /obj/structure/table,
@@ -1325,16 +1385,15 @@
 /turf/open/floor/plasteel/darkred/side,
 /area/f13/vault/security)
 "aBA" = (
-/obj/structure/table{
-	layer = 2.9
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/f13/doctorbag,
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#e8eaff"
 	},
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/epipak,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "bcircuit1";
 	light_color = "#0076bc";
@@ -1463,12 +1522,12 @@
 	},
 /area/f13/bunker/bighornbunker)
 "aEu" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/wood_common,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "aEy" = (
 /obj/machinery/light/floor{
@@ -1525,9 +1584,15 @@
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/security)
 "aFE" = (
-/obj/structure/sign/departments/chemistry,
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/chemistry)
+/obj/effect/turf_decal/arrows{
+	dir = 4;
+	pixel_y = -12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "aFN" = (
 /obj/structure/simple_door/bunker{
 	name = "Armoury"
@@ -1558,13 +1623,15 @@
 	},
 /area/ruin/powered)
 "aGf" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/ruins,
 /area/f13/brotherhood/operations)
 "aGs" = (
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/robot_debris/down,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
 /area/f13/brotherhood/operations)
 "aGt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1588,11 +1655,17 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/sewer)
 "aGI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/clothing/glasses/sunglasses/blindfold,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/item/restraints/handcuffs,
+/obj/structure/closet/crate,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 6
 	},
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "aGO" = (
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/f13,
@@ -1628,11 +1701,9 @@
 	},
 /area/f13/bunker/bunkerthree)
 "aIc" = (
-/obj/structure/chair/f13chair1{
-	dir = 4
-	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/dorms)
 "aIg" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks,
@@ -1704,17 +1775,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault/diner)
 "aJm" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#228B22"
-	},
-/obj/structure/bed,
-/obj/structure/curtain,
-/obj/item/bedsheet/cmo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/brotherhood/rnd)
 "aJr" = (
 /obj/item/stack/sheet/mineral/uranium/fifty,
 /turf/open/floor/f13{
@@ -1722,15 +1785,20 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"aJE" = (
+/obj/machinery/vending/medical/free{
+	pixel_x = -4
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/operating)
 "aJM" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "aJT" = (
 /obj/structure/railing{
 	dir = 1
@@ -1752,6 +1820,11 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker)
+"aKl" = (
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner{
+	dir = 8
+	},
+/area/f13/brotherhood/rnd)
 "aKq" = (
 /turf/closed/indestructible/f13/obsidian,
 /area/f13/caves)
@@ -1802,15 +1875,8 @@
 /area/f13/brotherhood/mining)
 "aLs" = (
 /obj/effect/decal/cleanable/dirt{
-	color = "000000"
+	color = "#363636"
 	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -1840,17 +1906,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "aMc" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosarmoryacc";
-	name = "Mine";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "aMg" = (
 /obj/item/clothing/head/collectable/flatcap,
 /turf/open/floor/plasteel/dark,
@@ -1875,11 +1934,6 @@
 /area/ruin/powered)
 "aNn" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 1;
-	pixel_y = -1
-	},
 /obj/machinery/computer/terminal{
 	dir = 4;
 	pixel_x = -3;
@@ -2000,12 +2054,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "aPD" = (
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/machinery/light{
+	light_color = "#e8eaff";
+	dir = 4
 	},
-/obj/effect/landmark/start/f13/seniorknight,
-/turf/open/floor/plasteel/f13/vault_floor/red/corner,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/cult,
+/area/f13/brotherhood/operations)
 "aPE" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -2028,6 +2082,10 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered)
+"aQg" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/operations)
 "aQy" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/freezer,
@@ -2078,13 +2136,11 @@
 /turf/closed/indestructible/f13/obsidian,
 /area/f13/caves)
 "aRB" = (
+/obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt{
-	color = "000000"
+	color = "#363636"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
@@ -2142,11 +2198,11 @@
 	},
 /area/f13/sewer)
 "aRW" = (
-/obj/effect/decal/cleanable/ash/large,
+/obj/structure/lattice/catwalk,
+/obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt{
-	color = "000000"
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operating)
 "aSa" = (
@@ -2181,11 +2237,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
 "aSA" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 4
-	},
-/area/f13/brotherhood/operating)
+/obj/machinery/vending/wardrobe/science_wardrobe/free,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood/rnd)
 "aSF" = (
 /obj/structure/simple_door/bunker{
 	name = "Hydro"
@@ -2228,6 +2282,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bighornbunker)
+"aTH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/operations)
 "aTL" = (
 /obj/machinery/processor,
 /obj/effect/gibspawner/human,
@@ -2255,9 +2316,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/ruin/powered)
 "aUd" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
 /area/f13/brotherhood/operations)
 "aUp" = (
 /obj/structure/barricade/wooden/planks/pregame,
@@ -2318,6 +2380,13 @@
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"aVJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	light_color = "green"
+	},
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/dorms)
 "aVM" = (
 /obj/structure/barricade/sandbags,
 /obj/effect/decal/cleanable/dirt,
@@ -2424,6 +2493,18 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"aXd" = (
+/obj/machinery/button/door{
+	pixel_y = -24;
+	name = "Turret Switch";
+	id = "bos_front_turret";
+	req_access_txt = "120"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 1
+	},
+/area/f13/brotherhood/chemistry)
 "aXk" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
@@ -2458,28 +2539,39 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
-"aYb" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+"aXZ" = (
+/obj/machinery/light/small{
+	brightness = 3
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
+"aYb" = (
+/turf/open/floor/wood_fancy,
 /area/f13/brotherhood/rnd)
 "aYm" = (
 /obj/effect/gibspawner/human,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
 "aYn" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
-"aYu" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/turf_decal/loading_area/white{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
+"aYu" = (
+/obj/machinery/computer/rdconsole/core/bos{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
 /area/f13/brotherhood/rnd)
 "aYM" = (
 /obj/structure/wreck/trash/three_barrels{
@@ -2512,8 +2604,9 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/brotherhood/operations)
 "aZU" = (
-/obj/machinery/computer/arcade/battle,
-/turf/open/floor/wood_common,
+/obj/structure/chair/right,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "aZV" = (
 /obj/machinery/vending/medical,
@@ -2648,7 +2741,10 @@
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
 	},
 /area/f13/brotherhood/operating)
 "bcK" = (
@@ -2691,12 +2787,16 @@
 /turf/closed/indestructible/f13/obsidian,
 /area/f13/bunker)
 "bdL" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Combat Caste Office";
-	req_access_txt = "120"
+/obj/machinery/light{
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood/armory)
 "bdT" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/inside/subway,
@@ -2769,11 +2869,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
 "bfF" = (
-/obj/structure/barricade/bars,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/simple_door/metal/barred{
+	req_one_access_txt = "120"
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/operations)
 "bfK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/glowstick,
@@ -2819,7 +2919,7 @@
 	dir = 4
 	},
 /turf/closed/indestructible/rock,
-/area/f13/sewer)
+/area/f13/caves)
 "bhq" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
 /turf/open/indestructible/ground/inside/mountain,
@@ -2932,8 +3032,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "biU" = (
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
+/obj/machinery/light{
+	light_color = "#e8eaff";
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "biZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2978,6 +3083,16 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker/bunkerthree)
+"bku" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/operations)
 "bkv" = (
 /obj/structure/simple_door/wood,
 /turf/open/floor/carpet,
@@ -3069,11 +3184,10 @@
 	},
 /area/ruin/powered)
 "bna" = (
-/obj/item/kirbyplants/random{
-	pixel_y = 6
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/indestructible/ground/outside/grass,
 /area/f13/brotherhood/rnd)
 "bne" = (
 /obj/structure/rack,
@@ -3169,8 +3283,9 @@
 /area/f13/building/abandoned/o)
 "bol" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green/corner,
+/area/f13/brotherhood/rnd)
 "bom" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -3236,6 +3351,15 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"bqa" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/turf_decal/loading_area/white{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "bqc" = (
 /obj/structure/table,
 /obj/item/ammo_box/shotgun/slug,
@@ -3278,9 +3402,7 @@
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerfive)
 "brH" = (
-/obj/structure/rack/shelf_metal{
-	pixel_y = -12
-	},
+/obj/structure/rack/shelf_metal,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -3467,14 +3589,12 @@
 	},
 /area/f13/vault/garden)
 "bwP" = (
-/obj/structure/closet/crate/freezer/blood/anchored,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS")
 	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plasteel/f13/vault_floor/green/corner,
+/area/f13/brotherhood/rnd)
 "bwT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/rack_parts,
@@ -3496,12 +3616,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/white,
 /area/f13/vault/medical/chemistry)
 "bxc" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/conveyor/auto{
+	dir = 1
 	},
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/red,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/caves)
 "bxd" = (
 /obj/structure/barricade/train{
 	dir = 8
@@ -3511,6 +3630,11 @@
 "bxs" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
+	},
+/obj/structure/barricade/sandbags,
+/obj/machinery/door/poddoor/shutters/old{
+	id = "bos_front_turret";
+	name = "security shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
@@ -3729,6 +3853,11 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"bBB" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bBD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
@@ -3769,10 +3898,12 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
 "bCQ" = (
-/obj/machinery/rnd/server/bos,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/brotherhood/rnd)
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/leisure)
 "bCU" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/decal/cleanable/dirt,
@@ -3916,13 +4047,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/atrium)
 "bGu" = (
-/obj/machinery/vending/security{
-	force_free = 1
+/obj/structure/table/wood/poker,
+/obj/item/blacksmith/woodrod{
+	pixel_y = 5;
+	name = "pool cue";
+	desc = "It's a rod, suitable for use at a pool table. Also could serve as a weapon, in a pinch."
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 10
-	},
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/leisure)
 "bGz" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/generic{
@@ -3946,6 +4079,12 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/enclave)
+"bHd" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood_worn/wood_worn_dark,
+/area/f13/brotherhood/dorms)
 "bHs" = (
 /obj/structure/lattice{
 	density = 1
@@ -3962,13 +4101,12 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/radiation)
 "bHN" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891";
-	pixel_y = 5
+/obj/machinery/door/airlock/medical/glass{
+	name = "Brotherhood Medical";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
 "bHU" = (
 /obj/structure/lattice,
@@ -4078,6 +4216,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"bKc" = (
+/obj/effect/decal/cleanable/generic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "bKh" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks,
@@ -4265,12 +4407,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "bNx" = (
-/obj/machinery/power/apc/auto_name/north,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/obj/effect/landmark/start/f13/paladin,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "bNE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice,
@@ -4288,15 +4427,11 @@
 	},
 /area/f13/bunker)
 "bNX" = (
-/obj/structure/table/reinforced,
-/obj/item/holosign_creator/security{
-	layer = 3.1;
-	name = "Head Knight's holobarrier projector";
-	pixel_y = 7
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/padded,
+/area/f13/brotherhood/leisure)
 "bOc" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
@@ -4470,10 +4605,11 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "bRN" = (
-/obj/effect/landmark/start/f13/Knight,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/wreck/trash/machinepile,
+/obj/structure/lattice{
+	layer = 3
 	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "bRV" = (
 /mob/living/simple_animal/hostile/handy/assaultron,
@@ -4517,8 +4653,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/bunker/bunkereight)
 "bSQ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/wood_common,
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/leisure)
 "bSV" = (
 /obj/machinery/vending/wardrobe/engi_wardrobe/free,
@@ -4567,12 +4703,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/sewer)
 "bUw" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/brotherhood/operations)
 "bUC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4700,6 +4837,19 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"bXw" = (
+/obj/structure/decoration/vent,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/rnd)
 "bXy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/campfire/barrel,
@@ -4745,21 +4895,22 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/porta_turret/f13/turret_556/burstfire{
-	faction = list("BOS");
-	req_access = list(120)
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "bYu" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/red,
+/obj/effect/landmark/start/f13/offduty,
+/obj/machinery/light{
+	light_color = "#e8eaff";
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/dorms)
 "bYx" = (
-/obj/machinery/computer/arcade/orion_trail,
-/turf/open/floor/wood_common,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/structure/chair/left,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "bYS" = (
 /turf/closed/mineral/random/low_chance,
@@ -4790,13 +4941,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "bZQ" = (
-/obj/structure/simple_door/metal/barred{
-	req_one_access_txt = "120"
-	},
+/obj/structure/barricade/bars,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "bZW" = (
 /obj/structure/wreck/car,
 /turf/open/indestructible/ground/inside/subway,
@@ -4856,6 +5005,12 @@
 	},
 /turf/open/floor/f13,
 /area/f13/vault)
+"caN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 5
+	},
+/area/f13/brotherhood/rnd)
 "cba" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 8
@@ -4974,26 +5129,31 @@
 /area/f13/vault/storage)
 "cdK" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "engine"
 	},
 /area/f13/brotherhood/reactor)
 "cea" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood/rnd)
 "ced" = (
-/obj/structure/closet/crate/medical,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#e8eaff"
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/surgical_drapes,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/stack/sticky_tape/surgical{
+	pixel_x = -11;
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "bcircuit1";
@@ -5026,6 +5186,11 @@
 	},
 /turf/open/floor/wood_mosaic/wood_mosaic_light,
 /area/f13/enclave)
+"ceH" = (
+/obj/structure/barricade/wooden,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ceK" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
@@ -5063,6 +5228,14 @@
 	icon_state = "floordirty"
 	},
 /area/f13/bunker/bunkerthree)
+"cfI" = (
+/obj/effect/turf_decal/weather/dirt{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/brotherhood/rnd)
 "cfM" = (
 /obj/structure/campfire/barrel,
 /obj/effect/decal/cleanable/dirt,
@@ -5213,6 +5386,13 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker/bighornbunker)
+"ciw" = (
+/obj/machinery/door/airlock/glass{
+	name = "Canteen";
+	req_access_txt = "120"
+	},
+/turf/open/floor/wood_worn/wood_worn_dark,
+/area/f13/brotherhood/leisure)
 "ciE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/lattice,
@@ -5289,19 +5469,22 @@
 /obj/item/locked_box/medical,
 /turf/open/floor/f13,
 /area/ruin/powered)
+"ckl" = (
+/obj/machinery/door/airlock/hatch{
+	req_access_txt = "120"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/dorms)
 "ckn" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/operating/bos{
+	dir = 1
 	},
-/obj/machinery/computer/rdconsole/core/bos{
-	dir = 4
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
 	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/brotherhood/rnd)
+/area/f13/brotherhood/operating)
 "cku" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/tunnel,
@@ -5371,6 +5554,21 @@
 	icon_state = "rubbleplate"
 	},
 /area/f13/sewer/powered)
+"clJ" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_y = 10;
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/dropper,
+/obj/structure/table/rolling,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 9
+	},
+/area/f13/brotherhood/rnd)
 "clL" = (
 /obj/structure/window/reinforced/fulltile/indestructable{
 	can_be_unanchored = 0
@@ -5616,10 +5814,8 @@
 	},
 /area/ruin/powered)
 "csR" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/brotherhood/operations)
 "csS" = (
 /obj/structure/chair/wood{
@@ -5787,12 +5983,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
 "cwc" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/leisure)
 "cwi" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/f13{
@@ -5874,25 +6069,29 @@
 	},
 /area/f13/bunker)
 "cxP" = (
-/obj/machinery/computer/card/bos,
-/obj/structure/noticeboard{
-	name = "display plate";
-	pixel_x = 16;
-	pixel_y = 34
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/footlocker{
+	pixel_y = 14
 	},
-/obj/item/gun/energy/pulse{
-	anchored = 1;
-	cell_type = null;
-	desc = "A heavy-duty, multifaceted energy rifle with three modes. Preferred by front-line combat personnel. This one is for display, and no longer fires.";
-	name = "display pulse rifle";
-	pin = null;
-	pixel_x = 16;
-	pixel_y = 29
+/obj/item/card/id/dogtag{
+	pixel_x = 4
 	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+/obj/item/card/id/dogtag{
+	pixel_x = 4
 	},
+/obj/item/card/id/dogtag{
+	pixel_x = 4
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_x = -8
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_x = -8
+	},
+/obj/item/encryptionkey/headset_bos{
+	pixel_x = -8
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
 "cxR" = (
@@ -5928,12 +6127,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "cyF" = (
-/obj/machinery/chem_master/advanced,
+/obj/effect/decal/cleanable/greenglow,
+/obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/chemistry)
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "cyK" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
@@ -5958,16 +6156,29 @@
 /obj/item/stack/f13Cash/random,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"czm" = (
+/obj/machinery/light/small{
+	light_color = "#ff4747"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/dorms)
 "czv" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
+/obj/structure/closet/crate/hydroponics{
+	anchored = 1
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/item/seeds/poppy/broc{
+	pixel_x = -5
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/operations)
+/obj/item/seeds/xander{
+	pixel_x = 5
+	},
+/obj/item/wrench,
+/obj/item/cultivator,
+/obj/item/shovel,
+/obj/item/shovel/spade,
+/obj/item/reagent_containers/glass/bucket/plastic,
+/turf/open/floor/plasteel/f13/vault_floor/green/side,
+/area/f13/brotherhood/rnd)
 "czE" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/light_brown,
@@ -6147,13 +6358,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
 "cDS" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 1
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/padded,
+/area/f13/brotherhood/leisure)
 "cEt" = (
 /obj/effect/gibspawner/robot,
 /turf/open/floor/plating/dirt/dark,
@@ -6170,17 +6381,30 @@
 /mob/living/simple_animal/hostile/raider/ranged/junker,
 /turf/open/floor/f13,
 /area/f13/bunker)
+"cEM" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = -2
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken5"
+	},
+/area/f13/brotherhood/operations)
 "cET" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/kirbyplants/random{
+	pixel_x = 6
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/filingcabinet{
+	pixel_x = -10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 8
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 1
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "cEZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/mattress{
@@ -6252,15 +6476,20 @@
 /obj/structure/simple_door/bunker/glass,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bighornbunker)
-"cHv" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/structure/bed,
-/obj/structure/curtain,
-/obj/item/bedsheet/cmo,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 4
+"cHo" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/area/f13/brotherhood/operating)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood/operations)
+"cHv" = (
+/obj/structure/decoration/vent,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/operations)
 "cHJ" = (
 /obj/effect/decal/cleanable/flour,
 /turf/open/floor/plasteel/f13/vault_floor/red/white/side{
@@ -6281,13 +6510,20 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkerthree)
 "cIr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/structure/closet/crate{
+	name = "anesthetic crate"
 	},
+/obj/item/clothing/mask/breath/medical,
+/obj/item/clothing/mask/breath/medical,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
+/obj/item/tank/internals/anesthetic,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "aesculapius"
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
 	},
 /area/f13/brotherhood/operating)
 "cIt" = (
@@ -6435,12 +6671,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
 "cLN" = (
-/obj/structure/shelf_wood,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/machinery/autolathe,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "cLQ" = (
 /obj/structure/wreck/trash/halftire,
@@ -6499,6 +6731,11 @@
 "cNy" = (
 /turf/closed/indestructible/syndicate,
 /area/ruin/powered)
+"cNB" = (
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "cNF" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/indestructible/ground/inside/mountain,
@@ -6540,10 +6777,14 @@
 	},
 /area/f13/vault)
 "cPd" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
+/obj/effect/turf_decal/delivery/white,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/weightlifter,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "cPM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/concrete,
@@ -6654,13 +6895,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
 "cQW" = (
-/obj/structure/table/reinforced,
-/obj/item/key,
-/obj/item/key,
-/obj/item/lock_construct,
-/obj/item/lock_construct,
-/turf/open/floor/plasteel/f13/vault_floor/red/side,
-/area/f13/brotherhood/armory)
+/obj/machinery/vending/hydronutrients{
+	force_free = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "cQZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -6694,6 +6935,10 @@
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/plasteel/f13/vault_floor/red/white,
 /area/f13/vault/atrium)
+"cRj" = (
+/obj/structure/table/booth,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/dorms)
 "cRO" = (
 /obj/structure/debris/v3,
 /obj/structure/debris/v4,
@@ -6766,9 +7011,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault/reactor)
 "cTi" = (
-/obj/structure/closet/fridge/standard,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
+/area/f13/caves)
 "cTt" = (
 /obj/structure/table_frame,
 /turf/open/indestructible/ground/inside/subway,
@@ -6813,6 +7058,12 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"cUj" = (
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/operating)
 "cUn" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6860,12 +7111,16 @@
 	},
 /area/f13/bunker/bunkerfive)
 "cWs" = (
-/obj/machinery/vending/cigarette/syndicate,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/chem_lab,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/brotherhood/operations)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "cWw" = (
 /obj/structure/debris/v3{
 	pixel_x = -15;
@@ -6887,8 +7142,10 @@
 	},
 /area/f13/bunker)
 "cWL" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/brotherhood/armory)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/leisure)
 "cWO" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -6943,6 +7200,7 @@
 	name = "Security Checkpoint";
 	req_access_txt = "120"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -7080,8 +7338,6 @@
 /area/f13/caves)
 "daZ" = (
 /obj/structure/table/rolling,
-/obj/item/locked_box/misc/attachments,
-/obj/item/lockpick_set,
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -7092,6 +7348,7 @@
 /obj/structure/window/reinforced/spawner{
 	dir = 1
 	},
+/obj/item/lockpick_set,
 /turf/open/floor/holofloor/plating,
 /area/f13/brotherhood/armory)
 "dbc" = (
@@ -7117,11 +7374,9 @@
 	},
 /area/f13/bunker/bunkerthree)
 "dbi" = (
-/obj/structure/chair/sofa/right,
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/lattice/catwalk,
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "dbr" = (
 /obj/machinery/door/locked/hard/maybe_trapped,
@@ -7513,13 +7768,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
 "dkQ" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 16
 	},
-/area/f13/brotherhood/chemistry)
+/obj/vehicle/ridden/janicart{
+	desc = "Some say a Scribe once got tired of walking across the bunker and gave rise to this thing of savage beauty.";
+	name = "maint-mobile"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "dkR" = (
 /obj/structure/closet/crate{
 	anchored = 1
@@ -7546,6 +7806,11 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"dlh" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/operating)
 "dlk" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -7699,8 +7964,8 @@
 /area/f13/sewer/powered)
 "dpa" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/green/corner,
+/area/f13/brotherhood/rnd)
 "dpi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stock_parts/manipulator/pico,
@@ -7768,11 +8033,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/ruin/powered)
 "dqS" = (
-/obj/structure/closet/secure_closet/brig,
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 6
+/obj/item/flashlight/lantern{
+	on = 1;
+	light_on = 1;
+	icon_state = "lantern-on";
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/area/f13/brotherhood/armory)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dqY" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -7794,6 +8063,20 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
 /area/f13/vault/science)
+"drM" = (
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood/operations)
 "drN" = (
 /obj/structure/fence/wooden{
 	dir = 1;
@@ -7809,14 +8092,10 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "dsc" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/security/bos{
-	circuit = /obj/item/circuitboard/computer/security;
-	dir = 4;
-	pixel_y = 10
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/brotherhood/rnd)
 "dsk" = (
 /obj/structure/rack,
 /obj/item/ammo_box/magazine/garand308,
@@ -7862,6 +8141,13 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
+"dte" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Head's Quarters";
+	req_access_txt = "120"
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood/dorms)
 "dtl" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -7914,17 +8200,9 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
 "dum" = (
-/obj/machinery/vending/hydroseeds{
-	force_free = 1
-	},
-/obj/machinery/light{
-	dir = 8;
-	flickering = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green/side{
-	dir = 4
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/obstacle/old_locked_door,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "duA" = (
 /obj/machinery/light{
 	dir = 4
@@ -8041,6 +8319,17 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
+"dxr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/overlay/junk/toilet{
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/operations)
 "dxt" = (
 /obj/structure/chair/left{
 	dir = 8
@@ -8051,6 +8340,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"dxG" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/operations)
 "dxK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/clothing/head/welding/weldingfire,
@@ -8138,13 +8434,6 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/shack)
 "dza" = (
-/obj/structure/closet/crate/medical,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/hypospray/medipen/stimpak,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
-/obj/item/reagent_containers/blood/radaway,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -8241,6 +8530,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/atrium)
+"dBt" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "dBC" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -8271,6 +8566,10 @@
 	name = "rusty reinforced wall"
 	},
 /area/f13/sewer)
+"dCd" = (
+/obj/machinery/door/poddoor/shutters,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dCk" = (
 /obj/structure/rack/shelf_metal{
 	dir = 4
@@ -8286,16 +8585,12 @@
 	},
 /area/f13/bunker/bunkerthree)
 "dCo" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
-	},
-/obj/structure/mirror{
-	pixel_x = 30
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/dorms)
 "dCv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/circuitboard/machine/chem_heater,
@@ -8305,6 +8600,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
+"dCx" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/table/wood,
+/obj/item/stack/sheet/hay/ten,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/indestructible/ground/outside/grass/corner,
+/area/f13/brotherhood/rnd)
 "dCA" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/mountain,
@@ -8460,10 +8764,23 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "dGq" = (
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 8
+/obj/structure/lattice{
+	layer = 3
 	},
-/area/f13/brotherhood/operating)
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/rnd)
+"dGs" = (
+/obj/structure/chair/sofa/corp/right,
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/leisure)
 "dGW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -8525,10 +8842,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer/powered)
 "dIT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 8
-	},
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/operating)
 "dIU" = (
 /obj/structure/bonfire/prelit,
@@ -8543,6 +8858,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"dJo" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side,
+/area/f13/brotherhood/chemistry)
 "dJG" = (
 /obj/effect/spawner/lootdrop/f13/medical/rnd/mid,
 /obj/effect/turf_decal/weather/dirt{
@@ -8742,11 +9063,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
 "dNx" = (
-/obj/structure/curtain,
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/plating/f13,
 /area/f13/brotherhood/operating)
 "dNy" = (
 /mob/living/simple_animal/hostile/handy/protectron,
@@ -9091,6 +9408,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"dWQ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/leisure)
 "dXp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -9127,17 +9451,19 @@
 /turf/open/water,
 /area/f13/radiation)
 "dXC" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/drinks/mug/coco{
-	pixel_x = -8;
-	pixel_y = 8
+/obj/effect/turf_decal/box/corners{
+	dir = 1
 	},
-/obj/machinery/recharger{
-	pixel_y = 6;
-	pixel_x = 6
+/obj/effect/turf_decal/arrows{
+	dir = 1;
+	pixel_x = 11;
+	pixel_y = -13
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "dXD" = (
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain/human,
 /obj/item/reagent_containers/food/snacks/meat/rawcutlet/plain/human,
@@ -9241,8 +9567,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
 /area/f13/enclave)
 "eao" = (
-/obj/structure/shelf_wood,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/structure/frame/machine{
+	anchored = 1
+	},
+/obj/item/circuitboard/machine/ore_silo,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
 /area/f13/brotherhood/rnd)
 "eau" = (
 /obj/structure/simple_door/metal/ventilation,
@@ -9483,6 +9818,13 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
+"eha" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/suit_storage_unit/mining,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "ehh" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
@@ -9762,6 +10104,12 @@
 /obj/machinery/computer/cloning,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/ruin/powered)
+"emx" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/circuit/f13_green,
+/area/f13/brotherhood/rnd)
 "emA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -9876,14 +10224,10 @@
 	},
 /area/f13/bunker)
 "epV" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/obj/effect/landmark/start/f13/initiate,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/shelf_wood,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood/reactor)
 "eqc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/computer,
@@ -9959,24 +10303,25 @@
 	},
 /area/f13/bunker/bunkerfive)
 "erw" = (
-/obj/machinery/rnd/science_lab,
-/obj/machinery/light{
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
 	dir = 1;
-	light_color = "#706891";
-	pixel_y = 5
+	icon_state = "shuttle_chair";
+	name = "prewar lounge chair"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/rnd)
 "erK" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "esj" = (
-/obj/machinery/light/floor,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/machinery/mech_bay_recharge_port{
+	dir = 8
 	},
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "esl" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul/soldier,
@@ -10013,6 +10358,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/ruin/powered)
+"etb" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/operations)
 "etg" = (
 /obj/structure/barricade/bars,
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
@@ -10137,11 +10489,10 @@
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker/bighornbunker)
 "ewv" = (
-/obj/structure/chair/wood{
-	dir = 8;
-	layer = 1
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/wood_common,
 /area/f13/brotherhood/leisure)
 "ewK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10350,9 +10701,9 @@
 /turf/open/water,
 /area/f13/sewer)
 "eAw" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
 "eAB" = (
 /obj/structure/handrail/g_central{
@@ -10365,6 +10716,17 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"eAC" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "eAP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -10458,21 +10820,23 @@
 /turf/open/floor/holofloor/plating,
 /area/f13/brotherhood/armory)
 "eCx" = (
-/obj/effect/decal/cleanable/ash/crematorium,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operating)
 "eCA" = (
+/obj/structure/barricade/bars,
 /turf/open/floor/plating,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "eCE" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "eCI" = (
 /obj/structure/table,
@@ -10676,14 +11040,15 @@
 	},
 /area/f13/sewer/powered)
 "eGH" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/structure/curtain,
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
-/area/f13/brotherhood/operating)
+/obj/machinery/door/airlock/grunge{
+	name = "Combat Caste Office";
+	req_access_txt = "120"
+	},
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "eGI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -10797,6 +11162,15 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bunkersix)
+"eKa" = (
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "eKj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin/trashbin,
@@ -10847,9 +11221,13 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "eLm" = (
-/obj/structure/sign/departments/security,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/armory)
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/structure/window/reinforced/clockwork/fulltile,
+/obj/structure/barricade/bars,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "eLo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice,
@@ -10914,6 +11292,12 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"eLY" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 16
+	},
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "eMv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/ammo,
@@ -10943,9 +11327,7 @@
 /turf/open/floor/carpet/green,
 /area/f13/radiation)
 "eNl" = (
-/obj/structure/rack/shelf_metal{
-	pixel_y = -12
-	},
+/obj/structure/rack/shelf_metal,
 /obj/item/pda/engineering{
 	name = "Knight-Engineer Pip-Boy 3000"
 	},
@@ -10999,12 +11381,9 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
 "eNP" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/leisure)
 "eNY" = (
 /obj/item/trash/f13/c_ration_1,
 /turf/open/floor/plasteel/dark,
@@ -11045,9 +11424,14 @@
 /turf/open/floor/plasteel,
 /area/f13/sewer)
 "eOY" = (
-/obj/structure/bed,
-/turf/open/floor/carpet/green,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/blood{
+	icon_state = "floor6";
+	pixel_x = -18;
+	pixel_y = 15
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "ePo" = (
 /obj/item/storage/firstaid/regular,
 /obj/structure/table,
@@ -11057,12 +11441,23 @@
 	},
 /area/f13/bunker/bunkerthree)
 "ePu" = (
-/obj/structure/chair/stool/retro/black,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/table/glass,
+/obj/item/stack/sheet/metal/fifty{
+	pixel_x = -2;
+	pixel_y = 1
 	},
-/area/f13/brotherhood/chemistry)
+/obj/item/stack/sheet/glass/fifty{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/white/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/f13/brotherhood/rnd)
 "ePB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -11114,12 +11509,10 @@
 	},
 /area/f13/bunker/bunkersix)
 "eQq" = (
-/obj/structure/curtain{
-	color = "#5c131b"
-	},
+/obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "eQw" = (
 /obj/structure/table,
 /obj/item/ammo_box/magazine/m556/rifle/extended/empty,
@@ -11295,7 +11688,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
 "eTY" = (
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/dorms)
 "eUd" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -11317,6 +11711,14 @@
 /mob/living/simple_animal/hostile/ghoul/soldier,
 /turf/open/water,
 /area/f13/sewer)
+"eUs" = (
+/obj/structure/bookcase/manuals,
+/obj/item/book/manual/wiki/research_and_development,
+/obj/item/book/manual/wiki/robotics_cyborgs,
+/obj/item/book/manual/wiki/surgery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "eUx" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/ladder/unbreakable{
@@ -11419,7 +11821,6 @@
 	name = "Weapon Attachments"
 	},
 /obj/effect/spawner/lootdrop/f13/attachments,
-/obj/effect/spawner/lootdrop/f13/attachments,
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -11434,21 +11835,26 @@
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer/powered)
+"eYm" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/f13/brotherhood/rnd)
 "eYo" = (
 /obj/structure/stairs/south,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "eYs" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/bedsheet,
+/obj/structure/curtain{
+	color = "#363636"
 	},
-/obj/structure/table/reinforced,
-/obj/structure/barricade/concrete,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
+/area/f13/brotherhood/dorms)
 "eYw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11503,6 +11909,11 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
+"eZh" = (
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 10
+	},
+/area/f13/brotherhood/operations)
 "eZv" = (
 /obj/item/storage/trash_stack{
 	icon_state = "Junk_9";
@@ -11761,6 +12172,11 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"ffM" = (
+/obj/structure/table,
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "ffS" = (
 /obj/structure/table,
 /obj/machinery/computer/terminal{
@@ -12003,9 +12419,15 @@
 /area/f13/sewer)
 "fla" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/bag/salvage,
-/obj/item/clothing/head/welding,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/item/armor_repair_kit{
+	pixel_y = 8;
+	pixel_x = -2
+	},
+/obj/item/armor_repair_kit{
+	pixel_y = 4;
+	pixel_x = 2
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood/reactor)
 "flf" = (
 /obj/effect/decal/waste{
@@ -12095,11 +12517,12 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "fno" = (
-/obj/machinery/light{
-	pixel_x = -16
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood/chemistry)
 "fnw" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -12133,7 +12556,7 @@
 "foH" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/closed/indestructible/f13/matrix,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "foK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -12186,17 +12609,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
 /area/f13/enclave)
 "fpr" = (
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	layer = 3.3;
-	pixel_x = -1;
-	pixel_y = 15
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/chemistry)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
+/area/f13/brotherhood/leisure)
 "fpu" = (
 /obj/item/trash/f13/c_ration_1,
 /turf/open/indestructible/ground/inside/subway,
@@ -12298,6 +12714,10 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"ftq" = (
+/obj/structure/decoration/vent,
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/operating)
 "ftv" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway,
@@ -12377,6 +12797,11 @@
 	},
 /turf/open/floor/plating/rust,
 /area/f13/brotherhood/reactor)
+"fvH" = (
+/obj/effect/decal/cleanable/robot_debris/down,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fvK" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/f13{
@@ -12392,9 +12817,12 @@
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
 "fwv" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/brotherhood/operations)
+/obj/structure/table/reinforced,
+/obj/machinery/vending/medical/free,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "fww" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash,
@@ -12490,6 +12918,13 @@
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/sewer)
+"fxS" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/brotherhood/reactor)
 "fxU" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/effect/decal/remains/human{
@@ -12593,11 +13028,29 @@
 	},
 /area/f13/vault/security/armory)
 "fAe" = (
+/obj/structure/kitchenspike_frame{
+	name = "Power armor frame";
+	anchored = 1;
+	desc = "A heavily-reinforced set of beams and chains meant to hold power armor in place during maintenance. Needless to say, you aren't moving it anytime soon."
+	},
+/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d{
+	pixel_y = 9;
+	pixel_x = 1;
+	anchored = 1;
+	desc = "An inoperable suit of T-45d power armor. It hangs from the frame like a freshly-cleaned fish, innards exposed.";
+	name = "inoperable T-45d helmet"
+	},
+/obj/item/clothing/suit/armor/tiered/heavy/salvaged_pa/tier3/t45d{
+	anchored = 1;
+	desc = "An inoperable suit of T-45d power armor. It hangs from the frame like a freshly-cleaned fish, innards exposed.";
+	name = "inoperable T-45d power armor"
+	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "fAg" = (
 /obj/structure/sign/poster/contraband/missing_gloves,
@@ -12646,9 +13099,10 @@
 	},
 /area/f13/bunker/bunkerthree)
 "fAK" = (
-/obj/machinery/light,
+/obj/item/bedsheet/hos,
+/obj/structure/bed,
 /turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/dorms)
 "fAN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/ammo/shotgun,
@@ -12683,12 +13137,15 @@
 	},
 /area/f13/building/abandoned/o)
 "fBB" = (
-/obj/structure/table/glass,
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/chair/sofa{
+	dir = 8
 	},
-/area/f13/brotherhood/operating)
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#228B22"
+	},
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "fBF" = (
 /turf/open/floor/f13{
 	dir = 4;
@@ -12714,10 +13171,7 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
 "fCv" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/advboards,
-/obj/effect/spawner/lootdrop/f13/advboards,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "fCA" = (
 /obj/structure/rack,
@@ -12749,8 +13203,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/overseer)
 "fDl" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
+/obj/machinery/workbench,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
 "fDr" = (
 /obj/structure/rack/shelf_metal{
@@ -12797,14 +13252,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/atrium)
 "fEM" = (
-/obj/item/flag/bos,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/floor/plasteel/cult,
 /area/f13/brotherhood/operations)
 "fET" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12961,22 +13412,14 @@
 	},
 /area/f13/bunker/bunkerthree)
 "fHN" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/scribe,
-/obj/structure/chair/folding{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/sign/departments/examroom,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/operating)
 "fHU" = (
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/barricade/sandbags,
+/obj/machinery/door/poddoor/shutters/old{
+	id = "bos_mine_turret";
+	name = "security shutters"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/mining)
@@ -13096,6 +13539,10 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/bunker/bunkerthree)
+"fKx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "fKF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
@@ -13299,14 +13746,11 @@
 	},
 /area/f13/bunker/bunkerthree)
 "fPf" = (
-/obj/structure/curtain,
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/brotherhood/operating)
 "fPj" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/waste{
@@ -13343,6 +13787,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker/bunkerthree)
+"fQi" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "fQq" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -13400,18 +13850,10 @@
 	},
 /area/f13/bunker/bunkerfive)
 "fRI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/closet/anchored,
-/obj/item/clothing/under/f13/bosform_f,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/under/f13/bosform_m,
-/obj/item/clothing/under/f13/bosform_f,
-/turf/open/floor/plasteel/cult,
-/area/f13/brotherhood/operations)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "fRO" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -13483,8 +13925,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "fTu" = (
-/obj/effect/landmark/start/f13/offduty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/f13,
 /area/f13/brotherhood/operations)
 "fTv" = (
 /obj/structure/lattice,
@@ -13624,14 +14071,17 @@
 /turf/closed/indestructible/rock,
 /area/f13/radiation)
 "fXe" = (
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/brotherhood/chemistry)
+/obj/item/key/janitor{
+	name = "maintmobile key"
+	},
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/operations)
 "fXB" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -13723,6 +14173,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/custodial)
+"gal" = (
+/obj/item/pickaxe/drill,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gam" = (
 /obj/item/trash/pistachios{
 	pixel_x = 10;
@@ -13816,10 +14270,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/atrium)
 "gcr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/headscribe,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
 /area/f13/brotherhood/rnd)
 "gcu" = (
 /obj/structure/barricade/sandbags,
@@ -13927,6 +14380,15 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"geY" = (
+/obj/machinery/porta_turret/f13/turret_556/burstfire{
+	faction = list("BOS");
+	req_access = list(120)
+	},
+/obj/effect/turf_decal/box/red,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "gfe" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -13935,15 +14397,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/sewer)
 "gfi" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/stock_parts,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+/obj/structure/toilet{
+	pixel_y = 13
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/brotherhood/operations)
 "gfl" = (
 /obj/structure/barricade/wooden/planks/pregame,
@@ -13988,10 +14445,10 @@
 /area/f13/sewer)
 "gfU" = (
 /obj/structure/bed/mattress{
-	icon_state = "mattress3"
+	icon_state = "mattress5"
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "gfV" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	desc = "A deadly close combat robot developed by RobCo in a vaguely feminine, yet ominous chassis. This one seems sleeker and more dangerous, with a slick red paintjob.";
@@ -14017,27 +14474,30 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
 "ggl" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891";
+	pixel_y = 5
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/comfy/shuttle{
-	dir = 4;
-	name = "driver's seat"
+/obj/item/storage/box/medsprays{
+	pixel_y = -2
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 10
+	},
 /area/f13/brotherhood/rnd)
 "ggw" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
 "ggL" = (
-/obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
-/turf/open/floor/carpet/black,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
 "ggU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14097,15 +14557,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "gic" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/chemistry)
 "giu" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white,
 /area/f13/vault/atrium)
@@ -14133,7 +14589,6 @@
 /obj/item/stack/sheet/prewar/five,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 9
@@ -14150,6 +14605,20 @@
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"gjp" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/item/kirbyplants/random{
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 10
+	},
+/area/f13/brotherhood/chemistry)
 "gjq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/one_barrel,
@@ -14373,6 +14842,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"gow" = (
+/obj/machinery/biogenerator,
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "goy" = (
 /turf/closed/wall/mineral/iron,
 /area/f13/bunker)
@@ -14429,13 +14904,27 @@
 	},
 /area/f13/sewer)
 "gpL" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/item/blueprint/research,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood/rnd)
+"gpX" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "gqb" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/holopad,
@@ -14449,6 +14938,20 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/sewer)
+"gqh" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/optable,
+/obj/machinery/iv_drip{
+	pixel_x = 15;
+	pixel_y = -2
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -27
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/operating)
 "gqq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/chair/wood{
@@ -14476,18 +14979,10 @@
 /area/f13/bunker/bunkerthree)
 "gqZ" = (
 /obj/structure/table/glass,
-/obj/item/integrated_circuit_printer,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/integrated_electronics/analyzer,
-/obj/item/integrated_electronics/debugger,
-/obj/item/integrated_electronics/detailer,
-/obj/item/integrated_electronics/wirer,
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#ff4747"
+/obj/item/kirbyplants/random{
+	pixel_y = 18
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/brotherhood/rnd)
 "grs" = (
 /obj/structure/sign/warning/nosmoking/circle,
@@ -14524,10 +15019,8 @@
 /area/f13/sewer)
 "gsa" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side,
+/area/f13/brotherhood/chemistry)
 "gsf" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -14546,12 +15039,9 @@
 	},
 /area/f13/tunnel)
 "gsj" = (
-/obj/structure/table/reinforced,
-/obj/item/documents/syndicate/blue,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/turf/open/floor/padded,
+/area/f13/brotherhood/leisure)
 "gsv" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/tunnel{
@@ -14642,6 +15132,14 @@
 /obj/structure/wreck/trash/secway,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/ruin/powered)
+"guO" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bodycontainer/crematorium,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operating)
 "guQ" = (
 /obj/machinery/button/door{
 	id = "DungeonRange";
@@ -14690,7 +15188,7 @@
 /area/f13/sewer)
 "gvu" = (
 /obj/structure/table/rolling,
-/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/item/locked_box/misc/attachments,
 /turf/open/floor/holofloor/plating,
 /area/f13/brotherhood/armory)
 "gvE" = (
@@ -14699,16 +15197,9 @@
 	},
 /area/f13/vault/medical/chemistry)
 "gvF" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_y = 5
-	},
-/obj/item/storage/firstaid/regular,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gvQ" = (
 /obj/structure/chair/comfy/modern{
 	dir = 1
@@ -14900,6 +15391,9 @@
 	req_access_txt = "120"
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#c1ac99";
 	icon_state = "floorrustysolid"
@@ -15007,6 +15501,7 @@
 /obj/machinery/power/port_gen/pacman/super/vault{
 	anchored = 1
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "engine"
 	},
@@ -15016,7 +15511,10 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood/rnd)
 "gBW" = (
 /obj/effect/gibspawner/human,
@@ -15045,12 +15543,11 @@
 	},
 /area/ruin/powered)
 "gCc" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/janitorialcart,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operations)
 "gCf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
@@ -15518,23 +16015,12 @@
 /turf/closed/wall/rust,
 /area/f13/sewer)
 "gMF" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/machinery/vending/wallmed{
-	pixel_y = 30;
-	products = list(/obj/item/reagent_containers/syringe=3,/obj/item/reagent_containers/pill/patch/styptic=10,/obj/item/reagent_containers/pill/patch/silver_sulf=10,/obj/item/reagent_containers/medspray/styptic=4,/obj/item/reagent_containers/medspray/silver_sulf=4,/obj/item/reagent_containers/pill/charcoal=2,/obj/item/reagent_containers/medspray/sterilizine=2)
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
-/area/f13/brotherhood/operating)
+/turf/closed/mineral/uranium,
+/area/f13/caves)
 "gMH" = (
-/obj/structure/noticeboard{
-	pixel_y = 32
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubbleplate"
 	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/paper_bin,
-/obj/item/pen/fourcolor,
-/turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "gMM" = (
 /obj/structure/lattice,
@@ -15565,9 +16051,11 @@
 	},
 /area/f13/bunker/bunkerseven)
 "gNu" = (
-/obj/structure/table/glass,
-/obj/item/scrap/research,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/machinery/mecha_part_fabricator,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood/rnd)
 "gNv" = (
 /obj/effect/overlay/junk/oldpipes/end,
@@ -15610,6 +16098,14 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
+"gOg" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 1
+	},
+/area/f13/brotherhood/chemistry)
 "gOy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/wreck/trash/three_barrels,
@@ -15775,9 +16271,12 @@
 	},
 /area/f13/bunker/bunkerseven)
 "gSr" = (
-/obj/structure/rack/large/shelf_rust,
-/obj/item/stack/ore/blackpowder/fifty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/turf_decal/big{
+	dir = 6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/reactor)
 "gSz" = (
 /turf/open/floor/plasteel/f13{
@@ -15845,13 +16344,11 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/caves)
 "gTI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/landmark/start/f13/headscribe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/brotherhood/rnd)
 "gTQ" = (
 /obj/effect/decal/cleanable/dirt{
@@ -15979,6 +16476,10 @@
 	dir = 1
 	},
 /area/f13/vault/science)
+"gWI" = (
+/obj/structure/nest/protectron,
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "gWK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/grass/jungle{
@@ -16002,11 +16503,13 @@
 	},
 /area/f13/bunker/bighornbunker)
 "gXb" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/structure/railing{
+	layer = 3.1
 	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/padded,
+/area/f13/brotherhood/leisure)
 "gXr" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -16216,11 +16719,9 @@
 	},
 /area/f13/bunker/bunkerthree)
 "haX" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/leisure)
 "hbg" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
@@ -16285,7 +16786,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/side,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "hco" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/inside/subway,
@@ -16382,61 +16883,20 @@
 	},
 /area/f13/bunker/bunkerthree)
 "heh" = (
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 11
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "twindowold"
 	},
-/obj/item/melee/classic_baton/telescopic{
-	pixel_x = -4;
-	pixel_y = 8
+/obj/structure/decoration/vent,
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -10;
-	pixel_y = -10
+/obj/machinery/shower{
+	pixel_y = 24
 	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -6;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = -2;
-	pixel_y = -10
-	},
-/obj/item/reagent_containers/spray/pepper{
-	pixel_x = 2;
-	pixel_y = -10
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 5;
-	pixel_y = 8
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 7;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 9;
-	pixel_y = 8
-	},
-/obj/item/grenade/flashbang{
-	pixel_x = 11;
-	pixel_y = 8
-	},
-/obj/machinery/light/small,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/box/handcuffs{
-	pixel_x = 13;
-	pixel_y = -8
-	},
-/obj/structure/rack/shelf_metal{
-	pixel_y = -12
-	},
-/obj/item/pda/warden,
-/obj/item/gun/ballistic/shotgun/police,
-/obj/item/ammo_box/shotgun/rubber,
-/obj/item/ammo_box/shotgun/bean,
-/turf/open/floor/plasteel/f13/vault_floor/red/side,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
+/area/f13/brotherhood/dorms)
 "heG" = (
 /obj/structure/sign/departments/security,
 /turf/closed/wall/r_wall/f13vault{
@@ -16472,11 +16932,14 @@
 /obj/item/cane,
 /obj/item/cane,
 /obj/item/roller,
-/obj/item/roller,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/box/mousetraps{
+	pixel_y = 12;
+	pixel_x = -4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operating)
 "hfu" = (
@@ -16518,6 +16981,11 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker/bunkernine)
+"hfM" = (
+/obj/structure/chair/stool/bar,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
+/area/f13/brotherhood/leisure)
 "hgc" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
 /area/f13/vault/science)
@@ -16624,13 +17092,10 @@
 	},
 /area/f13/bunker)
 "hhM" = (
-/obj/structure/chair/f13chair1{
-	dir = 8
-	},
-/obj/machinery/light{
-	pixel_x = -16
-	},
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/item/documents/syndicate/blue,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
 "hia" = (
 /obj/effect/decal/cleanable/blood/old{
@@ -16652,8 +17117,9 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "hig" = (
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green/corner,
+/area/f13/brotherhood/rnd)
 "hir" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -16765,6 +17231,14 @@
 	icon_state = "engine"
 	},
 /area/ruin/powered)
+"hlv" = (
+/obj/machinery/vending/wallmed{
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/operating)
 "hlx" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -16783,8 +17257,11 @@
 /area/f13/sewer)
 "hlz" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 5
+	},
+/area/f13/brotherhood/rnd)
 "hlF" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -16830,25 +17307,23 @@
 	color = "000000"
 	},
 /obj/structure/closet/fridge/meat,
-/turf/open/floor/carpet/purple,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
 "hmF" = (
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
 "hmU" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/carpet/black,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
 "hnc" = (
-/obj/structure/kitchenspike_frame{
-	name = "Power armour frame"
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
 	},
-/obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d{
-	pixel_y = 9;
-	pixel_x = 1
-	},
-/obj/item/clothing/suit/armor/tiered/heavy/salvaged_pa/tier3/t45d,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood/reactor)
 "hnf" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
@@ -17152,14 +17627,7 @@
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
 "hsU" = (
-/obj/structure/table/glass,
-/obj/structure/frame/machine{
-	anchored = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/circuitboard/machine/ore_silo,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood/rnd)
 "hth" = (
 /obj/machinery/light/fo13colored/Red{
@@ -17262,9 +17730,19 @@
 	},
 /area/f13/sewer)
 "hwP" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/book/granter/crafting_recipe/blueprint/trapper,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/machinery/workbench/forge{
+	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
+	icon_state = "generator_on";
+	name = "superheating forge";
+	pixel_y = 6;
+	pixel_x = 3
+	},
+/obj/effect/turf_decal/big{
+	dir = 10
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/reactor)
 "hwQ" = (
 /mob/living/simple_animal/hostile/handy/gutsy{
@@ -17421,10 +17899,13 @@
 	},
 /area/f13/enclave)
 "hAn" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+/obj/structure/sign/departments/security{
+	pixel_y = 32
 	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -17588,19 +18069,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
 "hEs" = (
-/obj/machinery/computer/rdconsole/core/bos{
-	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
-	name = "Head Scribe's Archive Terminal"
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/operating)
 "hEt" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/obj/structure/fluff/rug/rug_rubber,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood/leisure)
 "hED" = (
 /turf/open/floor/f13{
 	dir = 4;
@@ -17668,15 +18147,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess,
 /area/f13/enclave)
 "hFH" = (
-/obj/structure/rack/large/shelf,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier2,
-/obj/machinery/light{
-	light_color = "#e8eaff"
+/obj/item/mine/emp,
+/obj/item/mine/emp,
+/obj/item/broken_bottle{
+	pixel_x = -6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/item/trash/f13/mre{
+	pixel_x = 6
 	},
-/area/f13/brotherhood/operations)
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hFM" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/dark,
@@ -17816,16 +18296,14 @@
 	},
 /area/f13/enclave)
 "hJQ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 1
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "hJW" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -17849,11 +18327,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
 "hLk" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/table/booth,
+/obj/item/trash/plate{
+	pixel_y = 4
 	},
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood_common,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "hLv" = (
 /obj/structure/table,
@@ -17989,17 +18467,19 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/white/whiteredchess/whiteredchess2,
 /area/f13/enclave)
 "hOG" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operating)
 "hPf" = (
-/obj/machinery/computer/operating/bos{
-	dir = 1
+/obj/effect/turf_decal/arrows{
+	dir = 8;
+	pixel_y = 11
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operating)
+/area/f13/brotherhood/operations)
 "hPE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/frame/machine{
@@ -18027,10 +18507,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "hQa" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/dorms)
 "hQn" = (
 /obj/structure/closet/locker{
@@ -18070,16 +18547,18 @@
 	},
 /area/f13/sewer)
 "hRe" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/sleeper{
+	density = 1;
+	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
 	},
-/area/f13/brotherhood/reactor)
+/area/f13/brotherhood/operating)
 "hRn" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
@@ -18116,10 +18595,26 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/ruin/powered)
+"hSb" = (
+/obj/structure/closet/crate/trashcart,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "hSj" = (
 /obj/structure/debris/v1,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"hSr" = (
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
+	dir = 1;
+	name = "prewar lounge chair"
+	},
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/brotherhood/rnd)
 "hST" = (
 /obj/structure/table/booth,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -18136,13 +18631,13 @@
 /turf/open/floor/plating/rust,
 /area/f13/radiation)
 "hTr" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/mob/living/simple_animal/cow/brahmin{
+	name = "Knight Moosley";
+	desc = "A respected member of the bunker kitchen staff. Moo."
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 8
-	},
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/brotherhood/rnd)
 "hTu" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -18263,6 +18758,9 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
+"hUJ" = (
+/turf/closed/indestructible/f13/matrix,
+/area/f13/brotherhood/dorms)
 "hUK" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/closed/wall/f13/ruins,
@@ -18303,6 +18801,13 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/enclave)
+"hVw" = (
+/obj/structure/chair/left,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/leisure)
 "hVz" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -18358,7 +18863,7 @@
 /area/f13/caves)
 "hXs" = (
 /obj/machinery/camera/autoname{
-	name = "Secuirty Camera";
+	name = "Security Camera";
 	network = list("BoS")
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -18529,10 +19034,15 @@
 	},
 /area/f13/bunker/bunkerthree)
 "ibr" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/glass,
-/obj/item/scrap/research,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/item/pda/chemist{
+	name = "Scribe-Chemist Pip-Boy 3000";
+	pixel_y = 7
+	},
+/obj/item/storage/box/beakers,
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner{
+	dir = 8
+	},
 /area/f13/brotherhood/rnd)
 "ibz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18579,6 +19089,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/radiation)
+"icM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/bos,
+/turf/open/floor/plasteel/f13/vault_floor/red/corner,
+/area/f13/brotherhood/operations)
 "ida" = (
 /obj/item/target,
 /obj/structure/target_stake,
@@ -18601,11 +19116,31 @@
 /obj/structure/wreck/trash/three_barrels,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"idH" = (
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/chemistry)
 "idJ" = (
-/obj/structure/dresser,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/toy/cards/deck{
+	pixel_x = -6;
+	pixel_y = 1
+	},
 /turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "idM" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/rack/shelf_metal,
@@ -18713,9 +19248,8 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/sewer/powered)
 "ihK" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plating,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/operations)
 "ihU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/toy/plush/mammal/fox/squishfox,
@@ -18808,13 +19342,10 @@
 /area/f13/sewer/powered)
 "ikf" = (
 /obj/effect/decal/cleanable/dirt{
-	color = "000000"
+	color = "#363636"
 	},
-/obj/item/stack/sheet/mineral/abductor,
-/obj/machinery/rnd/destructive_analyzer,
-/obj/structure/window/reinforced/spawner/north,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood/operations)
 "ikj" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -18924,9 +19455,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
 "imC" = (
-/obj/structure/mirror,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/dorms)
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#c1caff"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/brotherhood/rnd)
 "imO" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/sewer/powered)
@@ -18972,11 +19507,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess/redchess2,
 /area/f13/bunker/bunkerfive)
 "inH" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 8;
-	name = "driver's seat"
+/obj/item/integrated_electronics/analyzer{
+	pixel_x = -6
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/item/integrated_electronics/detailer{
+	pixel_x = 6
+	},
+/obj/structure/table/glass,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/brotherhood/rnd)
 "inM" = (
 /obj/machinery/door/airlock/hatch,
@@ -19051,10 +19593,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "ipI" = (
-/obj/item/storage/money_stack{
-	pixel_x = 8
+/obj/effect/decal/cleanable/vomit/old,
+/obj/item/kirbyplants,
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS")
 	},
-/turf/open/floor/wood_common,
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/brotherhood/leisure)
 "ipW" = (
 /turf/open/indestructible/ground/inside/subway,
@@ -19125,14 +19670,14 @@
 	},
 /area/f13/bunker/bunkerfive)
 "iri" = (
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
+/obj/effect/decal/marking{
+	pixel_x = -16
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operations)
 "irp" = (
 /obj/machinery/light{
 	dir = 4
@@ -19277,6 +19822,10 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/enclave)
+"iuq" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "iuA" = (
 /obj/structure/closet/fridge,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -19554,8 +20103,7 @@
 	},
 /area/f13/bunker/bunkerseven)
 "iAV" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood/reactor)
 "iBL" = (
 /obj/structure/shelf_wood,
@@ -19604,9 +20152,9 @@
 	},
 /area/f13/bunker/bunkerthree)
 "iCz" = (
-/obj/machinery/rnd/production/protolathe,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/brotherhood/rnd)
+/obj/effect/landmark/start/f13/Knight,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/brotherhood/chemistry)
 "iCV" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -19751,9 +20299,13 @@
 	},
 /area/f13/bunker/bunkersix)
 "iGM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood/rnd)
 "iGQ" = (
 /obj/structure/wreck/trash/machinepile,
@@ -19884,9 +20436,11 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "iKj" = (
-/obj/structure/sign/departments/engineering,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "iKo" = (
 /obj/effect/decal/waste{
 	icon_state = "goo12"
@@ -19904,12 +20458,14 @@
 /turf/closed/wall/f13/ruins,
 /area/f13/sewer)
 "iKT" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/machinery/sleeper{
+	density = 1;
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/light{
+	dir = 8
 	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/operating)
 "iLg" = (
 /obj/structure/disposalpipe/segment{
@@ -20001,10 +20557,9 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "iOg" = (
-/obj/item/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/sofa/corp/left,
 /turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "iOq" = (
 /obj/structure/lattice,
 /obj/machinery/light/floor,
@@ -20090,8 +20645,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
 "iPM" = (
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 5
+	},
+/area/f13/brotherhood/rnd)
 "iPV" = (
 /obj/structure/debris/v4,
 /obj/structure/debris/v1,
@@ -20136,10 +20696,13 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "iRs" = (
-/obj/structure/sign/departments/evac,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
+"iRK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/operating)
 "iRU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/handy,
@@ -20178,11 +20741,12 @@
 	},
 /area/f13/bunker)
 "iSH" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#c1caff"
 	},
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/machinery/libraryscanner,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/rnd)
 "iSL" = (
 /obj/structure/table/wood,
@@ -20249,6 +20813,13 @@
 	},
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/diner)
+"iUL" = (
+/obj/structure/table/wood,
+/obj/item/twohanded/required/kirbyplants/random{
+	pixel_y = 6
+	},
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/dorms)
 "iUO" = (
 /obj/structure/lattice/clockwork,
 /obj/structure/fence/handrail{
@@ -20352,6 +20923,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/red/white/whiteredchess/whiteredchess2,
 /area/f13/enclave)
+"iXk" = (
+/obj/effect/landmark/start/f13/scribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "iXH" = (
 /obj/structure/simple_door/metal/dirtystore,
 /turf/open/floor/f13/wood,
@@ -20371,6 +20948,14 @@
 /obj/item/borg/upgrade/modkit/tracer/adjustable,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"iXZ" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/cult,
+/area/f13/brotherhood/operations)
 "iYd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/simple_door/metal/dirtystore,
@@ -20427,16 +21012,11 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
 "iZL" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/obj/structure/lattice/catwalk,
+/obj/item/stack/cable_coil/ten,
+/obj/item/wirecutters,
+/obj/item/light/tube,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "iZN" = (
 /obj/structure/simple_door/bunker,
@@ -20484,12 +21064,16 @@
 /turf/closed/indestructible/syndicate,
 /area/ruin/powered)
 "jat" = (
-/obj/machinery/chem_heater,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/light{
+	light_color = "#e8eaff";
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operations)
 "jax" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/one_barrel,
@@ -20613,7 +21197,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/turf/open/floor/wood_common,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "jcM" = (
 /obj/machinery/button/crematorium{
@@ -20623,12 +21207,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operating)
 "jcR" = (
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
@@ -20716,17 +21296,8 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
 "jeP" = (
-/obj/structure/table/reinforced,
-/obj/structure/barricade/concrete,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/green/side,
+/area/f13/brotherhood/rnd)
 "jeW" = (
 /obj/machinery/light/floor,
 /obj/effect/decal/cleanable/dirt,
@@ -20753,6 +21324,15 @@
 	},
 /turf/open/floor/plating/dirt/dark,
 /area/f13/radiation)
+"jfw" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "drip1";
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "jfx" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -20855,12 +21435,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/enclave)
 "jiB" = (
-/obj/structure/chair/sofa/left,
-/obj/effect/landmark/start/f13/Knight,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/turf_decal/weather/dirt{
+	pixel_x = -2;
+	pixel_y = -2
 	},
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass/dirtpath,
+/area/f13/brotherhood/rnd)
 "jiC" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
@@ -20869,6 +21450,10 @@
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"jjg" = (
+/obj/structure/barricade/wooden,
+/turf/closed/mineral/random/low_chance,
+/area/f13/caves)
 "jjj" = (
 /obj/item/clothing/mask/rat/bat,
 /obj/structure/rack,
@@ -20880,8 +21465,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
 "jjA" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood_common,
+/obj/structure/lattice/catwalk,
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "jjG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20954,7 +21541,7 @@
 /obj/machinery/flasher,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/closed/wall/r_wall,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "jmG" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -20993,13 +21580,12 @@
 /turf/open/floor/plating,
 /area/f13/tcoms)
 "jnJ" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a very futuristic vouge feel.";
-	dir = 1;
-	name = "prewar lounge chair"
+/obj/machinery/rnd/server/bos,
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS")
 	},
-/obj/effect/landmark/start/f13/seniorscribe,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/brotherhood/rnd)
 "jnR" = (
 /obj/machinery/light/small{
@@ -21010,22 +21596,16 @@
 	},
 /area/f13/bunker)
 "jon" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/clothing/under/rank/medical/green,
-/obj/item/clothing/under/rank/medical/purple,
-/obj/item/clothing/under/rank/medical/blue,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/structure/table/optable,
+/obj/machinery/iv_drip{
+	pixel_x = 15;
+	pixel_y = -2
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "bcircuit1";
 	light_color = "#0076bc";
@@ -21069,10 +21649,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/mining)
 "jpe" = (
-/obj/effect/landmark/start/f13/initiate,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/machinery/light/floor,
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "jpo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21106,15 +21684,14 @@
 	},
 /area/f13/bunker/bunkerthree)
 "jpG" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#228B22"
+/obj/structure/chair/sofa/left{
+	dir = 8
 	},
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/sign/poster/prewar/poster74{
+	pixel_x = 32
 	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "jpJ" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -21227,17 +21804,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "jsV" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/structure/chair/f13chair1{
+	dir = 1
 	},
-/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+/obj/machinery/light/small{
+	dir = 1
 	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/carpet/blue,
+/area/f13/brotherhood/dorms)
 "jsX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/decal/cleanable/dirt,
@@ -21331,6 +21905,20 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"juj" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/surgical_drapes,
+/obj/item/clothing/gloves/color/latex/nitrile,
+/obj/item/stack/sticky_tape/surgical{
+	pixel_x = -11;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/operating)
 "juB" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh,
@@ -21413,6 +22001,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/f13,
 /area/ruin/powered)
+"jwf" = (
+/turf/open/indestructible/ground/outside/ruins,
+/area/f13/brotherhood/operations)
 "jwi" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box,
@@ -21440,11 +22031,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker/bunkerfive)
 "jwK" = (
-/obj/structure/chair/office{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/doctorbag,
+/obj/structure/table{
+	layer = 2.9
 	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/operating)
 "jwU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21615,6 +22213,10 @@
 /obj/machinery/computer/terminal,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker/bighornbunker)
+"jAO" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/operations)
 "jBg" = (
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /obj/structure/rack,
@@ -21775,13 +22377,8 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "jFG" = (
-/obj/machinery/door/airlock/grunge{
-	id_tag = "bosarmoryacc";
-	name = "Mine";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plating/rust,
-/area/f13/brotherhood/mining)
+/turf/closed/wall/r_wall,
+/area/f13/caves)
 "jGi" = (
 /obj/structure/debris/v3{
 	pixel_x = -15;
@@ -21809,9 +22406,13 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/machinery/light{
-	light_color = "#e8eaff"
+/obj/structure/barricade/sandbags,
+/obj/machinery/door/poddoor/shutters/old{
+	id = "bos_front_turret";
+	name = "security shutters"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -21851,8 +22452,9 @@
 /area/f13/caves)
 "jIm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "jIn" = (
 /obj/structure/nest/gecko,
@@ -21894,12 +22496,29 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
+"jJh" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Security Checkpoint";
+	req_access_txt = "120"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "jJM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/ruin/powered)
+"jJW" = (
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/leisure)
 "jKd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/wood{
@@ -21909,14 +22528,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
 "jKg" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
+/obj/structure/railing{
+	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/padded,
+/area/f13/brotherhood/leisure)
 "jKh" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 1
@@ -21994,11 +22611,21 @@
 /area/f13/tunnel)
 "jLF" = (
 /obj/machinery/light{
-	dir = 1;
-	flickering = 1
+	dir = 8
 	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/operating)
+"jMa" = (
+/obj/structure/fluff/rug/rug_rubber,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood/leisure)
 "jMb" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/turf_decal/caution/stand_clear,
@@ -22058,7 +22685,17 @@
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/diner)
 "jNz" = (
-/obj/machinery/vending/medical/free,
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/item/storage/box/gloves{
+	pixel_y = 6;
+	pixel_x = -8
+	},
+/obj/item/storage/box/masks{
+	pixel_y = 6;
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "bcircuit1";
 	light_color = "#0076bc";
@@ -22195,18 +22832,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
 "jQQ" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "jRc" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = 16
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
 	},
-/turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "jRt" = (
 /obj/machinery/vending/dinnerware{
@@ -22304,6 +22936,9 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"jTT" = (
+/turf/open/floor/plasteel/dark,
+/area/f13/brotherhood/rnd)
 "jTV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -22417,14 +23052,24 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"jXt" = (
-/obj/structure/chair/sofa/left{
-	dir = 8
-	},
+"jXp" = (
+/obj/structure/closet/anchored,
+/obj/item/soap,
+/obj/item/soap,
+/obj/item/crafting/abraxo,
+/obj/item/crafting/abraxo,
+/obj/item/storage/bag/trash,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"jXt" = (
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "jXu" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/decal/cleanable/dirt,
@@ -22471,6 +23116,10 @@
 "jYz" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/sewer)
+"jYE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
+/area/f13/brotherhood/operating)
 "jYJ" = (
 /mob/living/simple_animal/hostile/raider/legendary,
 /turf/open/floor/f13{
@@ -22498,22 +23147,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
 "jYX" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 6
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair";
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/item/wrench/advanced{
-	pixel_x = 2
-	},
-/obj/item/crowbar/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/brotherhood/rnd)
 "jZf" = (
 /obj/machinery/light/small{
@@ -22738,6 +23380,12 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/enclave)
+"kcR" = (
+/obj/machinery/door/window/brigdoor,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "kcT" = (
 /obj/structure/fence{
 	dir = 8
@@ -22791,17 +23439,24 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/human,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"keg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/caution{
+	dir = 4;
+	pixel_x = -6
+	},
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/leisure)
 "kev" = (
-/obj/machinery/chem_dispenser,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+/obj/structure/fence/corner,
+/obj/structure/sign/yield{
+	pixel_x = 16;
+	pixel_y = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operations)
 "kfa" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -22930,6 +23585,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
+"khp" = (
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "khv" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt{
@@ -23006,16 +23666,12 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "kiv" = (
-/obj/structure/table/glass,
-/obj/machinery/plantgenes/seedvault{
-	pixel_y = 7
-	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#706891"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "kiG" = (
 /obj/structure/flora/rock/pile/largejungle,
 /turf/open/indestructible/ground/inside/mountain,
@@ -23380,6 +24036,9 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker/bunkerfive)
+"kol" = (
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/brotherhood/rnd)
 "koN" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
@@ -23401,9 +24060,11 @@
 /turf/open/floor/plating/dirt/dark,
 /area/f13/radiation)
 "kpo" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/structure/fence/door/opened,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "kpM" = (
 /turf/open/floor/f13{
 	dir = 1;
@@ -23518,10 +24179,20 @@
 	},
 /area/f13/bunker/bunkerseven)
 "krG" = (
-/obj/machinery/light,
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/leisure)
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 8;
+	pixel_y = 11;
+	pixel_x = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "krW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -23643,12 +24314,17 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "kuz" = (
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
+/obj/machinery/light{
+	dir = 8;
+	pixel_y = -15
+	},
+/obj/structure/table,
 /obj/item/mining_scanner,
 /obj/item/mining_scanner,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/mining)
 "kvc" = (
@@ -23826,6 +24502,14 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
+"kzF" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "kzG" = (
 /obj/structure/disposalpipe/broken{
 	dir = 8;
@@ -23850,10 +24534,14 @@
 	},
 /area/f13/bunker/bunkerfive)
 "kzQ" = (
-/obj/structure/filingcabinet,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/obj/structure/railing/corner{
+	color = "#A47449"
+	},
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/leisure)
 "kzR" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/bar,
@@ -23910,7 +24598,14 @@
 /turf/open/floor/plasteel/elevatorshaft,
 /area/f13/brotherhood/operations)
 "kAW" = (
-/obj/structure/chair/f13chair1,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/chair/wood/modern,
+/obj/effect/decal/cleanable/robot_debris/down,
+/obj/effect/decal/cleanable/cobweb{
+	dir = 1;
+	icon_state = "cobweb2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "kAX" = (
@@ -23955,6 +24650,27 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/bunker/bunkerthree)
+"kBJ" = (
+/obj/structure/table{
+	layer = 2.9
+	},
+/obj/machinery/reagentgrinder{
+	layer = 3.3;
+	pixel_x = -1;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/glass/beaker/large{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/item/storage/bag/chemistry{
+	pixel_x = 10;
+	pixel_y = 14
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "kBP" = (
 /obj/effect/overlay/junk/oldpipes/vent{
 	dir = 4
@@ -23975,6 +24691,10 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/enclave)
+"kBQ" = (
+/obj/machinery/vending/nukacolavendfull,
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "kBT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -24048,6 +24768,10 @@
 "kEQ" = (
 /turf/open/floor/plasteel/f13/vault_floor/purple/side,
 /area/f13/vault/atrium)
+"kET" = (
+/obj/machinery/light/floor,
+/turf/open/floor/plating,
+/area/f13/brotherhood/operations)
 "kFe" = (
 /mob/living/simple_animal/hostile/raider/junker,
 /turf/open/indestructible/ground/inside/subway,
@@ -24148,6 +24872,14 @@
 /obj/structure/mecha_wreckage/durand,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/bunker/bunkereight)
+"kHU" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/suit/armor/outfit/overalls/blacksmith,
+/obj/item/clothing/gloves/f13/blacksmith,
+/obj/item/twohanded/sledgehammer/simple,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/area/f13/brotherhood/reactor)
 "kHX" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/tunnel,
@@ -24168,10 +24900,13 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkerthree)
 "kIr" = (
-/obj/effect/landmark/start/f13/knightcap,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/padded,
+/area/f13/brotherhood/leisure)
 "kIt" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitories"
@@ -24223,8 +24958,10 @@
 /area/f13/sewer)
 "kKl" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/turf/open/floor/carpet{
+	icon_state = "carpetstar"
+	},
+/area/f13/brotherhood/leisure)
 "kKm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window,
@@ -24264,11 +25001,14 @@
 	},
 /area/f13/bunker/bunkerthree)
 "kKQ" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
+/obj/machinery/door/airlock/grunge{
+	name = "Head's Quarters";
+	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/cult,
-/area/f13/brotherhood/operations)
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/brotherhood/leisure)
 "kKV" = (
 /obj/structure/bed/old,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24491,12 +25231,14 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "kPi" = (
-/obj/effect/landmark/start/f13/initiate,
-/obj/structure/chair/wood{
-	dir = 8;
-	layer = 1
+/obj/effect/turf_decal/vg_decals/department/bar{
+	dir = 4;
+	pixel_x = -6
 	},
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "kPm" = (
 /obj/machinery/door/airlock/hatch,
@@ -24616,11 +25358,18 @@
 	},
 /area/f13/brotherhood/reactor)
 "kRr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/mob/living/simple_animal/cow/brahmin{
+	desc = "One day, it'll graduate to a real caste. Or a real steak dinner.";
+	name = "Initiate Moscowitz"
+	},
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/brotherhood/rnd)
 "kRs" = (
 /obj/structure/wreck/trash/machinepiletwo{
 	pixel_y = 6
@@ -24632,19 +25381,26 @@
 	dir = 4;
 	light_color = "#228B22"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/rack/shelf_metal,
+/obj/item/clothing/head/welding,
+/obj/item/storage/bag/salvage,
+/obj/item/storage/bag/salvage,
+/obj/item/weldingtool/hugetank,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "kRz" = (
 /mob/living/simple_animal/hostile/securitron/sentrybot,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "kRB" = (
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/turf/open/floor/carpet/green,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/brotherhood/chemistry)
 "kRH" = (
 /obj/structure/sign/poster/prewar/poster74{
 	pixel_x = 32
@@ -24989,20 +25745,8 @@
 	},
 /area/ruin/powered)
 "kXV" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "twindowold"
-	},
-/obj/structure/decoration/vent,
-/obj/structure/curtain{
-	color = "#845f58"
-	},
-/obj/machinery/shower{
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
-/area/f13/brotherhood/operations)
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/dorms)
 "kYd" = (
 /mob/living/simple_animal/hostile/raider/thief,
 /turf/open/floor/f13/wood,
@@ -25085,8 +25829,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault/diner)
 "kZC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood_fancy,
 /area/f13/brotherhood/rnd)
 "kZG" = (
 /obj/machinery/light/small{
@@ -25100,17 +25846,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/followers)
 "kZP" = (
-/obj/effect/turf_decal/stripes/white/line,
-/obj/machinery/camera/autoname{
-	dir = 8;
-	name = "Armory Camera";
-	network = list("BoS");
-	pixel_x = -1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 1
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/operations)
 "laa" = (
 /turf/open/floor/plasteel/vault/side,
 /area/f13/vault/security/armory)
@@ -25171,6 +25911,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/radiation)
+"laI" = (
+/obj/structure/table/glass,
+/obj/machinery/cell_charger{
+	pixel_y = 14
+	},
+/obj/item/integrated_circuit_printer,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/brotherhood/rnd)
 "laL" = (
 /obj/machinery/telecomms/server/presets/enclave,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -25190,6 +25938,13 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"lbD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken2"
+	},
+/area/f13/brotherhood/operations)
 "lbO" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -25272,13 +26027,24 @@
 	},
 /area/ruin/powered)
 "ldy" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/button/door{
+	pixel_x = -8;
+	pixel_y = -24;
+	name = "Lockdown Switch";
+	id = bos_mine_blast;
+	req_access_txt = "120"
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/button/door{
+	pixel_x = 8;
+	pixel_y = -24;
+	name = "Turret Switch";
+	id = "bos_mine_turret";
+	req_access_txt = "120"
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/operations)
 "ldz" = (
 /obj/structure/disposalpipe/segment,
@@ -25360,16 +26126,17 @@
 	},
 /area/f13/sewer/powered)
 "lgc" = (
-/obj/structure/chair/folding{
-	dir = 8
+/obj/effect/decal/cleanable/robot_debris/down,
+/obj/item/multitool{
+	pixel_x = 7;
+	pixel_y = 5
 	},
-/obj/effect/decal/cleanable/blood{
-	icon_state = "floor6";
-	pixel_x = -18;
-	pixel_y = 15
+/obj/item/wirecutters{
+	pixel_y = -4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
-/area/f13/brotherhood/armory)
+/area/f13/caves)
 "lgm" = (
 /obj/effect/decal/remains/human,
 /turf/open/water,
@@ -25608,11 +26375,13 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
 "lkP" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/structure/table/reinforced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
 	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "lla" = (
 /obj/structure/window{
@@ -25633,9 +26402,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
 "llC" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/green,
-/area/f13/brotherhood/dorms)
+/obj/structure/barricade/sandbags,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "llJ" = (
 /obj/machinery/camera/autoname{
 	dir = 8;
@@ -25674,14 +26450,13 @@
 	},
 /area/ruin/powered)
 "lmi" = (
-/obj/structure/chair/comfy/shuttle{
-	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
-	layer = 2.7;
-	name = "prewar lounge chair"
+/obj/structure/railing{
+	dir = 9
 	},
+/obj/item/clothing/gloves/boxing,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/turf/open/floor/padded,
+/area/f13/brotherhood/leisure)
 "lmp" = (
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side{
 	dir = 6
@@ -25775,7 +26550,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/microwave/stove,
-/turf/open/floor/carpet/purple,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
 "loM" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -25851,12 +26626,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
 "lqk" = (
-/obj/structure/table/wood,
-/obj/item/candle/infinite,
-/obj/item/lighter{
-	pixel_x = 6
+/obj/structure/chair/left{
+	dir = 1
 	},
-/turf/open/floor/carpet/black,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/dorms)
 "lqq" = (
 /obj/machinery/vending/sovietsoda,
@@ -25880,14 +26653,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "lqF" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Armory";
-	req_access_txt = "120"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
 	},
 /area/f13/brotherhood/operations)
 "lqZ" = (
@@ -26052,6 +26821,14 @@
 /obj/machinery/telecomms/server/presets/ranger,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/f13/tcoms)
+"lvA" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "lvJ" = (
 /obj/structure/disposalpipe/broken{
 	dir = 1
@@ -26082,6 +26859,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
+"lwl" = (
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS");
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/leisure)
 "lwr" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
@@ -26263,6 +27051,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"lAw" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/medi_wardrobe/free,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
+	},
+/area/f13/brotherhood/operating)
 "lAD" = (
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/caves)
@@ -26307,13 +27107,9 @@
 	},
 /area/f13/bunker/bighornbunker)
 "lAQ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/glass,
-/obj/item/scrap/research,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/brotherhood/rnd)
 "lAY" = (
 /obj/structure/timeddoor,
@@ -26420,28 +27216,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bighornbunker)
 "lCH" = (
-/obj/structure/table{
-	layer = 2.9
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
 	},
-/obj/item/clothing/under/rank/medical/green,
-/obj/item/clothing/under/rank/medical/purple,
-/obj/item/clothing/under/rank/medical/blue,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -9
-	},
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
-	},
-/area/f13/brotherhood/operating)
+/area/f13/brotherhood/operations)
 "lCK" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -26561,10 +27339,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/vault/science)
 "lFO" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt{
-	color = "000000"
+	color = "#363636"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#c1ac99";
 	icon_state = "floorrustysolid"
@@ -26624,14 +27402,14 @@
 	},
 /area/f13/bunker)
 "lHj" = (
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 8
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operating)
+/area/f13/brotherhood/operations)
 "lHB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -26643,10 +27421,9 @@
 	},
 /area/f13/bunker/bunkerfive)
 "lHD" = (
-/obj/structure/table/wood,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "lHY" = (
 /obj/structure/wreck/trash/machinepile,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26872,6 +27649,15 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"lNm" = (
+/obj/effect/decal/marking,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = -14;
+	pixel_x = -12
+	},
+/obj/item/wrench,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "lNr" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -26893,17 +27679,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
 "lNB" = (
-/obj/structure/rack/large/shelf,
-/obj/item/storage/belt/utility/full/engi,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/sheet/mineral/wood/twenty,
+/obj/item/stack/sheet/leather/five,
+/obj/item/blacksmith/woodrod,
+/obj/item/blacksmith/woodrod,
+/obj/item/reagent_containers/glass/beaker/large,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood/reactor)
 "lND" = (
-/obj/structure/table/glass,
-/obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/f13/brotherhood/operating)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/brotherhood/rnd)
 "lNL" = (
 /obj/structure/wreck/car/bike{
 	dir = 5;
@@ -26963,9 +27753,10 @@
 	},
 /area/ruin/powered)
 "lPN" = (
-/obj/structure/chair/stool/retro/black,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "lQc" = (
@@ -27156,6 +27947,15 @@
 	},
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/diner)
+"lTj" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "lTl" = (
 /obj/machinery/light{
 	dir = 8
@@ -27166,12 +27966,11 @@
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
 "lTn" = (
-/obj/structure/table/glass,
-/obj/item/stack/f13Cash/caps/twofive,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/sign/departments/medbay/alt{
+	name = "TRIAGE"
 	},
-/area/f13/brotherhood/operations)
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/chemistry)
 "lTI" = (
 /obj/item/am_containment{
 	pixel_x = 3
@@ -27198,13 +27997,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/brotherhood/reactor)
 "lTM" = (
-/obj/machinery/power/apc/auto_name/east,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
+/obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/mining)
 "lTW" = (
@@ -27226,6 +28019,7 @@
 /obj/structure/lattice{
 	layer = 3
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "lUl" = (
@@ -27244,16 +28038,10 @@
 /area/f13/vault)
 "lUx" = (
 /obj/effect/decal/cleanable/dirt{
-	color = "000000"
+	color = "#363636"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 1
 	},
 /area/f13/brotherhood/operations)
 "lUG" = (
@@ -27298,6 +28086,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"lWo" = (
+/obj/structure/wreck/trash/brokenvendor{
+	name = "collapsed machinery";
+	desc = "Corroded and collapsed machines, now unidentifiable.";
+	pixel_y = 5
+	},
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "lWv" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -27405,11 +28201,19 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
 "lYb" = (
-/obj/structure/rack/large/shelf_rust,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/blood{
+	icon_state = "drip1";
+	pixel_x = 6;
+	pixel_y = 6
 	},
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/f13/caves)
+"lYi" = (
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 1
+	},
+/area/f13/brotherhood/chemistry)
 "lYo" = (
 /obj/effect/gibspawner/robot,
 /obj/structure/fluff/railing{
@@ -27433,9 +28237,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/vault/medical/breakroom)
 "lYY" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/chemistry)
+/obj/effect/decal/cleanable/robot_debris/down,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood/operations)
 "lZc" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/dirt{
@@ -27454,7 +28258,8 @@
 /area/f13/sewer/powered)
 "lZy" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/landmark/start/f13/scribe,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "lZJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -27506,10 +28311,13 @@
 /turf/open/floor/f13/wood,
 /area/f13/vault/dormitory)
 "maM" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/security/bos,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/armory)
+/obj/structure/sign/stop{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "maO" = (
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/indestructible/ground/inside/subway,
@@ -27620,13 +28428,18 @@
 /turf/open/floor/f13,
 /area/f13/bunker)
 "mda" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "twindowold"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/toilet{
+	pixel_y = 10
 	},
-/area/f13/brotherhood/operations)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/f13{
+	icon_state = "redmark"
+	},
+/area/f13/brotherhood/dorms)
 "mdd" = (
 /obj/structure/rack/shelf_metal{
 	dir = 4
@@ -27687,6 +28500,19 @@
 	dir = 9
 	},
 /area/ruin/powered)
+"meR" = (
+/obj/effect/decal/remains/human{
+	pixel_x = 3;
+	pixel_y = -10
+	},
+/obj/item/card/id/rusted/brokenholodog{
+	desc = "A set of Brotherhood-issue holotags, damaged beyond recognition.";
+	pixel_x = 3
+	},
+/obj/effect/spawner/lootdrop/high_tools,
+/obj/item/storage/belt/utility/full/engi,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "mfh" = (
 /obj/machinery/light/small,
 /turf/open/floor/f13{
@@ -27787,10 +28613,7 @@
 	pixel_y = 17
 	},
 /obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/plastic/twenty,
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 1
 	},
@@ -27975,12 +28798,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
 /area/f13/enclave)
 "mnr" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/carpet/blue,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/dark/corner,
+/area/f13/brotherhood/rnd)
 "mnA" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
 /turf/open/indestructible/ground/inside/mountain,
@@ -27992,13 +28811,6 @@
 "moa" = (
 /obj/structure/table{
 	layer = 2.9
-	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/surgical_drapes,
-/obj/item/stack/sticky_tape/surgical{
-	pixel_x = -11;
-	pixel_y = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -28067,6 +28879,11 @@
 /obj/effect/landmark/start/f13/vaultsecurityofficer,
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security)
+"mpM" = (
+/obj/machinery/hydroponics/constructable,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel/f13/vault_floor/green/greenchess,
+/area/f13/brotherhood/rnd)
 "mpO" = (
 /obj/structure/barricade/concrete,
 /turf/open/floor/f13{
@@ -28074,11 +28891,7 @@
 	},
 /area/f13/sewer/powered)
 "mpS" = (
-/obj/structure/rack/shelf_metal{
-	pixel_y = -12
-	},
-/obj/item/storage/belt/utility/full,
-/obj/item/storage/belt/utility/full,
+/obj/structure/rack/shelf_metal,
 /obj/item/storage/belt/utility/full,
 /obj/item/screwdriver/power,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -28098,12 +28911,14 @@
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/security)
 "mqC" = (
-/obj/structure/table/reinforced,
-/obj/item/crafting/abraxo,
+/obj/structure/table/optable,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/chemistry)
 "mqE" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2";
@@ -28194,11 +29009,26 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "msR" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal";
+	pixel_y = -16
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
+"msW" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/closet/crate/large,
+/obj/item/stack/sheet/mineral/wood/twenty,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "mti" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/lattice{
@@ -28418,6 +29248,21 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/bunker/bunkerthree)
+"mwP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/box/corners{
+	dir = 8
+	},
+/obj/effect/turf_decal/arrows{
+	dir = 4;
+	pixel_y = -12;
+	pixel_x = -5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "mwS" = (
 /obj/structure/chair/comfy{
 	dir = 1
@@ -28447,6 +29292,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
+"mxz" = (
+/obj/structure/table/wood/poker,
+/obj/item/blacksmith/woodrod{
+	pixel_x = 4;
+	name = "pool cue";
+	desc = "It's a rod, suitable for use at a pool table. Also could serve as a weapon, in a pinch."
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/leisure)
 "mxV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kitchen/knife/butcher,
@@ -28557,14 +29412,8 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/sewer)
 "mAe" = (
-/obj/structure/table/glass,
-/obj/item/kirbyplants/photosynthetic,
-/obj/structure/decoration/smokeold{
-	pixel_y = -31
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "mAf" = (
 /obj/machinery/light{
@@ -28787,6 +29636,18 @@
 	},
 /turf/open/floor/f13,
 /area/f13/bunker)
+"mDe" = (
+/obj/machinery/door/poddoor/preopen{
+	id = bos_mine_blast;
+	name = "Brotherhood blast door"
+	},
+/obj/effect/turf_decal,
+/obj/effect/turf_decal/caution/stand_clear/white,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/mining)
 "mDf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small{
@@ -28870,10 +29731,15 @@
 	},
 /area/f13/building/abandoned/o)
 "mEc" = (
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS");
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 1
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "mEe" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/nest/assaultron,
@@ -28910,6 +29776,13 @@
 	icon_state = "engine"
 	},
 /area/ruin/powered)
+"mFl" = (
+/obj/effect/decal/cleanable/robot_debris/down{
+	pixel_y = -5
+	},
+/obj/structure/wreck/trash/machinepile,
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "mFw" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade/guardian,
@@ -29041,8 +29914,8 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
 "mJs" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood_common,
+/obj/structure/chair/right,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "mJw" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -29229,27 +30102,26 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
 "mND" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/folding{
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/caves)
 "mNG" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/elitemutant,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
 "mNI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/decoration/vent/rusty,
+/obj/machinery/shower{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/shelf_wood,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/effect/turf_decal/box,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 9
+	},
 /area/f13/brotherhood/rnd)
 "mNJ" = (
 /obj/structure/lattice,
@@ -29273,6 +30145,27 @@
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
+"mOL" = (
+/obj/item/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/dorms)
+"mON" = (
+/obj/effect/turf_decal/arrows{
+	dir = 1;
+	pixel_x = 11
+	},
+/obj/effect/decal/marking{
+	pixel_x = -16
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "mOR" = (
 /obj/structure/barricade/train{
 	dir = 1
@@ -29344,11 +30237,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/vault/science)
 "mQP" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/area/f13/brotherhood/operating)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass/corner{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "mRe" = (
 /turf/open/floor/plating/dirt/dark,
 /area/f13/bunker/bunkereight)
@@ -29359,10 +30255,15 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
 "mRs" = (
-/obj/structure/chair/folding,
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating/rust,
-/area/f13/brotherhood/armory)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/bos{
+	circuit = /obj/item/circuitboard/computer/security;
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "mRM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -29381,13 +30282,10 @@
 	},
 /area/f13/bunker/bunkerfive)
 "mRZ" = (
-/obj/machinery/vending/hydronutrients{
-	force_free = 1
-	},
-/turf/open/floor/plasteel/f13/vault_floor/green/side{
-	dir = 4
-	},
-/area/f13/brotherhood/operations)
+/obj/machinery/computer/arcade/orion_trail,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
+/area/f13/brotherhood/leisure)
 "mSl" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks,
@@ -29520,8 +30418,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/powered)
 "mVt" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/vg_decals/numbers/zero,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/dorms)
 "mVx" = (
 /obj/structure/table/wood/settler,
@@ -29682,11 +30585,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bighornbunker)
 "mYd" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 4
 	},
-/area/f13/brotherhood/armory)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/radioterminal/bos,
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "mYm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -29800,16 +30706,12 @@
 /turf/open/floor/f13,
 /area/f13/vault)
 "nbm" = (
-/obj/structure/curtain,
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/structure/lattice{
+	layer = 3
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 1
-	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "nbp" = (
 /obj/structure/closet/locker/oldstyle,
 /obj/item/shield/riot,
@@ -29828,17 +30730,9 @@
 	},
 /area/f13/bunker/bunkersix)
 "nbK" = (
-/obj/structure/rack/shelf_metal{
-	pixel_y = -12
-	},
-/obj/item/pickaxe/drill{
-	pixel_y = 3
-	},
-/obj/item/storage/bag/ore,
-/obj/item/storage/bag/ore,
-/obj/item/clothing/glasses/meson,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
+/area/f13/brotherhood/reactor)
 "nbW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -29895,8 +30789,10 @@
 /turf/open/floor/f13,
 /area/f13/bunker)
 "ncX" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/green,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/f13,
 /area/f13/brotherhood/dorms)
 "ndd" = (
 /mob/living/simple_animal/hostile/handy/gutsy/nsb,
@@ -30061,8 +30957,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/brotherhood/reactor)
 "nhg" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/item/book/manual/nuka_recipes,
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/book/manual/wiki/engineering_singulo_tesla,
+/obj/structure/bookcase/manuals,
+/turf/open/floor/wood_fancy,
 /area/f13/brotherhood/rnd)
 "nhp" = (
 /turf/closed/indestructible/opshuttle{
@@ -30274,10 +31173,10 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/armory)
 "nlz" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/table/glass,
-/obj/item/blueprint/research,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/item/scrap/research,
+/obj/item/scrap/research,
+/turf/open/floor/wood_fancy,
 /area/f13/brotherhood/rnd)
 "nlA" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -30287,15 +31186,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
 "nlB" = (
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/structure/closet/crate/medical,
+/obj/item/reagent_containers/hypospray/medipen/stimpak/epipak,
+/obj/item/reagent_containers/blood/radaway,
+/obj/item/reagent_containers/blood/radaway,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
 	},
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operating)
 "nlJ" = (
 /mob/living/simple_animal/hostile/handy/gutsy{
 	faction = list("hostile")
@@ -30382,8 +31283,10 @@
 /area/f13/vault/atrium)
 "nnI" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 5
+	},
+/area/f13/brotherhood/rnd)
 "nnM" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -30416,9 +31319,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker)
 "noV" = (
-/obj/structure/sign/poster/prewar/poster72,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "npd" = (
 /obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/plating/tunnel,
@@ -30445,12 +31353,9 @@
 	},
 /area/f13/sewer)
 "nqA" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 9
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/brotherhood/rnd)
 "nrd" = (
 /obj/effect/decal/cleanable/glass,
@@ -30541,13 +31446,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/sewer)
 "nsx" = (
-/obj/structure/chair/sofa/right{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "nsD" = (
 /mob/living/simple_animal/hostile/handy/robobrain{
 	auto_fire_delay = 2;
@@ -30584,16 +31487,13 @@
 	},
 /area/f13/bunker/bunkerthree)
 "ntq" = (
-/obj/structure/table,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/machinery/recharger{
-	pixel_x = 6
+/obj/machinery/chem_heater,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
 	},
-/obj/machinery/recharger{
-	pixel_x = -6
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/brotherhood/rnd)
 "ntG" = (
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
@@ -30761,21 +31661,11 @@
 	},
 /area/f13/enclave)
 "nwq" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 1
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "nwD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -30960,6 +31850,30 @@
 /obj/item/stack/f13Cash/random/low,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"nAQ" = (
+/obj/effect/turf_decal/weather/dirt{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/obj/structure/sink/puddle,
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/grass/corner{
+	dir = 8
+	},
+/area/f13/brotherhood/rnd)
+"nAY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "nBe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -31063,60 +31977,9 @@
 	},
 /area/f13/enclave)
 "nCC" = (
-/obj/machinery/light/small,
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/clothing/neck/stethoscope{
-	pixel_x = 6;
-	pixel_y = 9
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/item/flashlight/pen{
-	pixel_x = -5;
-	pixel_y = -7
-	},
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operating)
+/obj/effect/landmark/start/f13/seniorscribe,
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "nCU" = (
 /mob/living/simple_animal/hostile/handy/gutsy/nsb,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -31135,10 +31998,12 @@
 	},
 /area/f13/vault/atrium)
 "nDr" = (
-/obj/machinery/seed_extractor,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "nDz" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -31221,15 +32086,14 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "nEO" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 8
-	},
-/area/f13/brotherhood/armory)
+/obj/effect/landmark/start/f13/seniorpaladin,
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "nEV" = (
 /obj/structure/bookcase,
 /obj/structure/decoration/clock{
@@ -31336,6 +32200,23 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
+"nGM" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/reagent_containers/food/snacks/f13/mre{
+	pixel_x = -7
+	},
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = 10;
+	pixel_y = 3
+	},
+/obj/item/reagent_containers/glass/beaker/waterbottle{
+	pixel_x = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 9
+	},
+/area/f13/brotherhood/chemistry)
 "nGT" = (
 /obj/structure/frame/machine{
 	anchored = 1
@@ -31360,16 +32241,18 @@
 /turf/open/water,
 /area/f13/radiation)
 "nHC" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13/brotherhood/operations)
+/obj/machinery/light/floor,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/leisure)
 "nHG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/flasher,
-/obj/machinery/cell_charger{
-	pixel_y = 13
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/armory)
+/obj/effect/landmark/start/f13/sentinel,
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "nHO" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel,
@@ -31408,8 +32291,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "nJe" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/wood_common,
+/obj/machinery/vending/cigarette/syndicate,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "nJv" = (
 /obj/machinery/light{
@@ -31417,6 +32300,13 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
+"nJU" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/brotherhood/leisure)
 "nJW" = (
 /obj/structure/girder,
 /obj/structure/grille/broken,
@@ -31538,14 +32428,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/f13/vault/diner)
 "nNC" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
-	},
+/obj/effect/landmark/start/f13/scribe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
 	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/chemistry)
 "nNL" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/decal/cleanable/greenglow,
@@ -32032,12 +32919,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
 "nYu" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "nYD" = (
 /turf/open/floor/f13{
@@ -32080,6 +32965,20 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"nZz" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/structure/closet/crate/radiation,
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS");
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "nZD" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/floor/f13{
@@ -32088,6 +32987,18 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"nZE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/brotherhood/rnd)
+"nZO" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/brotherhood/rnd)
 "oab" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -32187,9 +33098,19 @@
 	},
 /area/f13/bunker/bunkerthree)
 "ocx" = (
-/obj/item/kirbyplants/random,
+/obj/structure/closet/cabinet{
+	anchored = 1;
+	name = "formal attire cabinet"
+	},
+/obj/item/clothing/under/f13/bosformgold_f,
+/obj/item/clothing/under/f13/bosformgold_m,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/neck/mantle/bos/paladin,
+/obj/item/clothing/neck/mantle/bos/left,
+/obj/item/clothing/neck/mantle/bos/right,
+/obj/item/clothing/neck/mantle/commander,
 /turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/dorms)
 "ocG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/reagent_containers/blood/radaway{
@@ -32208,18 +33129,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/dormitory)
 "odh" = (
-/obj/structure/rack/large/shelf,
-/obj/item/assembly/timer,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/furnace,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "odp" = (
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
-	},
-/obj/structure/curtain{
-	color = "#845f58"
-	},
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operating)
@@ -32250,7 +33163,7 @@
 	icon_state = "mattress5"
 	},
 /turf/open/floor/plating/rust,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "oef" = (
 /obj/structure/lattice,
 /obj/effect/gibspawner/human,
@@ -32287,6 +33200,12 @@
 /obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/holofloor/plating,
 /area/f13/brotherhood/armory)
+"oeL" = (
+/obj/machinery/light/floor,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/brotherhood/operations)
 "oeM" = (
 /obj/structure/wreck/trash/autoshaft{
 	pixel_x = 17
@@ -32323,13 +33242,13 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "ofG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair";
+	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/plasteel/dark,
 /area/f13/brotherhood/rnd)
 "ofN" = (
 /obj/machinery/door/locked/regular/maybe_trapped,
@@ -32424,6 +33343,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/enclave)
+"oho" = (
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 1
+	},
+/area/f13/brotherhood/operating)
 "ohp" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/f13{
@@ -32438,6 +33362,13 @@
 "ohv" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ohA" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 10
+	},
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
+/area/f13/brotherhood/dorms)
 "ohB" = (
 /mob/living/simple_animal/hostile/handy,
 /turf/open/water,
@@ -32472,9 +33403,8 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
 "ois" = (
-/obj/structure/sign/departments/examroom,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
+/area/f13/brotherhood/operating)
 "oiE" = (
 /obj/structure/table,
 /obj/item/trash/f13/c_ration_3,
@@ -32533,6 +33463,11 @@
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"ojR" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/hydroponics/constructable,
+/turf/open/floor/plasteel/f13/vault_floor/green/corner,
+/area/f13/brotherhood/rnd)
 "ojV" = (
 /obj/item/shard,
 /mob/living/simple_animal/hostile/securitron/sentrybot{
@@ -32553,6 +33488,20 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"okC" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "okU" = (
 /obj/structure/wreck/trash/five_tires,
 /turf/open/indestructible/ground/inside/subway,
@@ -32590,6 +33539,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerfive)
+"olX" = (
+/obj/effect/landmark/start/f13/seniorknight,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/brotherhood/operations)
 "oma" = (
 /obj/structure/barricade/wooden/crude,
 /obj/structure/decoration/rag{
@@ -32625,6 +33580,18 @@
 	},
 /turf/open/floor/f13,
 /area/f13/vault)
+"omD" = (
+/obj/structure/wreck/trash/autoshaft{
+	name = "belt shaft";
+	desc = "A stripped conveyor assembly. Totally useless."
+	},
+/obj/structure/wreck/trash/autoshaft{
+	name = "belt shaft";
+	desc = "A stripped conveyor assembly. Totally useless.";
+	pixel_x = 16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "omJ" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/cleanable/dirt,
@@ -32641,8 +33608,8 @@
 	},
 /area/f13/bunker/bunkerthree)
 "omW" = (
-/obj/machinery/autolathe,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "onv" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier4,
@@ -32660,10 +33627,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/overseer)
 "onR" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lantern,
-/turf/open/floor/plating/rust,
-/area/f13/brotherhood/armory)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/grass/corner{
+	dir = 1
+	},
+/area/f13/brotherhood/rnd)
 "oon" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
@@ -33035,11 +34005,9 @@
 /turf/open/floor/plasteel/airless/floorgrime,
 /area/f13/bunker/bunkerfive)
 "ouH" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
+/obj/machinery/rnd/production/circuit_imprinter,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood/rnd)
 "ouS" = (
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/building/abandoned/o)
@@ -33311,6 +34279,11 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"oBS" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/dorms)
 "oBV" = (
 /obj/machinery/computer/turret_controller{
 	dir = 8;
@@ -33354,20 +34327,15 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
 "oCL" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/ruins,
 /area/f13/brotherhood/operations)
 "oCO" = (
-/obj/structure/rack/shelf_metal,
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -16
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/item/book/granter/crafting_recipe/blueprint/fh_46/bos,
+/obj/item/book/manual/wiki/detective,
+/obj/item/book/manual/nuclear,
+/obj/structure/bookcase/manuals,
+/turf/open/floor/wood_fancy,
 /area/f13/brotherhood/rnd)
 "oCS" = (
 /obj/structure/disposalpipe/segment,
@@ -33603,6 +34571,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
+"oIg" = (
+/obj/structure/wreck/trash/brokenvendor{
+	name = "collapsed machinery";
+	desc = "Corroded and collapsed machines, now unidentifiable.";
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "oIz" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
@@ -33640,6 +34616,15 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
+"oJx" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood/armory)
 "oJX" = (
 /mob/living/simple_animal/hostile/rat,
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -33654,11 +34639,14 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/dormitory)
 "oKj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/fence{
+	dir = 1;
+	icon_state = "straight"
 	},
-/area/f13/brotherhood/chemistry)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "oKs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
@@ -33725,6 +34713,10 @@
 /obj/item/ammo_box/magazine/autopipe,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"oLF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_worn/wood_worn_dark,
+/area/f13/brotherhood/dorms)
 "oLJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/brokenvendor,
@@ -33801,17 +34793,16 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
 "oNz" = (
-/obj/structure/curtain,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
+	},
+/obj/structure/mirror{
+	pixel_x = 30
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
-/area/f13/brotherhood/operating)
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/dorms)
 "oNB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
@@ -34082,6 +35073,28 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/brotherhood/reactor)
+"oTp" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/turf_decal/loading_area,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/operations)
+"oTE" = (
+/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken2"
+	},
+/area/f13/brotherhood/operations)
 "oTG" = (
 /obj/structure/wreck/trash/five_tires{
 	pixel_y = 11
@@ -34203,11 +35216,19 @@
 	},
 /area/ruin/powered)
 "oVS" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/effect/overlay/junk/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/turf/open/floor/plating/rust,
-/area/f13/brotherhood/armory)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/overlay/junk/mirror{
+	pixel_x = 30
+	},
+/obj/item/melee/onehanded/knife/cosmicdirty,
+/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/operations)
 "oWa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/lattice,
@@ -34281,6 +35302,10 @@
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
+"oYk" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "oYH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -34333,18 +35358,15 @@
 	name = "Security Checkpoint";
 	req_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
-	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "pag" = (
-/obj/structure/table{
-	layer = 2.9
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/obj/effect/spawner/lootdrop/f13/doctorbag,
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS")
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "bcircuit1";
 	light_color = "#0076bc";
@@ -34445,9 +35467,15 @@
 	},
 /area/f13/enclave)
 "pbF" = (
-/obj/structure/sign/poster/contraband/power,
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/chemistry)
+/obj/structure/lattice{
+	layer = 3
+	},
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS")
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "pbI" = (
 /obj/structure/barricade/sandbags,
 /obj/structure/table/wood,
@@ -34466,7 +35494,10 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
 "pcg" = (
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 9
+	},
 /area/f13/brotherhood/rnd)
 "pcq" = (
 /turf/open/indestructible/ground/inside/subway,
@@ -34487,11 +35518,8 @@
 /turf/open/floor/plasteel/cult,
 /area/f13/brotherhood/operations)
 "pcL" = (
-/obj/structure/chair/f13chair1{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood/operations)
 "pdc" = (
 /mob/living/simple_animal/hostile/giantantqueen,
@@ -34623,6 +35651,12 @@
 /obj/item/reagent_containers/glass/beaker/glass_dish,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/white,
 /area/f13/vault/medical/chemistry)
+"phb" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "phl" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/barricade/concrete,
@@ -34636,11 +35670,13 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "phC" = (
-/obj/machinery/biogenerator,
-/turf/open/floor/plasteel/f13/vault_floor/green/side{
-	dir = 4
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/structure/simple_door/bunker/glass{
+	req_access_txt = "120";
+	req_one_access_txt = "120"
 	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plating/f13/inside,
+/area/f13/brotherhood/rnd)
 "phE" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -34732,9 +35768,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
 "pkh" = (
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
+	dir = 8
 	},
 /area/f13/brotherhood/operations)
 "pkm" = (
@@ -34780,6 +35816,28 @@
 "plQ" = (
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"plV" = (
+/obj/structure/noticeboard{
+	name = "display plate";
+	pixel_x = 16;
+	pixel_y = 34
+	},
+/obj/item/gun/energy/pulse{
+	anchored = 1;
+	cell_type = null;
+	desc = "A heavy-duty, multifaceted energy rifle with three modes. Preferred by front-line combat personnel. This one is for display, and no longer fires.";
+	name = "display pulse rifle";
+	pin = null;
+	pixel_x = 16;
+	pixel_y = 29
+	},
+/mob/living/simple_animal/pet/dog/pug{
+	name = "\improper Elder Barkson";
+	desc = "You put some respect into those pets."
+	},
+/obj/structure/bed/dogbed,
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "plY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -34834,10 +35892,11 @@
 /area/f13/building/abandoned/o)
 "pmS" = (
 /obj/effect/decal/cleanable/dirt{
-	color = "000000"
+	color = "#363636"
 	},
-/obj/structure/closet/crate/engineering,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/rnd)
 "pnk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34888,9 +35947,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker/bunkerthree)
 "pop" = (
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 4
-	},
+/turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/brotherhood/operating)
 "poF" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -34979,6 +36036,14 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds/drug,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/sewer)
+"ppT" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood/armory)
 "ppU" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -35022,8 +36087,9 @@
 /turf/closed/wall/rust,
 /area/f13/followers)
 "pqN" = (
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/armory)
+/obj/machinery/rnd/production/protolathe,
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/brotherhood/rnd)
 "prq" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -35130,10 +36196,13 @@
 /turf/open/floor/f13,
 /area/f13/bunker)
 "puc" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /obj/machinery/power/apc/auto_name/north,
+/obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/carpet/black,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/dorms)
 "puh" = (
 /obj/effect/decal/cleanable/generic,
@@ -35169,7 +36238,7 @@
 	default_price = 0;
 	extra_price = 0
 	},
-/turf/open/floor/carpet/purple,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
 "puF" = (
 /obj/structure/barricade/concrete,
@@ -35311,9 +36380,8 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/tunnel)
 "pxz" = (
-/obj/structure/sign/departments/holy,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/closed/wall/r_wall,
+/obj/structure/debris/v2,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "pxD" = (
 /obj/effect/decal/waste,
@@ -35507,6 +36575,14 @@
 /obj/structure/spacevine,
 /turf/open/water,
 /area/f13/sewer)
+"pBR" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/security/bos,
+/obj/effect/turf_decal/stripes/white/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side,
+/area/f13/brotherhood/chemistry)
 "pCd" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -35559,6 +36635,16 @@
 "pCR" = (
 /turf/closed/wall/r_wall,
 /area/f13/sewer/powered)
+"pDh" = (
+/obj/structure/barricade/sandbags,
+/obj/machinery/door/poddoor/shutters/old{
+	id = "bos_front_turret";
+	name = "security shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "pDi" = (
 /obj/structure/table/abductor,
 /obj/item/stack/sheet/metal/fifty,
@@ -35611,15 +36697,10 @@
 /turf/closed/wall/f13/wood,
 /area/f13/sewer/powered)
 "pEl" = (
-/obj/structure/curtain,
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner,
 /area/f13/brotherhood/operating)
 "pEp" = (
 /obj/structure/destructible/tribal_torch/wall,
@@ -35737,8 +36818,16 @@
 /area/f13/building/firestation)
 "pGu" = (
 /obj/structure/sign/departments/engineering,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/reactor)
+"pGC" = (
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/leisure)
 "pGI" = (
 /obj/effect/landmark/start/f13/vaultscientist,
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
@@ -35837,8 +36926,10 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/table/wood,
-/turf/open/floor/wood_common,
+/obj/structure/chair/right{
+	dir = 1
+	},
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "pIl" = (
 /obj/structure/timeddoor,
@@ -35848,8 +36939,8 @@
 /turf/closed/wall/r_wall,
 /area/f13/sewer/powered)
 "pIq" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
 "pIB" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35950,17 +37041,23 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
+"pLZ" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood/operations)
 "pMe" = (
 /obj/structure/table,
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe/drill{
-	pixel_y = 3
-	},
-/obj/item/storage/bag/ore,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/purple/side,
-/area/f13/brotherhood/rnd)
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/obj/item/reagent_containers/food/snacks/f13/mre,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "pMg" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -36003,13 +37100,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "pNK" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS");
+	dir = 10
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/structure/table/glass,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/wood_fancy,
 /area/f13/brotherhood/rnd)
 "pNN" = (
 /obj/structure/sign/poster/official/the_owl,
@@ -36092,13 +37189,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
 "pPd" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 9
+	dir = 1
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "pPm" = (
 /turf/open/floor/plating/rust,
 /area/f13/caves)
@@ -36385,6 +37481,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/sewer/powered)
+"pTH" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
+/area/f13/brotherhood/dorms)
 "pTM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -36424,15 +37527,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "pUN" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
 	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -15
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/operations)
 "pVl" = (
 /obj/structure/closet/crate{
 	anchored = 1
@@ -36495,9 +37594,13 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "pWD" = (
+/obj/structure/railing{
+	dir = 6
+	},
+/obj/item/clothing/gloves/boxing/blue,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/turf/open/floor/padded,
+/area/f13/brotherhood/leisure)
 "pWF" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -36511,9 +37614,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/enclave)
 "pWN" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/structure/curtain{
+	color = "#5c131b"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/dorms)
 "pWT" = (
 /obj/structure/cargocrate,
 /turf/open/indestructible/ground/inside/subway,
@@ -36723,9 +37829,10 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/sewer/powered)
 "qaR" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/obj/structure/lattice/catwalk,
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/dorms)
 "qaU" = (
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/mountain,
@@ -36738,7 +37845,8 @@
 /obj/machinery/light{
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "qbe" = (
 /obj/structure/lattice,
@@ -36821,6 +37929,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"qch" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/obj/machinery/jukebox,
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
+/area/f13/brotherhood/leisure)
 "qcv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -36876,14 +37992,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
 "qdV" = (
-/obj/structure/curtain,
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
+/obj/structure/ladder/unbreakable{
+	level = 1;
+	id = "town_lair";
+	height = 1
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/darkgreen,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plating/tunnel,
+/area/f13/caves)
 "qej" = (
 /obj/structure/wreck/trash/five_tires{
 	pixel_y = 14
@@ -36943,8 +38058,10 @@
 /area/ruin/powered)
 "qeP" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/f13/vault_floor/green/white,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "qeZ" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/cigarettes/cigars/havana,
@@ -37054,9 +38171,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
 "qfW" = (
-/obj/structure/sign/departments/medbay/alt,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "qgb" = (
 /mob/living/simple_animal/hostile/raider/ranged/junker/scavver,
 /turf/open/floor/f13,
@@ -37075,13 +38193,18 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
 "qgp" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
+/obj/structure/car/rubbish3{
+	icon_state = "car_rubish2";
+	name = "abandoned fixer-upper";
+	pixel_x = 3;
+	desc = "A rusty pre-War automobile carcass.<br>Someone evidently thought they could fix it, but gave up partway through."
 	},
-/obj/effect/landmark/start/f13/Knight,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/item/storage/trash_stack{
+	icon_state = "trash_2";
+	pixel_x = -3;
+	pixel_y = 1
 	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
 "qgz" = (
 /obj/structure/wreck/trash/machinepile,
@@ -37161,13 +38284,18 @@
 	},
 /area/f13/sewer/powered)
 "qiD" = (
-/obj/structure/chair/sofa{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/item/storage/box/beakers{
+	pixel_y = 12
+	},
+/obj/item/storage/pill_bottle/chem_tin/radx{
+	pixel_y = 6;
+	pixel_x = 6
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/chemistry)
 "qiF" = (
 /obj/structure/flora/grass/jungle/b,
 /turf/open/water,
@@ -37254,10 +38382,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/enclave)
 "qkl" = (
-/obj/machinery/hydroponics/constructable,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/structure/table/glass,
+/obj/item/storage/box/disks_plantgene,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "qkm" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
@@ -37302,9 +38431,8 @@
 	},
 /area/f13/bunker)
 "qlm" = (
-/obj/item/stack/ore/blackpowder/five,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood/reactor)
 "qlx" = (
 /obj/machinery/smartfridge/bottlerack/lootshelf/construction,
@@ -37462,29 +38590,14 @@
 	},
 /area/f13/bunker/bunkerfive)
 "qoc" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/table/glass,
+/obj/item/reagent_containers/blood/radaway{
+	pixel_x = 8;
+	pixel_y = 8
 	},
-/obj/structure/closet/anchored,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/under/f13/bosformgold_m,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_f,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/under/f13/bosformsilver_m,
-/obj/item/clothing/neck/mantle/bos/left,
-/obj/item/clothing/neck/mantle/bos/right,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/gloves/color/white/bos,
-/obj/item/clothing/neck/mantle/bos/paladin,
-/obj/item/clothing/neck/mantle/bos/paladin,
-/obj/item/clothing/neck/mantle/bos/paladin,
-/turf/open/floor/plasteel/cult,
-/area/f13/brotherhood/operations)
+/obj/item/reagent_containers/food/drinks/coffee,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/operating)
 "qoq" = (
 /obj/item/clothing/head/cone{
 	pixel_x = 4;
@@ -37573,18 +38686,21 @@
 /turf/open/floor/plasteel/f13/vault_floor/green,
 /area/f13/vault/garden)
 "qpN" = (
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/area/f13/brotherhood/operating)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/brotherhood/rnd)
 "qpS" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 1
-	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/brotherhood/reactor)
 "qqL" = (
 /obj/machinery/light{
 	bulb_colour = "#BC8F8F";
@@ -37645,6 +38761,22 @@
 /obj/machinery/jukebox,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
+"qrK" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	icon_state = "twindowold"
+	},
+/obj/structure/decoration/vent/rusty,
+/obj/structure/curtain{
+	color = "#845f58"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/overlay/junk/shower{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/f13/brotherhood/operations)
 "qrU" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/dormitory)
@@ -37796,14 +38928,11 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
 "quG" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 9
-	},
-/area/f13/brotherhood/operating)
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/leisure)
 "quJ" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plating/rust,
@@ -38019,9 +39148,9 @@
 	},
 /area/ruin/powered)
 "qyz" = (
-/obj/structure/table/wood,
 /obj/machinery/vending/boozeomat,
-/turf/open/floor/carpet/black,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
 "qyN" = (
 /obj/structure/table,
@@ -38220,10 +39349,10 @@
 	},
 /area/ruin/powered)
 "qCp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/brotherhood/rnd)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks,
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "qCz" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 4
@@ -38248,8 +39377,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "qDb" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/chemistry)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "qDk" = (
 /obj/structure/chair/stool,
 /mob/living/simple_animal/hostile/raider/tribal,
@@ -38357,12 +39494,10 @@
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerfive)
 "qFn" = (
-/obj/machinery/suit_storage_unit/mining,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 10
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/area/f13/brotherhood/rnd)
 "qFt" = (
 /obj/effect/mob_spawn/human/corpse/charredskeleton,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
@@ -38525,10 +39660,12 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "qIa" = (
-/obj/structure/shelf_wood,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
+/obj/structure/lattice/catwalk,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "qIe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -38620,11 +39757,10 @@
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker/bighornbunker)
 "qKa" = (
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "qKo" = (
 /obj/item/gun/ballistic/automatic/pistol/n99,
 /turf/open/indestructible/ground/inside/mountain,
@@ -38796,9 +39932,6 @@
 	},
 /area/f13/sewer/powered)
 "qNy" = (
-/obj/machinery/computer/operating/bos{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -38893,15 +40026,6 @@
 /obj/item/stock_parts/cell/ammo/mfc,
 /obj/item/stock_parts/cell/ammo/mfc,
 /obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/mfc,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
-/obj/item/stock_parts/cell/ammo/ec,
 /obj/item/stock_parts/cell/ammo/ec,
 /obj/item/stock_parts/cell/ammo/ec,
 /obj/item/stock_parts/cell/ammo/ec,
@@ -39040,12 +40164,11 @@
 /turf/open/floor/f13/wood,
 /area/f13/caves)
 "qSn" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/structure/lattice/catwalk,
+/obj/structure/simple_door/metal/ventilation,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/rnd)
 "qSr" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/plasteel/dark,
@@ -39069,12 +40192,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/enclave)
-"qSM" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "120"
+"qSB" = (
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS");
+	dir = 4
 	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood/armory)
+"qSM" = (
+/obj/machinery/power/apc/auto_name/north,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/landmark/start/f13/elder,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/wood_common,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
 "qSP" = (
 /obj/structure/closet/fridge/cannibal,
@@ -39165,6 +40298,21 @@
 "qVl" = (
 /turf/closed/wall/rust,
 /area/f13/bunker/bighornbunker)
+"qVn" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/whiskey{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/dorms)
 "qVw" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/weapon_parts,
@@ -39174,10 +40322,10 @@
 	},
 /area/f13/brotherhood/armory)
 "qVD" = (
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 9
 	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
 /area/f13/brotherhood/reactor)
 "qVE" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39366,14 +40514,11 @@
 	},
 /area/f13/building/abandoned/o)
 "qZz" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/effect/spawner/lootdrop/f13/advcrafting,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#e8eaff"
+/obj/structure/sign/poster/contraband/power{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "qZJ" = (
 /obj/structure/chair/f13chair2{
@@ -39390,22 +40535,18 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bighornbunker)
 "qZW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/pda{
-	icon_state = "pda-hos";
-	name = "Head Scribe's PipBoy"
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger{
+	pixel_y = 13
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/item/reagent_containers/food/drinks/coffee{
+	pixel_y = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/brotherhood/rnd)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 6
+	},
+/area/f13/brotherhood/chemistry)
 "ran" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal/ten,
@@ -39500,11 +40641,12 @@
 /turf/open/water,
 /area/f13/caves)
 "rcU" = (
-/obj/item/book/manual/nuka_recipes,
-/obj/item/book/manual/wiki/engineering_construction,
-/obj/item/book/manual/wiki/engineering_singulo_tesla,
-/obj/structure/bookcase/manuals,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/machinery/mech_bay_recharge_port{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
 /area/f13/brotherhood/rnd)
 "rcV" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
@@ -39541,16 +40683,25 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"rdL" = (
+/obj/structure/table/glass,
+/obj/machinery/plantgenes/seedvault{
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green/side,
+/area/f13/brotherhood/rnd)
 "ree" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/side{
 	dir = 5
 	},
 /area/ruin/powered)
 "rej" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/effect/turf_decal/loading_area/white{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "rex" = (
 /obj/structure/table,
 /turf/open/floor/f13{
@@ -39586,6 +40737,12 @@
 	dir = 8
 	},
 /area/f13/radiation)
+"rfv" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/leisure)
 "rfJ" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -39593,11 +40750,11 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "rfL" = (
-/obj/structure/chair/wood/wings{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "rfM" = (
 /obj/machinery/porta_turret/f13/turret_556/hostile,
 /turf/open/floor/plasteel/f13/vault_floor/red/corner{
@@ -39615,6 +40772,15 @@
 /obj/item/paper/secretrecipe,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"rfV" = (
+/obj/structure/table/reinforced,
+/obj/item/roller{
+	pixel_y = 12
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "rgb" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -39638,11 +40804,8 @@
 	},
 /area/f13/brotherhood/armory)
 "rgg" = (
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "rgt" = (
 /obj/machinery/door/airlock/silver{
@@ -39784,6 +40947,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"rjS" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/whiteyellowfull,
+/area/f13/brotherhood/reactor)
 "rkk" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_3"
@@ -40068,16 +41238,19 @@
 	},
 /area/f13/bunker/bunkerseven)
 "rpM" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
+/obj/structure/sign/directions/dorms{
+	pixel_x = -32;
+	pixel_y = 5
 	},
-/area/f13/brotherhood/leisure)
+/obj/structure/sign/directions/evac{
+	pixel_y = -5;
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "rqd" = (
 /obj/structure/spider/stickyweb,
 /obj/structure/disposalpipe/segment{
@@ -40101,6 +41274,12 @@
 /obj/machinery/door/airlock/vault,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"rqM" = (
+/obj/structure/table,
+/obj/item/advanced_crafting_components/p_circuits,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "rqQ" = (
 /obj/item/trash/f13/rotten{
 	pixel_x = 4;
@@ -40222,15 +41401,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
 "rsO" = (
-/obj/structure/barricade/bars,
 /obj/machinery/camera/autoname{
-	name = "Secuirty Camera";
+	name = "Security Camera";
 	network = list("BoS")
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger{
+	pixel_y = 13
 	},
-/area/f13/brotherhood/armory)
+/obj/machinery/button/flasher,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood/operations)
 "rsW" = (
 /obj/structure/flora/wasteplant/wild_fungus,
 /obj/effect/decal/cleanable/dirt{
@@ -40258,7 +41439,8 @@
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/security)
 "rtw" = (
-/turf/open/floor/carpet/black,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/brotherhood/leisure)
 "rtG" = (
 /turf/closed/mineral/random/low_chance,
@@ -40302,6 +41484,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/sewer/powered)
+"rvi" = (
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood/operations)
 "rvj" = (
 /obj/structure/obstacle/barbedwire,
 /turf/open/indestructible/ground/inside/subway,
@@ -40315,6 +41500,13 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"rvV" = (
+/obj/structure/wreck/trash/four_barrels,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "rwb" = (
 /obj/structure/rack,
 /obj/item/reagent_containers/spray/cleaner,
@@ -40378,10 +41570,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/bar/heaven)
 "rwV" = (
-/obj/structure/sign/departments/medbay,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/obj/machinery/light{
+	dir = 8;
+	flickering = 1
+	},
+/obj/machinery/vending/hydroseeds{
+	force_free = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "rwW" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -40404,15 +41603,10 @@
 /turf/closed/wall/rust,
 /area/f13/followers)
 "rxQ" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light{
-	dir = 8;
-	pixel_y = -15
-	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/obj/structure/sign/departments/botany,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/rnd)
 "ryd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel{
@@ -40483,6 +41677,7 @@
 /area/f13/bunker)
 "rAk" = (
 /obj/structure/lattice,
+/obj/structure/lattice/catwalk,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "engine"
 	},
@@ -40716,11 +41911,14 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "rFi" = (
-/obj/structure/toilet{
-	pixel_y = 13
+/obj/structure/table/reinforced,
+/obj/machinery/vending/security{
+	force_free = 1
 	},
-/turf/open/floor/plating/rust,
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/red/corner{
+	dir = 8
+	},
+/area/f13/brotherhood/operations)
 "rFo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass,
@@ -40783,10 +41981,6 @@
 /area/f13/building/firestation)
 "rGJ" = (
 /obj/machinery/light/small,
-/obj/machinery/porta_turret/f13/turret_556/burstfire{
-	faction = list("BOS");
-	req_access = list(120)
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
 	},
@@ -40799,12 +41993,19 @@
 /turf/open/water,
 /area/f13/enclave)
 "rHg" = (
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = 16
+/obj/effect/decal/cleanable/blood{
+	icon_state = "drip1"
 	},
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/ruins{
+	icon_state = "rubblepillar"
+	},
 /area/f13/brotherhood/operations)
+"rHj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/leisure)
 "rHm" = (
 /obj/machinery/light/small{
 	light_color = "red"
@@ -40890,11 +42091,7 @@
 	},
 /area/f13/bunker/bunkerseven)
 "rID" = (
-/obj/item/book/granter/crafting_recipe/blueprint/fh_46/bos,
-/obj/item/book/manual/wiki/detective,
-/obj/item/book/manual/nuclear,
-/obj/structure/bookcase/manuals,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/circuit/f13_green,
 /area/f13/brotherhood/rnd)
 "rIJ" = (
 /turf/closed/wall/r_wall/rust,
@@ -40914,6 +42111,14 @@
 	icon_state = "dark"
 	},
 /area/f13/sewer/powered)
+"rIU" = (
+/obj/machinery/iv_drip{
+	pixel_x = 15;
+	pixel_y = -2
+	},
+/obj/structure/chair/comfy/beige,
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/operating)
 "rIX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -40981,13 +42186,16 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer/powered)
 "rJZ" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/comfy/shuttle{
+	desc = "A comfortable, secure seat. It has a futuristic vouge feel.";
+	layer = 2.7;
+	name = "prewar lounge chair";
+	dir = 8
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "rKt" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -41049,18 +42257,13 @@
 /turf/open/floor/plating/rust,
 /area/f13/bunker/bunkersix)
 "rMQ" = (
-/obj/structure/table/glass,
-/obj/item/storage/bag/chemistry{
-	pixel_x = 10;
-	pixel_y = 14
+/obj/structure/fence{
+	dir = 4
 	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operations)
 "rNg" = (
 /turf/closed/wall/rust,
 /area/f13/bunker/bunkersix)
@@ -41073,11 +42276,11 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
 	pixel_y = 17
 	},
-/turf/open/floor/carpet/purple,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
 "rNp" = (
 /obj/structure/lattice,
@@ -41154,7 +42357,8 @@
 	req_access_txt = "120";
 	req_one_access_txt = "120"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/rnd)
 "rOe" = (
 /obj/structure/simple_door/metal/iron,
@@ -41173,12 +42377,11 @@
 	},
 /area/f13/bunker)
 "rOH" = (
-/obj/structure/bodycontainer/crematorium,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/operating)
 "rOK" = (
 /obj/machinery/telecomms/receiver/preset_right,
@@ -41358,10 +42561,18 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"rRl" = (
+/obj/structure/wreck/trash/three_barrels,
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "rRp" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
 	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 1
 	},
@@ -41636,13 +42847,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/followers)
 "rYR" = (
-/obj/structure/table/glass,
-/obj/item/stack/f13Cash/caps/fivezero,
-/obj/machinery/light{
-	light_color = "#e8eaff"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/turf/open/floor/plasteel/f13/vault_floor/yellow/corner{
+	dir = 1
 	},
 /area/f13/brotherhood/operations)
 "rYW" = (
@@ -41764,6 +42973,19 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"sbc" = (
+/obj/effect/spawner/lootdrop/trash,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/operating)
 "sbq" = (
 /obj/structure/debris/v4,
 /obj/structure/debris/v1,
@@ -41795,6 +43017,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"scE" = (
+/obj/structure/barricade/bars,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/brotherhood/operations)
 "scQ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/f13,
@@ -41893,10 +43119,9 @@
 	},
 /area/f13/enclave)
 "seR" = (
-/obj/item/bedsheet/hos,
-/obj/structure/bed,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "sfb" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -41943,6 +43168,12 @@
 	icon_state = "greenfull"
 	},
 /area/f13/sewer)
+"sfM" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "sfQ" = (
 /obj/effect/spawner/lootdrop/f13/armor/tier4,
 /obj/structure/closet/crate/footlocker,
@@ -42165,11 +43396,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/brotherhood/reactor)
 "skF" = (
-/obj/machinery/light/floor,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
-	},
+/obj/effect/landmark/start/f13/knightcap,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
 "skI" = (
 /obj/structure/table/reinforced,
@@ -42452,15 +43680,10 @@
 	},
 /area/f13/sewer)
 "sqC" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/porta_turret/f13/turret_556/burstfire{
-	faction = list("BOS");
-	req_access = list(120)
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/mining)
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/rnd/destructive_analyzer,
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "sqG" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -42474,6 +43697,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"sqL" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/dorms)
 "sqP" = (
 /obj/structure/handrail/g_central{
 	layer = 2.7;
@@ -42563,12 +43792,8 @@
 	},
 /area/f13/bunker/bunkerthree)
 "sug" = (
-/obj/machinery/light{
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 1
 	},
 /area/f13/brotherhood/operations)
 "suj" = (
@@ -42856,15 +44081,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
 "sAG" = (
-/obj/machinery/power/apc/auto_name/south,
+/obj/structure/sign/poster/contraband/pinup_couch{
+	pixel_y = 32
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "0-1"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/chemistry)
+/turf/open/floor/wood_worn/wood_worn_dark,
+/area/f13/brotherhood/dorms)
 "sAQ" = (
 /mob/living/simple_animal/hostile/handy/assaultron{
 	desc = "A deadly close combat robot developed by RobCo in a vaguely feminine, yet ominous chassis. This one seems sleeker and more dangerous, with a slick red paintjob.";
@@ -42893,16 +44115,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/vault/custodial)
 "sBD" = (
-/obj/structure/table/optable,
-/obj/machinery/iv_drip{
-	pixel_x = 15;
-	pixel_y = -2
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/brotherhood/chemistry)
 "sBI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -42924,19 +44141,15 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "sCb" = (
-/obj/structure/closet/cabinet{
-	anchored = 1;
-	name = "formal attire cabinet"
+/obj/structure/table{
+	layer = 2.9
 	},
-/obj/item/clothing/under/f13/bosformgold_f,
-/obj/item/clothing/under/f13/bosformgold_m,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 5
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/neck/mantle/bos/paladin,
-/obj/item/clothing/neck/mantle/bos/left,
-/obj/item/clothing/neck/mantle/bos/right,
-/obj/item/clothing/neck/mantle/commander,
 /turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "sCv" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6";
@@ -43008,15 +44221,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
 "sDP" = (
-/obj/structure/table/glass,
-/obj/item/seeds/poppy/broc{
-	pixel_x = -5
-	},
-/obj/item/seeds/xander{
-	pixel_x = 5
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "sDV" = (
 /obj/machinery/door/airlock/maintenance_hatch/abandoned,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
@@ -43108,8 +44315,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/enclave)
 "sFT" = (
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
 "sFV" = (
@@ -43166,10 +44374,11 @@
 /turf/open/floor/plating/rust,
 /area/f13/bunker/bunkersix)
 "sGT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 4
+/obj/machinery/door/airlock/medical/glass{
+	name = "Brotherhood Medical";
+	req_access_txt = "120"
 	},
+/turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/brotherhood/operating)
 "sGX" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
@@ -43241,6 +44450,20 @@
 /obj/structure/barricade/wooden/planks,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
+"sIW" = (
+/obj/structure/decoration/vent,
+/obj/item/assembly/mousetrap/armed,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/operating)
 "sJg" = (
 /obj/structure/girder,
 /turf/closed/mineral/random/low_chance,
@@ -43257,11 +44480,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
 "sJS" = (
-/obj/structure/shelf_wood,
-/obj/effect/spawner/lootdrop/bombparts,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
+/obj/structure/lattice/catwalk,
+/obj/effect/landmark/start/f13/initiate,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
 "sKe" = (
 /obj/structure/window/fulltile/house{
@@ -43302,6 +44523,18 @@
 /obj/machinery/porta_turret/f13/turret_shotgun/raider,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer/powered)
+"sKP" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "sKS" = (
 /obj/structure/bed,
 /turf/open/floor/f13/wood{
@@ -43425,6 +44658,48 @@
 /obj/structure/table,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
+"sNZ" = (
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 11
+	},
+/obj/item/melee/classic_baton/telescopic{
+	pixel_x = -4;
+	pixel_y = 8
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -10;
+	pixel_y = -10
+	},
+/obj/item/reagent_containers/spray/pepper{
+	pixel_x = -2;
+	pixel_y = -10
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 5;
+	pixel_y = 8
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 7;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/item/grenade/flashbang{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_box/shotgun/rubber,
+/obj/item/ammo_box/shotgun/bean,
+/obj/structure/closet/anchored,
+/obj/item/gun/ballistic/shotgun/police,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/brotherhood/operations)
 "sOj" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/effect/decal/waste{
@@ -43535,6 +44810,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
+"sQp" = (
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 5
+	},
+/area/f13/brotherhood/rnd)
 "sQt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -43609,12 +44889,29 @@
 	},
 /area/f13/building/abandoned/o)
 "sRz" = (
-/obj/machinery/light{
-	dir = 4;
-	flickering = 1
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/floor/plasteel/cult,
 /area/f13/brotherhood/operations)
+"sRC" = (
+/obj/structure/barricade/sandbags,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/old{
+	id = "bos_mine_turret";
+	name = "security shutters"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
+"sRE" = (
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS");
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/operating)
 "sRT" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/gold/fifty,
@@ -43791,8 +45088,12 @@
 /turf/open/floor/plating/rust,
 /area/f13/bunker/bunkersix)
 "sXx" = (
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
+/obj/machinery/ammobench{
+	desc = "The shell of a pre-War reloading press. The internals have been completely removed, rendering it useless.";
+	name = "dusty reloading press"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "sXB" = (
 /obj/effect/gibspawner/human,
 /obj/structure/table,
@@ -44086,13 +45387,22 @@
 	},
 /area/f13/enclave)
 "tdC" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/power/apc/auto_name/east,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/rnd)
+"tdI" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "drip1";
+	pixel_x = -8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/brotherhood/rnd)
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "tdJ" = (
 /obj/structure/chair/sofa/right{
 	dir = 4
@@ -44132,11 +45442,14 @@
 	},
 /area/f13/bunker)
 "teG" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+	dir = 4
 	},
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken3"
+	},
 /area/f13/brotherhood/operations)
 "teL" = (
 /obj/structure/window/reinforced/spawner{
@@ -44240,6 +45553,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
+"tgV" = (
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "thJ" = (
 /obj/machinery/light/floor{
 	light_color = "#ff4500";
@@ -44323,18 +45640,11 @@
 	},
 /area/f13/bunker/bunkerthree)
 "tjv" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/obj/item/reagent_containers/blood/OMinus,
-/obj/item/clothing/gloves/color/latex/nitrile,
-/obj/item/surgical_drapes,
-/obj/item/stack/sticky_tape/surgical{
-	pixel_x = -11;
-	pixel_y = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/computer/operating/bos{
+	dir = 1
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "bcircuit1";
 	light_color = "#0076bc";
@@ -44454,13 +45764,10 @@
 /turf/open/water,
 /area/f13/sewer)
 "tkZ" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "tlg" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/bomb/tier1,
@@ -44510,19 +45817,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
 "tmA" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
+/obj/structure/curtain{
+	color = "#5c131b";
+	pixel_x = -32
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 1
-	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "tmI" = (
 /obj/structure/chair/left{
 	dir = 1
@@ -44754,7 +46054,7 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/sign/departments/science,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/rnd)
 "tqW" = (
@@ -44773,14 +46073,16 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "trK" = (
-/obj/machinery/light{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/chemistry)
+"trM" = (
+/obj/structure/chair/folding{
+	pixel_y = 11
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/operating)
 "trV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -44794,6 +46096,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
+"trX" = (
+/obj/structure/chair/left{
+	dir = 1
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/leisure)
 "tsd" = (
 /obj/structure/simple_door/metal/barred{
 	req_one_access_txt = "134"
@@ -44834,6 +46142,17 @@
 /mob/living/simple_animal/hostile/radscorpion,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"ttg" = (
+/obj/structure/decoration/vent,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/structure/nest/radroach,
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/operations)
 "tth" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -44882,20 +46201,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
 "ttS" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Armory";
-	req_access_txt = "120"
-	},
 /obj/effect/decal/cleanable/dirt{
-	color = "000000"
+	color = "#363636"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/f13{
-	dir = 10;
-	icon_state = "redmark"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "ttV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepiletwo,
@@ -45092,13 +46405,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
 "tyq" = (
-/obj/structure/dresser,
-/obj/machinery/light{
-	dir = 1;
-	pixel_x = 16
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/side{
+	dir = 5
 	},
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
+/area/f13/brotherhood/chemistry)
 "tyU" = (
 /obj/structure/table/abductor,
 /obj/item/grenade/f13/incendiary{
@@ -45183,6 +46496,17 @@
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"tAn" = (
+/obj/item/bodypart/l_arm/robot{
+	pixel_y = 12;
+	pixel_x = -8
+	},
+/obj/effect/decal/cleanable/robot_debris{
+	pixel_y = 22
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "tAB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
@@ -45417,9 +46741,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/ruin/powered)
 "tFX" = (
-/obj/effect/landmark/start/f13/elder,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/obj/structure/railing{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/padded,
+/area/f13/brotherhood/leisure)
 "tGh" = (
 /obj/item/bedsheet{
 	icon_state = "sheetcmo";
@@ -45446,7 +46773,16 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/enclave)
 "tGj" = (
-/turf/open/floor/carpet/green,
+/obj/machinery/light{
+	dir = 4;
+	pixel_y = -16
+	},
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/bedsheet,
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/brotherhood/dorms)
 "tGk" = (
 /obj/structure/shelf_wood,
@@ -45562,15 +46898,10 @@
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/shack)
 "tJB" = (
-/obj/structure/curtain,
-/obj/structure/simple_door/bunker/glass{
-	req_access_txt = "120";
-	req_one_access_txt = "120"
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/darkgreen,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "tJI" = (
 /obj/item/instrument/guitar,
 /obj/structure/rack,
@@ -45618,6 +46949,16 @@
 /obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tKS" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "tKW" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -45811,6 +47152,19 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"tOE" = (
+/mob/living/simple_animal/hostile/securitron/sentrybot{
+	name = "Brother Rust";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6";
+	pixel_y = 9;
+	pixel_x = -10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "tOL" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/bot,
@@ -45826,6 +47180,10 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
+"tPj" = (
+/obj/structure/table/booth,
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/leisure)
 "tPn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack,
@@ -45841,6 +47199,16 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/sewer/powered)
+"tPy" = (
+/obj/structure/closet/anchored,
+/obj/item/mop,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket/plastic,
+/obj/item/reagent_containers/glass/bucket/plastic,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "tPS" = (
 /mob/living/simple_animal/hostile/supermutant/legendary,
 /obj/structure/lattice,
@@ -45858,6 +47226,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
+"tQa" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/dorms)
 "tQd" = (
 /obj/structure/table,
 /obj/structure/barricade/bars,
@@ -45885,6 +47259,9 @@
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"tQp" = (
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side,
+/area/f13/brotherhood/operations)
 "tQG" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -45968,6 +47345,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"tRN" = (
+/obj/structure/table/glass,
+/obj/item/integrated_electronics/wirer{
+	pixel_x = 6
+	},
+/obj/item/integrated_electronics/debugger{
+	pixel_x = -6
+	},
+/turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
+/area/f13/brotherhood/rnd)
 "tRQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -46071,9 +47458,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
 "tTK" = (
-/obj/structure/bed/double,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/marking{
+	pixel_x = -16
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "tUi" = (
 /obj/structure/toilet{
 	pixel_y = 13
@@ -46124,6 +47517,17 @@
 /obj/effect/overlay/junk,
 /turf/closed/wall/f13/ruins,
 /area/f13/sewer/powered)
+"tUW" = (
+/obj/structure/table/wood,
+/obj/item/book/manual/advice_farming{
+	pixel_x = 5
+	},
+/obj/item/book/manual/advice_blacksmith{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "tVc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
@@ -46249,20 +47653,23 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "tWR" = (
-/obj/structure/barricade/bars,
-/obj/structure/table{
-	pixel_y = 6
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_y = 6;
+	pixel_x = 6
 	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
+/obj/item/reagent_containers/food/drinks/mug/coco{
+	pixel_x = -8;
+	pixel_y = 8
 	},
-/area/f13/brotherhood/armory)
-"tXl" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
 	},
 /area/f13/brotherhood/operations)
+"tXl" = (
+/obj/structure/wreck/trash/machinepile,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "tXw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing{
@@ -46299,10 +47706,28 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"tYS" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/item/storage/money_stack{
+	pixel_x = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "tZs" = (
 /mob/living/simple_animal/hostile/raider,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"tZw" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "tZT" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -46329,6 +47754,28 @@
 /obj/structure/girder/displaced,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"ubq" = (
+/obj/effect/decal/marking{
+	icon_state = "singlehorizontal";
+	pixel_y = -16
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
+"ubx" = (
+/obj/structure/table/reinforced,
+/obj/machinery/porta_turret/f13/turret_556/burstfire{
+	faction = list("BOS");
+	req_access = list(120)
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/turf_decal/box/red,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "ubE" = (
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/vault/garden)
@@ -46557,6 +48004,18 @@
 /obj/effect/spawner/lootdrop/ammo/military,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkereight)
+"ufH" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/vg_decals/numbers/one,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/dorms)
 "ufJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
@@ -46684,12 +48143,15 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "ujj" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/shoes/workboots/mining{
+	pixel_y = 10
 	},
-/obj/machinery/rnd/science_lab,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
-/area/f13/brotherhood/rnd)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken4"
+	},
+/area/f13/brotherhood/operations)
 "ujn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
@@ -46780,6 +48242,17 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/sewer/powered)
+"ulC" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/robot_debris,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/operations)
 "ulH" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/vault/dormitory)
@@ -46795,6 +48268,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/white,
 /area/f13/vault/science)
+"uma" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/sandbags,
+/obj/item/stack/sheet/mineral/wood/five,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/brotherhood/chemistry)
 "umc" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/generic{
@@ -46837,17 +48318,11 @@
 /turf/open/floor/wood_wide,
 /area/f13/vault/diner)
 "umn" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/medsprays,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 4
+/obj/structure/bed/mattress{
+	icon_state = "mattress5"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
-/area/f13/brotherhood/chemistry)
+/turf/open/floor/plating,
+/area/f13/brotherhood/operations)
 "ums" = (
 /obj/structure/closet/locker{
 	anchored = 1
@@ -47058,10 +48533,15 @@
 /turf/open/floor/f13,
 /area/ruin/powered)
 "upF" = (
-/obj/structure/sign/departments/botany,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/closed/wall/r_wall,
-/area/f13/brotherhood/operations)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/brotherhood/rnd)
 "upG" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -47123,27 +48603,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
 "uqW" = (
-/obj/structure/table/reinforced,
-/obj/item/card/id/dogtag{
-	pixel_x = 4
+/obj/effect/decal/cleanable/blood{
+	icon_state = "drip1";
+	pixel_y = 6;
+	pixel_x = -6
 	},
-/obj/item/card/id/dogtag{
-	pixel_x = 4
-	},
-/obj/item/card/id/dogtag{
-	pixel_x = 4
-	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_x = -8
-	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_x = -8
-	},
-/obj/item/encryptionkey/headset_bos{
-	pixel_x = -8
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/carpet/red,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
 /area/f13/brotherhood/operations)
 "urc" = (
 /obj/effect/spawner/lootdrop/lighter,
@@ -47175,16 +48641,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
+"uro" = (
+/obj/structure/window/reinforced/spawner/east,
+/obj/machinery/rnd/science_lab,
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "urv" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Interrogation";
-	req_access_txt = "120"
+/obj/structure/curtain{
+	color = "#845f58"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 4
+/obj/structure/simple_door/bunker/glass{
+	req_access_txt = "120";
+	req_one_access_txt = "120"
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/stone,
+/area/f13/brotherhood/operating)
 "urF" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -47259,6 +48730,12 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/f13/vault/overseer)
+"usX" = (
+/obj/structure/chair/right{
+	dir = 1
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/dorms)
 "utp" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -47290,13 +48767,14 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "utX" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
+/obj/machinery/light/floor,
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 1
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "utY" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable{
@@ -47347,10 +48825,10 @@
 	},
 /area/f13/enclave)
 "uuv" = (
-/obj/structure/rack/large/shelf,
-/obj/item/assembly/prox_sensor,
-/obj/item/stack/cable_coil/thirty,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/structure/anvil/obtainable/legion{
+	desc = "A solid steel anvil with a winged cog etched into it."
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/brotherhood/reactor)
 "uuB" = (
 /obj/machinery/light{
@@ -47411,6 +48889,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker/bunkerfive)
+"uvG" = (
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/f13/vault_floor/green/side,
+/area/f13/brotherhood/rnd)
 "uvH" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/caves)
@@ -47458,6 +48943,14 @@
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
+"uwK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/broken,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken4"
+	},
+/area/f13/brotherhood/operations)
 "uwX" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/tentclothedge{
@@ -47655,6 +49148,12 @@
 /obj/structure/junk/cabinet,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"uAO" = (
+/obj/machinery/mecha_part_fabricator{
+	pixel_y = 12
+	},
+/turf/open/floor/plating/rust,
+/area/f13/caves)
 "uAS" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -47703,6 +49202,13 @@
 	dir = 1
 	},
 /area/f13/brotherhood/armory)
+"uBO" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/outside/grass,
+/area/f13/brotherhood/rnd)
 "uBQ" = (
 /obj/structure/sign/poster/prewar/poster63{
 	pixel_y = -32
@@ -47754,14 +49260,17 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
 "uCZ" = (
-/obj/machinery/door/window/brigdoor,
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/turf_decal/box/corners{
+	dir = 4
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 8
+/obj/effect/turf_decal/arrows{
+	pixel_x = -11
 	},
-/area/f13/brotherhood/armory)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "uDf" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -47808,13 +49317,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
 "uEh" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/machinery/light{
+/obj/effect/turf_decal/arrows{
 	dir = 1;
-	flickering = 1
+	pixel_x = 11
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
-/area/f13/brotherhood/operating)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "uEn" = (
 /obj/machinery/vending/robotics,
 /turf/open/floor/f13{
@@ -47823,30 +49335,14 @@
 	},
 /area/ruin/powered)
 "uED" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Security Checkpoint";
-	req_access_txt = "120"
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
-	},
+/obj/structure/table/wood/poker,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "uEK" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 8
-	},
-/area/f13/brotherhood/armory)
+/obj/effect/landmark/start/f13/paladin,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/area/f13/brotherhood/reactor)
 "uFc" = (
 /obj/structure/debris/v3,
 /obj/structure/debris/v4,
@@ -47898,6 +49394,10 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
+"uGM" = (
+/obj/machinery/seed_extractor,
+/turf/open/floor/plasteel/f13/vault_floor/green/side,
+/area/f13/brotherhood/rnd)
 "uGW" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin";
@@ -47940,10 +49440,11 @@
 /turf/closed/wall/rust,
 /area/f13/bunker)
 "uHv" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/wood_common,
+/obj/structure/closet/crate/bin/trash_fallout,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "uHG" = (
 /obj/effect/decal/cleanable/oil/slippery,
@@ -48011,7 +49512,7 @@
 	},
 /obj/machinery/camera/autoname{
 	dir = 10;
-	name = "Secuirty Camera";
+	name = "Security Camera";
 	network = list("BoS")
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
@@ -48351,6 +49852,18 @@
 /obj/structure/table,
 /turf/open/floor/f13,
 /area/ruin/powered)
+"uPD" = (
+/obj/machinery/computer/rdconsole/core/bos{
+	desc = "The Head Scribe's terminal. Better not touch it, i'll get chewed out.";
+	name = "Head Scribe's Archive Terminal"
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891";
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood/rnd)
 "uPH" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/landmark/start/f13/vaultengineer,
@@ -48398,11 +49911,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "uQE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/fulltile,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
-/area/f13/brotherhood/armory)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/brotherhood/operations)
 "uQH" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker)
@@ -48434,14 +49947,19 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "uQY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
-	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/computer/card/bos,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/armory)
+"uRq" = (
+/obj/structure/table/reinforced,
+/obj/item/holosign_creator/security{
+	layer = 3.1;
+	name = "Head Knight's holobarrier projector";
+	pixel_y = 7
+	},
+/turf/open/floor/carpet/red,
+/area/f13/brotherhood/operations)
 "uRw" = (
 /obj/structure/handrail/g_central{
 	pixel_y = -11
@@ -48551,10 +50069,7 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
 "uTK" = (
-/obj/structure/rack/shelf_metal{
-	pixel_y = -12
-	},
-/obj/item/circuitboard/machine/pacman/super,
+/obj/structure/rack/shelf_metal,
 /obj/item/circuitboard/machine/pacman/super,
 /obj/item/circuitboard/machine/recharger,
 /obj/item/circuitboard/cryopodcontrol,
@@ -48748,6 +50263,11 @@
 	icon_state = "floordirty"
 	},
 /area/f13/bunker/bunkerthree)
+"uYQ" = (
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "uYR" = (
 /obj/machinery/rnd/production/protolathe,
 /obj/effect/turf_decal/stripes/line{
@@ -48766,6 +50286,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker/bunkerfive)
+"uZd" = (
+/obj/structure/shelf_wood,
+/obj/effect/spawner/lootdrop/low_tools,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
+/area/f13/brotherhood/reactor)
 "uZx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48988,15 +50513,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
 "veX" = (
-/obj/structure/curtain,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/door/airlock/grunge{
+	name = "On-Duty Barracks";
+	req_access_txt = "120"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 4
-	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/wood_worn/wood_worn_dark,
+/area/f13/brotherhood/dorms)
 "vfc" = (
 /obj/structure/table,
 /obj/item/storage/box/cups{
@@ -49253,6 +50777,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"vkE" = (
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/f13/brotherhood/rnd)
 "vkK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/flour,
@@ -49265,13 +50794,12 @@
 	},
 /area/f13/bunker)
 "vkW" = (
-/obj/structure/curtain,
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 1
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 8
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner{
+	dir = 4
 	},
 /area/f13/brotherhood/operating)
 "vla" = (
@@ -49328,12 +50856,12 @@
 	},
 /area/f13/bunker/bunkerthree)
 "vma" = (
-/obj/structure/table/reinforced,
-/obj/item/kirbyplants/random{
-	pixel_y = 8
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/scribe,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/red/side,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "vmj" = (
 /obj/structure/fluff/hedge,
 /obj/structure/sign/poster/prewar/vault_tec{
@@ -49408,6 +50936,12 @@
 /obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"voq" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/operations)
 "vov" = (
 /obj/machinery/porta_turret/f13/turret_9mm/raider{
 	dir = 1
@@ -49416,6 +50950,13 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/sewer/powered)
+"voF" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/machinery/smartfridge/chemistry,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "whitedirtysolid"
+	},
+/area/f13/brotherhood/rnd)
 "voH" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -49834,8 +51375,14 @@
 	},
 /area/f13/tcoms)
 "vxp" = (
-/turf/open/floor/plasteel/f13/vault_floor/green/corner,
-/area/f13/brotherhood/operations)
+/obj/structure/simple_door/bunker/glass{
+	req_access_txt = "120";
+	req_one_access_txt = "120"
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/rnd)
 "vxL" = (
 /mob/living/simple_animal/hostile/handy/gutsy{
 	icon_living = "pvtgutsy";
@@ -49884,10 +51431,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "vyu" = (
-/turf/open/floor/plasteel/f13/vault_floor/green/side{
-	dir = 4
+/obj/structure/simple_door/bunker/glass{
+	req_access_txt = "120";
+	req_one_access_txt = "120"
 	},
-/area/f13/brotherhood/operations)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/rnd)
 "vyv" = (
 /obj/structure/closet/toolcloset{
 	anchored = 1
@@ -50035,10 +51585,12 @@
 /turf/closed/wall/f13/wood,
 /area/f13/sewer/powered)
 "vBk" = (
-/obj/structure/curtain,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 5
+/obj/machinery/door/airlock/medical/glass{
+	name = "Brotherhood Medical";
+	req_access_txt = "120"
 	},
+/obj/structure/curtain,
+/turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/brotherhood/operating)
 "vBr" = (
 /obj/effect/gibspawner/robot,
@@ -50098,6 +51650,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
+"vCD" = (
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/side{
+	dir = 1
+	},
+/area/f13/brotherhood/operations)
 "vDk" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8;
@@ -50110,6 +51670,19 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"vDv" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "vDK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50378,6 +51951,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"vKD" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "red"
+	},
+/turf/open/floor/wood_common/wood_common_dark,
+/area/f13/brotherhood/dorms)
 "vKK" = (
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/mountain,
@@ -50430,8 +52010,11 @@
 /area/ruin/powered)
 "vLp" = (
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/carpet/black,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "vLt" = (
 /obj/structure/simple_door/blast{
 	req_one_access_txt = "120";
@@ -50512,9 +52095,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "vMX" = (
-/obj/effect/landmark/start/f13/seniorpaladin,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/padded,
+/area/f13/brotherhood/leisure)
 "vNk" = (
 /obj/structure/dresser,
 /obj/effect/turf_decal/siding/wood{
@@ -50736,10 +52322,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/bunker/bunkereight)
 "vRY" = (
-/obj/item/kirbyplants/random,
+/obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/leisure)
 "vSk" = (
 /obj/structure/table/glass,
 /obj/machinery/chem_heater{
@@ -50889,9 +52475,7 @@
 /obj/structure/closet/crate/secure/weapon{
 	anchored = 1
 	},
-/obj/item/grenade/barrier,
 /obj/item/grenade/f13/frag,
-/obj/item/grenade/barrier,
 /obj/item/grenade/stingbang,
 /obj/item/grenade/stingbang,
 /obj/item/grenade/f13/frag,
@@ -51065,17 +52649,23 @@
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
 "vZC" = (
-/obj/structure/closet/crate/bin/trashbin,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
-/area/f13/brotherhood/operations)
+/obj/machinery/chem_master,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "vZG" = (
-/obj/structure/bookcase/manuals,
-/obj/item/book/manual/wiki/research_and_development,
-/obj/item/book/manual/wiki/robotics_cyborgs,
-/obj/item/book/manual/wiki/surgery,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/structure/table/reinforced,
+/obj/item/storage/belt/utility/full/engi,
+/obj/item/crowbar/advanced,
+/obj/item/wrench/advanced{
+	pixel_x = 2
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 13
+	},
+/obj/item/mmi/posibrain,
+/turf/open/floor/plasteel/dark/corner,
 /area/f13/brotherhood/rnd)
 "vZI" = (
 /obj/structure/table,
@@ -51229,31 +52819,12 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/f13/sewer)
 "wdU" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/f13/mre,
-/obj/item/reagent_containers/food/snacks/f13/mre{
-	pixel_x = -7
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = 10;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/glass/beaker/waterbottle{
-	pixel_x = 12
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/closed/wall/r_wall,
+/area/f13/brotherhood/chemistry)
 "wec" = (
-/obj/machinery/light/small{
-	dir = 1;
-	pixel_x = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rust,
 /area/f13/brotherhood/operations)
 "wer" = (
 /obj/structure/chair/right{
@@ -51417,18 +52988,10 @@
 	},
 /area/f13/bunker)
 "wit" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	icon_state = "twindowold"
-	},
-/obj/structure/toilet{
-	pixel_y = 10
-	},
+/obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/f13{
-	icon_state = "redmark"
-	},
-/area/f13/brotherhood/operations)
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/dorms)
 "wiv" = (
 /obj/structure/closet/cabinet{
 	anchored = 1
@@ -51438,14 +53001,17 @@
 /turf/open/floor/f13/wood,
 /area/f13/vault/dormitory)
 "wix" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/table/wood/fancy/red,
+/obj/item/paper_bin{
+	pixel_y = 6;
+	pixel_x = 6
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/item/pen/fountain{
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/obj/structure/fluff/paper/stack,
+/turf/open/floor/carpet/red,
 /area/f13/brotherhood/rnd)
 "wiD" = (
 /obj/machinery/ntnet_relay,
@@ -51650,8 +53216,13 @@
 	},
 /turf/open/floor/f13,
 /area/ruin/powered)
+"wmp" = (
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/brotherhood/armory)
 "wmt" = (
 /obj/structure/sign/poster/random,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood/leisure)
 "wmz" = (
@@ -51665,13 +53236,17 @@
 	},
 /area/f13/bunker/bunkerthree)
 "wmG" = (
-/obj/structure/closet/crate/medical,
+/obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /obj/effect/decal/cleanable/dirt{
-	color = "000000"
+	color = "#363636"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/plating,
-/area/f13/brotherhood/operating)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/turf/open/floor/wood_common,
+/area/f13/brotherhood/operations)
 "wmL" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -51686,14 +53261,20 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
 "wmP" = (
-/obj/structure/closet/crate/bin,
+/obj/effect/decal/marking,
+/obj/structure/wreck/trash/engine,
 /obj/machinery/light/small{
-	pixel_x = -10
+	brightness = 7
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"wmS" = (
+/obj/structure/chair/comfy/lime{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_fancy,
+/area/f13/brotherhood/rnd)
 "wmX" = (
 /obj/machinery/autolathe/ammo/unlocked_basic,
 /obj/machinery/light,
@@ -51732,15 +53313,13 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
 "wnm" = (
-/obj/structure/table,
-/obj/item/scrap/research,
-/obj/item/scrap/research,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/item/flashlight/lamp{
-	pixel_y = 12
+/obj/machinery/chem_dispenser,
+/obj/structure/sign/departments/chemistry{
+	pixel_y = 32
 	},
-/turf/open/floor/plasteel/f13/vault_floor/purple,
+/turf/open/floor/plasteel/f13/vault_floor/blue/corner{
+	dir = 4
+	},
 /area/f13/brotherhood/rnd)
 "wnF" = (
 /obj/structure/table/wood,
@@ -51866,6 +53445,17 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
+"wqF" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#e8eaff"
+	},
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/f13/doctorbag,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "wqO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/barricade/wooden/strong,
@@ -51988,13 +53578,12 @@
 /turf/open/floor/f13,
 /area/f13/vault)
 "wsI" = (
-/obj/structure/bed,
-/obj/structure/curtain,
-/obj/item/bedsheet/cmo,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/decoration/vent,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/dorms)
 "wsJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
@@ -52017,9 +53606,12 @@
 	},
 /area/f13/bunker)
 "wsX" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side,
-/area/f13/brotherhood/operating)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/f13/initiate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "wsY" = (
 /obj/structure/debris/v1,
 /obj/structure/debris/v3{
@@ -52230,11 +53822,14 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/radiation)
 "wym" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress5"
-	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
+"wys" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
+/area/f13/brotherhood/dorms)
 "wyv" = (
 /obj/structure/closet/crate{
 	anchored = 1
@@ -52269,11 +53864,10 @@
 	},
 /area/f13/sewer/powered)
 "wyY" = (
-/obj/structure/curtain,
-/obj/effect/turf_decal/stripes/white/line{
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 1
 	},
-/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralsolid,
 /area/f13/brotherhood/operating)
 "wzh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -52316,10 +53910,22 @@
 "wAm" = (
 /turf/closed/wall/rust,
 /area/f13/building/firestation)
+"wAx" = (
+/obj/structure/table/reinforced,
+/obj/item/lock_construct,
+/obj/item/lock_construct,
+/obj/item/key,
+/obj/item/key,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/brotherhood/operations)
 "wAC" = (
-/obj/structure/shelf_wood,
-/obj/effect/spawner/lootdrop/stock_parts,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/machinery/workbench/advanced,
+/obj/machinery/light{
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "wAG" = (
 /obj/effect/decal/cleanable/dirt{
@@ -52563,6 +54169,11 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"wFz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/medical,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "wFH" = (
 /mob/living/simple_animal/hostile/renegade/soldier,
 /turf/open/indestructible/ground/inside/subway,
@@ -52616,12 +54227,7 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/radiation)
 "wHI" = (
-/obj/structure/chair/folding{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/operating)
 "wHM" = (
 /obj/effect/spawner/lootdrop/f13/armor/random,
@@ -52677,9 +54283,11 @@
 /area/f13/bunker/bunkerthree)
 "wIG" = (
 /obj/structure/shelf_wood,
-/obj/effect/spawner/lootdrop/low_tools,
-/obj/effect/spawner/lootdrop/low_tools,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/item/stack/cable_coil/thirty,
+/obj/item/assembly/prox_sensor,
+/obj/item/assembly/timer,
+/obj/effect/spawner/lootdrop/stock_parts,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "wIN" = (
 /obj/structure/disposalpipe/segment{
@@ -52692,6 +54300,11 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/bunker)
+"wIY" = (
+/obj/machinery/door/poddoor/shutters,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "wJk" = (
 /obj/structure/lattice/clockwork,
 /obj/structure/fence/handrail{
@@ -52849,7 +54462,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/structure/closet/fridge/standard,
-/turf/open/floor/carpet/purple,
+/obj/effect/spawner/lootdrop/mre,
+/obj/effect/spawner/lootdrop/mre,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
 "wLY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -52870,11 +54485,11 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
 "wMK" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/wood_common,
-/area/f13/brotherhood/leisure)
+/area/f13/brotherhood/chemistry)
 "wMV" = (
 /mob/living/simple_animal/hostile/raider/ranged/boss/junker,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -53064,9 +54679,9 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/machinery/light{
-	dir = 4;
-	pixel_y = -16
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 4
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/mining)
@@ -53128,11 +54743,12 @@
 	},
 /area/f13/bunker/bunkersix)
 "wQP" = (
-/obj/structure/table{
-	layer = 2.9
+/obj/effect/landmark/start/f13/initiate,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
-/area/f13/brotherhood/chemistry)
+/area/f13/brotherhood/operations)
 "wQW" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/ncr_k_ration,
@@ -53297,21 +54913,17 @@
 	dir = 4;
 	light_color = "#228B22"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/green/side{
+	dir = 4
+	},
+/area/f13/brotherhood/rnd)
 "wUQ" = (
 /obj/structure/chair/bench,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "wUS" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress4";
-	pixel_x = 9;
-	pixel_y = -11
-	},
-/obj/machinery/light/floor,
 /turf/open/floor/plating,
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "wVb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/kitchenspike,
@@ -53388,11 +55000,17 @@
 /area/ruin/powered)
 "wXq" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/scribe,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/structure/table{
+	layer = 2.9
 	},
-/area/f13/brotherhood/chemistry)
+/obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "bcircuit1";
+	light_color = "#0076bc";
+	light_power = 3;
+	light_range = 4
+	},
+/area/f13/brotherhood/operating)
 "wXx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/oldpipes{
@@ -53477,8 +55095,9 @@
 /turf/open/floor/plating/dirt,
 /area/f13/sewer/powered)
 "wZn" = (
-/obj/structure/chair/wood,
-/turf/open/floor/wood_common,
+/obj/machinery/power/apc/auto_name/east,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/brotherhood/leisure)
 "wZr" = (
 /obj/item/stack/sheet/mineral/uranium,
@@ -53506,7 +55125,7 @@
 "wZw" = (
 /obj/machinery/camera/autoname{
 	dir = 10;
-	name = "Secuirty Camera";
+	name = "Security Camera";
 	network = list("BoS")
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -53549,7 +55168,6 @@
 	color = "000000"
 	},
 /obj/item/reagent_containers/food/drinks/dry_ramen,
-/obj/item/stack/sheet/mineral/plasma/fifty,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/brotherhood/reactor)
 "xaQ" = (
@@ -53584,11 +55202,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault/reactor)
 "xbs" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/machinery/door/airlock/hatch{
+	name = "Living Spaces";
+	req_access_txt = "120"
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/wood_common,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "xbv" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
@@ -53668,13 +55288,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
 "xde" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/structure/junk/cabinet,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/neck/mantle/ragged{
+	pixel_y = -18;
+	pixel_x = -4
 	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/operations)
 "xdt" = (
@@ -53689,10 +55309,11 @@
 	},
 /area/f13/bunker/bunkerfive)
 "xdF" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/disks_plantgene,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "xdI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -53713,6 +55334,12 @@
 	},
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker/bunkertwo)
+"xdV" = (
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/turf/closed/indestructible/rock,
+/area/f13/caves)
 "xei" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/mineral/wood/fifty,
@@ -53910,12 +55537,9 @@
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "xhB" = (
-/obj/machinery/light{
-	dir = 1;
-	flickering = 1
-	},
-/turf/open/floor/carpet/blue,
-/area/f13/brotherhood/dorms)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "xhI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/clothing_low,
@@ -53994,12 +55618,11 @@
 /turf/open/floor/plasteel,
 /area/f13/tcoms)
 "xjl" = (
-/obj/structure/simple_door/metal/ventilation,
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/plating/f13/inside,
+/turf/closed/wall/r_wall,
 /area/f13/brotherhood/operating)
 "xjm" = (
 /obj/structure/debris/v1,
@@ -54026,15 +55649,10 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "xjC" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#c1ac99";
-	icon_state = "floorrustysolid"
-	},
-/area/f13/brotherhood/operations)
+/obj/structure/table/reinforced,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
+/area/f13/brotherhood/chemistry)
 "xjG" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -54115,11 +55733,14 @@
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
 "xlI" = (
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
+/obj/effect/turf_decal/arrows{
+	pixel_x = -11
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
@@ -54141,15 +55762,8 @@
 	},
 /area/f13/radiation)
 "xmd" = (
-/obj/structure/table{
-	layer = 2.9
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
-	},
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/f13,
 /area/f13/brotherhood/operating)
 "xml" = (
 /obj/structure/chair/stool,
@@ -54158,6 +55772,10 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/followers)
+"xmF" = (
+/obj/effect/landmark/start/f13/seniorknight,
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/armory)
 "xmL" = (
 /obj/machinery/workbench/forge{
 	desc = "A reactor-heated megafurnace used for forging metal items such as swords, spears and shields and more.";
@@ -54184,8 +55802,13 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
 "xnb" = (
-/obj/machinery/vending/cigarette/syndicate,
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/leisure)
 "xni" = (
 /obj/structure/simple_door/bunker,
@@ -54259,11 +55882,8 @@
 	},
 /area/f13/sewer/powered)
 "xoQ" = (
-/obj/structure/chair/folding{
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 8
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
 	},
 /area/f13/brotherhood/operating)
 "xoT" = (
@@ -54412,11 +56032,13 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/vault/security)
 "xqV" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/sign/directions/evac{
+	pixel_x = -32
 	},
-/turf/open/floor/carpet/red,
+/obj/effect/landmark/start/f13/initiate,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
 /area/f13/brotherhood/dorms)
 "xqX" = (
 /obj/structure/chair/sofa/left,
@@ -54524,16 +56146,14 @@
 /turf/open/water,
 /area/f13/sewer)
 "xuf" = (
-/obj/machinery/vending/wallmed{
-	pixel_y = -29
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "bcircuit1";
-	light_color = "#0076bc";
-	light_power = 3;
-	light_range = 4
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plating/f13,
+/area/f13/brotherhood/dorms)
 "xux" = (
 /obj/item/reagent_containers/food/snacks/meat/steak/molerat,
 /obj/structure/table/wood,
@@ -54546,16 +56166,8 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "xuQ" = (
-/obj/machinery/door/airlock/grunge{
-	name = "Combat Caste Office";
-	req_access_txt = "120"
-	},
-/obj/effect/decal/cleanable/dirt{
-	color = "000000"
-	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/turf/closed/wall/r_wall/rust,
+/area/f13/brotherhood/leisure)
 "xuS" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 1
@@ -54588,6 +56200,10 @@
 	},
 /turf/open/water,
 /area/f13/radiation)
+"xvu" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood/rnd)
 "xvx" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -54830,6 +56446,17 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"xAr" = (
+/obj/machinery/light{
+	dir = 1;
+	pixel_x = 16
+	},
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/dorms)
 "xAu" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -54993,16 +56620,23 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier3,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"xDb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken3"
+	},
+/area/f13/brotherhood/operations)
 "xDh" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
 	},
-/obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks{
 	density = 0;
 	pixel_y = 17
 	},
-/turf/open/floor/carpet/purple,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
 "xDw" = (
 /obj/machinery/power/terminal,
@@ -55019,6 +56653,11 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
+"xDK" = (
+/turf/open/floor/plasteel/f13/vault_floor/blue/side{
+	dir = 4
+	},
+/area/f13/brotherhood/operating)
 "xDO" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -55060,10 +56699,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess/yellowchess2,
 /area/f13/enclave)
 "xFd" = (
-/obj/item/storage/bag/salvage,
-/obj/item/weldingtool/hugetank,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/plasteel/f13/vault_floor/yellow,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
 "xFj" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -55087,6 +56724,14 @@
 /obj/structure/wreck/trash/brokenvendor,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/ruin/powered)
+"xFH" = (
+/obj/item/pda{
+	icon_state = "pda-hos";
+	name = "Head Scribe's PipBoy"
+	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
+/area/f13/brotherhood/rnd)
 "xFP" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/water,
@@ -55112,6 +56757,13 @@
 /obj/structure/debris/v3,
 /turf/closed/wall/rust,
 /area/f13/sewer)
+"xGE" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 1
+	},
+/obj/effect/landmark/start/f13/Knight,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/operations)
 "xGF" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -55160,8 +56812,20 @@
 	},
 /area/ruin/powered)
 "xHG" = (
-/turf/closed/wall/r_wall/rust,
-/area/f13/brotherhood/reactor)
+/obj/effect/decal/cleanable/dirt{
+	color = "000000"
+	},
+/obj/item/storage/bag/ore,
+/obj/item/clothing/glasses/meson,
+/obj/item/storage/bag/ore,
+/obj/item/pickaxe/drill{
+	pixel_y = 3
+	},
+/obj/structure/rack/shelf_metal,
+/obj/machinery/power/apc/auto_name/west,
+/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/brotherhood/mining)
 "xHL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/machinepile,
@@ -55170,9 +56834,10 @@
 	},
 /area/f13/sewer)
 "xHM" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
+/obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/light,
-/turf/open/floor/wood_common,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "xIq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55180,6 +56845,14 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/bar,
 /area/f13/bunker/bunkerthree)
+"xIy" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/floodlight_frame,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/operations)
 "xIC" = (
 /obj/structure/lattice,
 /obj/structure/chair/sofa,
@@ -55372,6 +57045,9 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
+"xNW" = (
+/turf/open/floor/plasteel/f13/vault_floor/red,
+/area/f13/brotherhood/operations)
 "xOa" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/landmark/start/f13/vaultdweller,
@@ -55425,6 +57101,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/vault/overseer)
+"xOF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_common{
+	icon_state = "common-broken4"
+	},
+/area/f13/brotherhood/operations)
 "xOK" = (
 /obj/effect/spawner/bundle/f13/armor/swat,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -55469,10 +57151,13 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
+	},
 /turf/open/floor/plasteel/f13/vault_floor/red/side{
 	dir = 1
 	},
-/area/f13/brotherhood/armory)
+/area/f13/brotherhood/operations)
 "xQI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_wide,
@@ -55494,11 +57179,14 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/bunker/bunkerthree)
 "xRy" = (
-/obj/structure/sign/flag_america_pristine{
-	pixel_y = 29
+/obj/structure/lattice{
+	layer = 3
 	},
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/leisure)
 "xRz" = (
 /obj/structure/fence{
 	dir = 8
@@ -55547,12 +57235,14 @@
 	},
 /area/f13/enclave)
 "xSj" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/structure/table/glass,
-/turf/open/floor/plasteel/f13/vault_floor/neutral/white/side{
-	dir = 4
+/obj/structure/simple_door/bunker/glass{
+	req_access_txt = "120";
+	req_one_access_txt = "120"
 	},
-/area/f13/brotherhood/operating)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/chemistry)
 "xSs" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -55730,6 +57420,15 @@
 /obj/structure/debris/v3,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"xVE" = (
+/obj/effect/turf_decal/arrows{
+	pixel_x = -11
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#c1ac99";
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "xVH" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13{
@@ -55757,8 +57456,13 @@
 /turf/open/floor/plating/rust,
 /area/f13/sewer)
 "xWV" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/green,
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/bedsheet,
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/brotherhood/dorms)
 "xXt" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -55821,11 +57525,8 @@
 /area/f13/vault/security)
 "xYo" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	light_color = "green"
-	},
 /turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/dorms)
 "xYr" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/f13{
@@ -55883,7 +57584,7 @@
 /obj/machinery/hydroponics/constructable,
 /obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
 /turf/open/floor/plasteel/f13/vault_floor/green,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/rnd)
 "yaj" = (
 /obj/structure/bed/old,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -55972,8 +57673,8 @@
 	},
 /area/f13/bunker/bunkerthree)
 "ycc" = (
-/turf/open/floor/plasteel/f13/vault_floor/green/side,
-/area/f13/brotherhood/operations)
+/turf/open/floor/plasteel/f13/vault_floor/green/corner,
+/area/f13/brotherhood/rnd)
 "ycf" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -56056,13 +57757,15 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
 "yeo" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/chair/f13chair1{
+	dir = 8
+	},
 /obj/machinery/light{
 	dir = 4;
-	pixel_y = -16
+	light_color = "#c1caff"
 	},
 /turf/open/floor/wood_common,
-/area/f13/brotherhood/operations)
+/area/f13/brotherhood/leisure)
 "yeC" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt{
@@ -56083,12 +57786,15 @@
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
 "yfa" = (
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/obj/machinery/chem_lab,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
+/obj/machinery/camera/autoname{
+	name = "Security Camera";
+	network = list("BoS");
+	dir = 4
 	},
-/area/f13/brotherhood/chemistry)
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	icon_state = "floorrustysolid"
+	},
+/area/f13/brotherhood/operations)
 "yfc" = (
 /obj/effect/spawner/lootdrop/costume,
 /obj/structure/rack/shelf_metal,
@@ -56135,19 +57841,19 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/building/abandoned/o)
+"ygn" = (
+/obj/effect/landmark/start/f13/offduty,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/dorms)
 "ygv" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/abandoned/o)
 "ygM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#228B22"
+/obj/effect/decal/cleanable/dirt{
+	color = "#363636"
 	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	icon_state = "whitedirtysolid"
-	},
+/turf/open/floor/plasteel/f13/vault_floor/blue/side,
 /area/f13/brotherhood/operating)
 "ygQ" = (
 /obj/structure/barricade/wooden,
@@ -56246,23 +57952,26 @@
 	},
 /area/f13/bunker)
 "yjV" = (
-/obj/effect/landmark/start/f13/sentinel,
-/obj/machinery/light/small{
-	brightness = 7;
+/obj/structure/railing{
+	color = "#A47449";
 	dir = 4
 	},
-/obj/effect/mapping_helpers/network_builder/power_cable/red/auto,
-/turf/open/floor/carpet/red,
-/area/f13/brotherhood/operations)
+/obj/structure/lattice{
+	layer = 3
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/brotherhood/leisure)
 "yjZ" = (
 /turf/closed/indestructible/f13/obsidian,
 /area/f13/bunker)
 "ykg" = (
-/obj/machinery/sleeper{
-	density = 1;
-	dir = 4
+/obj/effect/spawner/lootdrop/f13/doctorbag,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -9
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/table{
+	layer = 2.9
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "bcircuit1";
 	light_color = "#0076bc";
@@ -81987,7 +83696,7 @@ bgK
 bgK
 bgK
 bgK
-bgK
+qCp
 bgK
 bgK
 bgK
@@ -82288,11 +83997,11 @@ bgK
 bgK
 bgK
 bgK
-bgK
-yhR
-yhR
-yhR
-yhR
+qdV
+ohv
+ohv
+ohv
+jjg
 yhR
 yhR
 yhR
@@ -82590,11 +84299,11 @@ cNy
 cNy
 cNy
 bgK
-bgK
-yhR
-yhR
-yhR
-yhR
+cTi
+dqS
+ohv
+ohv
+ohv
 yhR
 yhR
 yhR
@@ -82893,9 +84602,9 @@ voI
 cNy
 bgK
 bgK
-yhR
-yhR
-yhR
+ohv
+ohv
+gal
 yhR
 yhR
 yhR
@@ -83195,8 +84904,8 @@ vuA
 cNy
 bgK
 bgK
-yhR
-yhR
+ohv
+jjg
 yhR
 yhR
 yhR
@@ -91579,13 +93288,13 @@ oEb
 yhR
 yhR
 yhR
-yhR
-oEb
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -91880,15 +93589,15 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-oEb
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
 yhR
+yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -92181,18 +93890,18 @@ yhR
 yhR
 yhR
 yhR
+bgK
+bgK
 yhR
+xfY
+xfY
+xfY
+agI
+ohv
 yhR
-yhR
-yhR
-yhR
-oEb
-yhR
-yhR
-yhR
-yhR
-yhR
-oEb
+bgK
+bgK
+bgK
 oEb
 yhR
 yhR
@@ -92482,20 +94191,20 @@ yhR
 yhR
 yhR
 yhR
+bgK
+bgK
+yhR
+gvF
+xfY
+xfY
+xfY
+wIY
+xfY
+ohv
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-oEb
-yhR
-yhR
-yhR
-yhR
-yhR
-oEb
+bgK
+bgK
 oEb
 yhR
 yhR
@@ -92784,21 +94493,21 @@ oEb
 yhR
 yhR
 yhR
+bgK
 oEb
+tXl
+pMe
+tAn
+xfY
+xfY
+dCd
+lYb
+xfY
+xfY
+fKx
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-oEb
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-oEb
+bgK
+bgK
 oEb
 yhR
 yhR
@@ -93086,22 +94795,22 @@ yhR
 yhR
 oEb
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
 oEb
+tXl
+ffM
+lHD
+jfw
+xfY
 yhR
 yhR
+tdI
+xfY
+ohv
 yhR
+yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -93388,23 +95097,23 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
+bgK
 oEb
 yhR
+uAO
+lHD
+tOE
+xfY
+yhR
+mFl
+iuq
+lHD
+xfY
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-oEb
-yhR
-yhR
-yhR
-oEb
-yhR
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -93679,35 +95388,35 @@ yhR
 yhR
 yhR
 yhR
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
 yhR
 yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+bgK
 oEb
 yhR
+afY
+eLY
+esj
+cyF
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-oEb
+gWI
+xfY
+xfY
+lHD
+gBk
+xfY
+bBB
+ohv
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -93980,14 +95689,6 @@ yhR
 yhR
 yhR
 yhR
-bgK
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-bgK
 yhR
 yhR
 yhR
@@ -93997,20 +95698,28 @@ yhR
 yhR
 yhR
 yhR
-oEb
-oEb
+yhR
+yhR
+yhR
 bgK
 bgK
 bgK
 bgK
-bgK
-bgK
-bgK
-bgK
+dum
 bgK
 bgK
 yhR
-yhR
+lWo
+lgc
+xfY
+xfY
+xfY
+xfY
+eOY
+xfY
+gBk
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -94277,35 +95986,18 @@ yhR
 yhR
 yhR
 yhR
-yhR
 bgK
 bgK
 bgK
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -94314,8 +96006,25 @@ yhR
 bgK
 bgK
 bgK
+rqM
+hFH
+meR
+bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+eQq
+ceH
+xfY
+ohv
 bgK
 bgK
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -94578,36 +96287,8 @@ yhR
 yhR
 yhR
 yhR
-yhR
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+bgK
 yhR
 yhR
 yhR
@@ -94620,6 +96301,34 @@ yhR
 yhR
 bgK
 bgK
+yhR
+yhR
+yhR
+yhR
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+bgK
+fvH
+ohv
+ohv
+xfY
+ohv
+ohv
+bgK
+bgK
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -94885,41 +96594,41 @@ yhR
 yhR
 yhR
 yhR
+gMF
 yhR
 yhR
 yhR
 yhR
+gMF
+yhR
+yhR
+bgK
+bgK
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-xHG
-xHG
-xHG
-xHG
-xHG
-xHG
+bgK
+uDl
+uDl
+uDl
+uDl
+uDl
+pHi
+pHi
+xuQ
+pHi
+pHi
+xuQ
+pHi
+csR
+wec
+csR
+csR
+uqW
+csR
 mWm
 yeV
-yeV
-yeV
-yeV
-yeV
-yeV
-rFP
-yeV
-rFP
-yeV
-yeV
-yeV
-yeV
-yhR
+jFG
 yhR
 yhR
 yhR
@@ -95191,37 +96900,37 @@ yhR
 yhR
 yhR
 yhR
-yhR
+gMF
 nuI
 ohv
+gMF
+yhR
+bgK
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-xHG
+bgK
+uDl
 omW
 iAV
 xFd
 fla
-uDl
-aqH
+pHi
 cwc
-ogc
 cwc
-wRE
-yeV
-aGs
-rxQ
-aGs
+cwc
+cwc
+vRY
+xuQ
+csR
+csR
+wym
 aGs
 csR
-aGs
+csR
 jjA
-yeV
-yhR
+ttg
+jFG
 yhR
 yhR
 yhR
@@ -95486,17 +97195,17 @@ bgK
 yhR
 yhR
 yhR
+gMF
 yhR
 yhR
 yhR
-yhR
-yhR
+gMF
 yhR
 ohv
 ohv
 ohv
 ohv
-yhR
+gMF
 yhR
 uDl
 vyf
@@ -95505,25 +97214,25 @@ uDl
 uDl
 uDl
 fAe
-vrw
-vrw
+uEK
+nbK
 qba
-uDl
-cxP
+pHi
+xRy
 lmi
 cDS
-gXb
-wRE
-yeV
+jKg
+quG
+pHi
 gMH
-aGf
-aGs
-aGs
-yeV
-aGs
-qaR
-yeV
-yhR
+csR
+csR
+csR
+csR
+lYY
+mWm
+fTu
+jFG
 yhR
 yhR
 yhR
@@ -95794,7 +97503,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+gMF
 ohv
 fTO
 ujJ
@@ -95806,27 +97515,27 @@ qFJ
 mpS
 aPF
 uDl
-msR
-vrw
-vrw
+omW
+iAV
+xFd
 lNB
-uDl
-wRE
+pHi
+cwc
 vMX
 bNX
 gXb
-wRE
-yeV
-aGs
+vRY
+pHi
+oCL
 aGf
-aGs
-aGs
-yeV
+csR
+csR
+csR
 rHg
-aGs
-yeV
+mWm
+fXe
+jFG
 oEb
-yhR
 yhR
 yhR
 yhR
@@ -96109,25 +97818,25 @@ vrw
 vrw
 sHi
 hwP
-vrw
-vrw
+xFd
+nbK
 odh
-uDl
-bNx
-uqW
+pHi
+cwc
+vMX
 gsj
-aYn
-eNP
+gXb
+vRY
 xuQ
 avX
 xde
-pWN
+ujj
 oCL
-yeV
-aGs
-aIc
-yeV
-yhR
+xDb
+jwf
+jjA
+ulC
+jFG
 yhR
 yhR
 yhR
@@ -96411,25 +98120,25 @@ jzw
 irU
 uDl
 gSr
-vrw
-vrw
+nbK
+xFd
 uuv
-uDl
+pHi
 xRy
 tFX
 kIr
 pWD
-pWD
-yeV
-kAW
-aGs
-aGs
+vRY
+kKQ
+xOF
+lbD
+oTE
 pcL
-yeV
-aGs
-dsc
-yeV
-yhR
+qrK
+uwK
+mWm
+bku
+jFG
 oEb
 yhR
 yhR
@@ -96714,24 +98423,24 @@ pYI
 rys
 qlm
 lZy
-lZy
-lZy
-rys
+qlm
+kHU
+gYT
 kzQ
 yjV
-pED
-mwx
+aqG
+aqG
 vRY
-yeV
+xuQ
 kAW
 teG
-aGs
-pWN
-yeV
-aGs
-jwK
-yeV
-yhR
+cEM
+pcL
+dxr
+oVS
+mWm
+aTH
+jFG
 yhR
 oEb
 yhR
@@ -97014,26 +98723,26 @@ eDZ
 kRg
 gTQ
 jHy
-qVD
-qVD
-vrw
-vrw
-uDl
-yeV
-yeV
-bdL
-yeV
-yeV
-yeV
-yeV
-yeV
-yeV
-qSM
-yeV
-yeV
-yeV
-yeV
-yhR
+fxS
+rjS
+fCv
+akt
+pHi
+pHi
+dGs
+seR
+seR
+keg
+pHi
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+ncX
+jFG
 yhR
 yhR
 yhR
@@ -97315,27 +99024,27 @@ kRg
 wSg
 gTQ
 gTQ
-hRe
+jHy
+qpS
 qVD
-qVD
-vrw
-vrw
+iAV
+fCv
 wIG
-yeV
+pHi
 iOg
 kKl
 kKl
-kKl
-eQq
-kKl
+seR
+tnL
+mOL
 ocx
-yeV
+xYo
 pWN
-aIc
+xYo
 aIc
 qaR
-yeV
-yhR
+ncX
+jFG
 yhR
 yhR
 oEb
@@ -97619,25 +99328,25 @@ xaM
 ngH
 rys
 qZz
-qVD
-vrw
-vrw
+iAV
+fCv
+nbK
 cLN
-yeV
+pHi
 sCb
 kKl
 kKl
-aGs
-yeV
+seR
+dte
 kXV
 xYo
-yeV
-pWN
-aGs
-aGs
-qaR
-yeV
-yhR
+kXV
+tnL
+heh
+aVJ
+tnL
+xuf
+jFG
 yhR
 yhR
 yhR
@@ -97921,25 +99630,25 @@ iDW
 uJT
 rys
 hnc
-qVD
-vrw
-vrw
+fCv
+iAV
+xFd
 wAC
-yeV
+pHi
 idJ
 yeo
-kKl
+pGC
 seR
-yeV
+tnL
 wit
 dCo
-yeV
-jRc
-aGs
-aGs
-qaR
-yeV
-yhR
+fAK
+tnL
+mda
+oNz
+tnL
+xuf
+jFG
 yhR
 yhR
 yhR
@@ -98223,25 +99932,25 @@ iDW
 vMH
 rys
 fCv
-qVD
+iAV
 kRy
-vrw
-wAC
-yeV
-yeV
-yeV
-yeV
-yeV
-yeV
-yeV
-yeV
-yeV
-pWN
-aGs
-eCE
-hhM
-yeV
-yhR
+epV
+uZd
+pHi
+pHi
+pHi
+pHi
+joH
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+tnL
+xuf
+jFG
 yhR
 yhR
 yhR
@@ -98521,29 +100230,29 @@ uDl
 uDl
 uDl
 uDl
-uDl
+rys
 rys
 rys
 pGu
 pae
+gYT
 pHi
 pHi
-pHi
-pHi
+haX
 pHi
 ipI
 nJe
-nJe
+jpe
 mJs
-mJs
-pId
-pHi
-pWN
-aGs
-yeV
-yeV
-yeV
-yhR
+tPj
+trX
+jEO
+kYz
+fMp
+lVC
+tnL
+ncX
+jFG
 yhR
 yhR
 yhR
@@ -98813,39 +100522,39 @@ upz
 uME
 upz
 upz
-fRI
-wvA
-gfi
-iVq
-iVq
-iVq
-iVq
-iVq
+upz
+iXZ
+upz
+upz
+gjp
+uma
+nGM
+lor
 gic
 iKj
 cWs
 vZC
 fwv
-vJB
+aUd
 sug
-pHi
+gYT
 xDh
-afm
-afm
+hmU
+jMa
 qyz
 rtw
 jcL
 jcL
-jcL
+hVw
 hLk
 pId
-pHi
-pWN
-aGs
-fTu
-nHC
-yeV
-yhR
+jEO
+jsV
+pEe
+pEe
+qaR
+wsI
+jFG
 yhR
 yhR
 yhR
@@ -99105,51 +100814,51 @@ bgK
 bgK
 bgK
 bgK
-yeV
+bgK
 wvA
 upz
 upz
 upz
+aPD
 upz
 upz
 upz
 upz
 upz
-qoc
-wvA
-haX
-iVq
-gsa
-vJB
-vJB
-vJB
-vJB
-nNC
-vJB
-ljc
-vJB
-vJB
-vJB
-pHi
-rNo
-afm
-afm
-pIq
-hmU
-jcL
-biU
-sXx
-sXx
-sXx
-joH
+iXZ
+upz
+fEM
+dJo
+iCz
+lYi
+lor
+kBJ
+dBt
+wMK
+fno
+rfV
 aUd
-aGs
-fTu
+sug
+gYT
+rNo
+hmU
+hmU
+pIq
+hfM
+jcL
 nHC
-yeV
-yhR
-yhR
-yhR
+jpe
+jpe
+jpe
+ckl
+pEe
+pEe
+cjE
+tnL
+ncX
+jFG
+mND
+mND
 yhR
 yhR
 yhR
@@ -99403,53 +101112,53 @@ yhR
 yhR
 yhR
 bgK
-nlw
-fJY
+qui
+wvA
 foH
-fJY
-fJY
-qui
-uME
-upz
-upz
-upz
-upz
-kKQ
-qui
 wvA
 wvA
 qui
+wvA
+wvA
+wvA
+wvA
+wvA
+wvA
+qui
+wvA
+wvA
+wvA
 qIa
-iVq
-gsa
-vJB
-vJB
-vJB
-vJB
+rZJ
+pBR
+sBD
+gOg
+idH
+wqF
 nNC
-vJB
-ljc
-vJB
-vJB
-vJB
-pHi
+wMK
+tZw
+qiD
+aUd
+vCD
+gYT
 wLP
-afm
-afm
-krG
 hmU
+hEt
+pIq
+hfM
 jcL
-sXx
-sXx
-bSQ
+jpe
+jpe
+jpe
 xHM
 jEO
 jEO
 tnL
 tnL
 tnL
-tnL
-yhR
+qaR
+jFG
 yhR
 yhR
 yhR
@@ -99705,53 +101414,53 @@ oEb
 yhR
 yhR
 bgK
-fJY
-rFi
-eEr
-odX
-bfF
 wvA
-uME
-upz
-upz
-upz
-upz
-upz
+ihK
+ihK
+odX
+bZQ
+rvi
+msW
+nZz
+drM
+vlM
+vlM
+xIy
 iZL
-lFO
-skF
-yeV
+vlM
+vlM
+wvA
 sJS
-iVq
+rZJ
 gsa
-vJB
-vJB
-iVq
+kRB
+aXd
+lor
 mqC
 qfW
-vJB
-ljc
-vJB
-vJB
-vJB
+jXt
+qfW
+xSj
+tQp
+lUx
 wmt
 hmq
-afm
+hmU
 afm
 pIq
-hmU
+hfM
 jcL
-sXx
-sXx
-bSQ
-sXx
-jKg
-vLp
+bGu
+uED
+jpe
+jpe
+mrZ
 eTY
 eTY
-akt
-tnL
-yhR
+eTY
+cOK
+iUL
+jFG
 yhR
 yhR
 yhR
@@ -100007,53 +101716,53 @@ yhR
 oEb
 yhR
 bgK
-fJY
-vhR
-ihK
-eEr
-bfF
 wvA
-uME
+wym
+ihK
+ihK
+bZQ
+rvi
 sRz
-upz
-upz
-upz
-upz
-czv
-oez
-cCi
-yeV
-lYb
-iVq
-gsa
-vJB
-vJB
-iVq
+sRz
+uQE
+vlM
+vlM
+vlM
+vlM
+vlM
+vlM
+wvA
+rZJ
+rZJ
+qZW
+xjC
+tyq
 wdU
-yeV
+wdU
 trK
-ljc
+trK
+fQi
 lTn
 pkh
 rYR
-pHi
+gYT
 puw
-afm
+hmU
 ggL
 pIq
-hmU
+hfM
 jcL
-sXx
-sXx
-cPd
-mJs
-tnL
+uED
+uED
+jpe
+dWQ
+jEO
 puc
+ozU
 eTY
 eTY
-cTi
-tnL
-yhR
+qVn
+jFG
 yhR
 yhR
 yhR
@@ -100309,53 +102018,53 @@ yhR
 oEb
 yhR
 bgK
-fJY
-vhR
-vhR
-eEr
+wvA
+gfi
+kET
+ihK
 bfF
-wvA
-wvA
-wvA
+kZP
+aJM
+aJM
 lqF
-ttS
-wvA
-wvA
-pxz
-lFO
-cCi
-yeV
+iVq
+jcR
+iVq
+iVq
+iVq
+lTj
+etb
 hAn
+lHj
+nAY
+jcR
+iVq
+yfa
 iVq
 iVq
-vJB
-vJB
 iVq
-hFH
-yeV
-vJB
-ljc
-nsx
-qiD
-jXt
-pHi
+sFT
+iVq
+iVq
+aLs
+gYT
 loz
-afm
 hmU
 hmU
-rtw
-sXx
-sXx
-sXx
-cPd
-mJs
+nJU
+fpr
+jpe
+uED
+mxz
+jpe
+jpe
+pmg
+jEO
+nDM
+cOK
+czm
 tnL
-tyq
-eTY
-eTY
-eTY
-tnL
-yhR
+jFG
 yhR
 oEb
 yhR
@@ -100611,62 +102320,62 @@ yhR
 oEb
 yhR
 bgK
-fJY
-vhR
-vhR
-vhR
+wvA
+gfU
+cHo
+wym
 bZQ
-eVf
-pWn
+ikf
+sRz
 aJM
 pPd
 uCZ
-uEK
-bGu
+vJB
 noV
-ljc
+noV
 vJB
-cmM
-cCi
-cCi
+noV
+gpX
+noV
+lFO
+noV
+noV
 vJB
 vJB
-vJB
-bRN
 xlI
-yeV
-nNC
-rwV
-wvA
-wvA
-wvA
+noV
+noV
+noV
+vJB
+mwP
+iVq
 gYT
 gYT
 gYT
 gYT
 xyq
-aEu
-bSQ
+qch
 jpe
-bSQ
-cPd
-lHD
-jEO
+jpe
+jpe
+jpe
+jpe
+vKD
 hQa
-eTY
-eTY
-fno
-imC
+jEO
+vqY
+vqY
+tnL
+jFG
+mND
+mND
+mND
+mND
+mND
+mND
+mND
 yhR
 yhR
-yhR
-yhR
-oEb
-yhR
-yhR
-yhR
-oEb
-oEb
 oEb
 yhR
 yhR
@@ -100914,59 +102623,59 @@ yhR
 yhR
 bgK
 jml
-vhR
-uwi
+scE
+jAO
 eCA
-bfF
-eVf
-pWn
-pWn
-utX
+bZQ
+rvi
+sRz
+aJM
+pUN
 dXC
-pqN
-heh
-tee
-hJQ
-lFO
+vJB
+vJB
+iri
+noV
+noV
 gzj
-oez
-oez
-oez
-cCi
+lPN
+noV
+noV
+noV
+noV
+mON
+noV
+noV
+noV
+lFO
+noV
 vJB
 iVq
-lkP
-ldy
-cCi
-lFO
-sFT
-sFT
-sFT
-sFT
-sFT
+nYu
+phb
 qgp
 gYT
 bSQ
-bSQ
-wMK
-wMK
-sXx
-sXx
+jJW
+jpe
+rHj
+jpe
+jpe
 aZU
-jEO
+cRj
 lqk
-rfL
-eTY
-tTK
+jEO
 tnL
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+tnL
+tnL
+jFG
+mND
+mND
+mND
+mND
+mND
+mND
+mND
 yhR
 yhR
 yhR
@@ -101215,53 +102924,53 @@ yhR
 yhR
 yhR
 bgK
-fJY
-odX
+wvA
+icM
 bUw
-eCA
+olX
 tWR
-eVf
-pWn
-pWn
-utX
+aGI
+sRz
+sRz
+pUN
 maM
-aPD
-dqS
-tee
-ljc
-cCi
-yeV
-fEM
 iVq
-oez
-ljc
-lFO
-agI
-aLs
-hEt
-lFO
+jcR
+iVq
+iVq
+iVq
+wvA
+bYs
+iVq
 aRB
+qDb
+qDb
+jcR
+aLs
+aLs
+aLs
+aRB
+noV
+noV
 sFT
-sFT
-sFT
-sFT
-sFT
-epV
-pHi
-bSQ
+nYu
+eCE
+jQQ
+gYT
+mRZ
 wZn
-mJs
-mJs
+cWL
+cWL
 uHv
-sXx
+rfv
 bYx
+cRj
+usX
 jEO
 tnL
 tnL
 tnL
-tnL
-tnL
-oEb
+jFG
 yhR
 yhR
 oEb
@@ -101517,51 +103226,51 @@ yhR
 yhR
 yhR
 bgK
-fJY
+wvA
 rsO
-tWR
-bfF
-tWR
-cQW
-pWn
-esj
+oeL
+sRz
+kcR
+aJM
+sRz
+aJM
 utX
-nHG
-vma
-uQE
+yeV
+yeV
 eLm
-ljc
+eLm
+eLm
+eGH
+wvA
+wvA
+yeV
+oez
+noV
+noV
 cCi
-yeV
-yeV
-yeV
-jeP
-vJB
-eYs
-yeV
-yeV
+pDh
+lkP
 rFP
-xjC
-lFO
-sFT
-sFT
-sFT
-sFT
-sFT
+iVq
+ubq
+noV
+iVq
+xGE
+lNm
 wmP
-pHi
-bSQ
-wZn
-mJs
-mJs
-uHv
-sXx
-sXx
-mrZ
-cOK
-cOK
-cOK
-cOK
+gYT
+gYT
+gYT
+bCQ
+ciw
+bCQ
+bCQ
+gYT
+jEO
+jEO
+jEO
+tnL
+tnL
 tnL
 yhR
 yhR
@@ -101819,51 +103528,51 @@ yhR
 yhR
 yhR
 bgK
-fJY
+wvA
 rFi
 tkZ
-eCA
-tWR
-eVf
-pWn
-pWn
-dDY
-hTr
+sNZ
+wAx
+eZh
+sRz
+aJM
+lCH
+yeV
 cET
 nEO
 tmA
-aRB
-cCi
+nHG
+aXZ
 yeV
 iIc
 diq
-oez
-vJB
-cCi
-vJB
+okC
+vDv
+oTp
+wmG
 jGR
+ubx
 yeV
-yeV
-lUx
-mda
-sFT
-sFT
+iVq
+vJB
+vJB
+iVq
 nYu
-yeV
-yeV
-pHi
-bSQ
-sXx
+bKc
+tgV
+gYT
+xnb
+ewv
 ewv
 kPi
-sXx
-sXx
+ewv
+ewv
 xnb
-jEO
+tQa
 xqV
 mVt
-ozU
-cOK
+ygn
+hUJ
 tnL
 yhR
 yhR
@@ -102122,50 +103831,50 @@ oEb
 yhR
 bgK
 jml
-eEr
-uwi
+jAO
+jAO
 eCA
-bfF
-eVf
-pWn
-pWn
-qCz
-ybq
-qCz
-ybq
-nwq
-cCi
-skF
+bZQ
+rvi
+sRz
+aJM
+lCH
 yeV
+plV
+nwq
+nwq
+wRE
+skF
+wvA
 rWq
+aLs
+noV
+noV
+sKP
+vJB
+bxs
+rFP
+yeV
 iVq
 vJB
 vJB
-cCi
-vJB
-bxs
-bxs
-yeV
-ljc
-mda
-sFT
-sFT
-sFT
+eKa
+tYS
 jQQ
 mAe
-pHi
+gYT
 aEu
-sXx
-sXx
+aEu
+cNB
 biU
-sXx
-sXx
-fAK
-pmg
-jEO
-nDM
+ewv
+lwl
+ewv
+xAr
+sqL
+ufH
 bYu
-cOK
+hUJ
 tnL
 yhR
 yhR
@@ -102423,22 +104132,22 @@ yhR
 oEb
 yhR
 bgK
-fJY
-vhR
-vhR
-eCA
+wvA
+wym
+anW
+umn
 bZQ
-eVf
-pWn
-esj
+rvi
+aJM
+sRz
 mEc
-mYd
-mYd
-mYd
-fJY
-tee
-tee
 yeV
+cxP
+ogc
+hhM
+uRq
+pED
+wvA
 hXs
 vlM
 rZJ
@@ -102448,26 +104157,26 @@ rZJ
 vlM
 wZw
 xwz
-ljc
-lFO
-lFO
-ljc
-ljc
-ljc
-cCi
-uED
+yeV
+cmM
+cmM
+yeV
+yeV
+yeV
+wvA
+gYT
 xbs
-jcL
-jcL
-sXx
-sXx
-sXx
-sXx
-sXx
-nJe
-jEO
-jLF
-cOK
+xbs
+pHi
+pHi
+pHi
+pHi
+eNP
+oBS
+veX
+pmg
+tnL
+tnL
 tnL
 yhR
 yhR
@@ -102725,21 +104434,21 @@ yhR
 yhR
 yhR
 bgK
-fJY
-vhR
-eEr
-eEr
+wvA
+gfi
+aQg
+ihK
 bfF
-eVf
-pWn
-pWn
-mEc
-mYd
-mYd
-mYd
+xNW
+aJM
+sRz
+jRc
+yeV
+qSM
+pED
 rJZ
 mRs
-onR
+pED
 yeV
 bYs
 vlM
@@ -102750,26 +104459,26 @@ vSU
 vlM
 rGJ
 yeV
+tKS
+hPf
 vJB
-vJB
-cCi
-cCi
-vJB
-ljc
-ljc
+rMQ
+tPy
+jXp
+wvA
 rpM
-ouH
+rZJ
+rZJ
+bRN
+oIg
+pxz
 sXx
-sXx
-nJe
-sXx
-sXx
-sXx
-sXx
-sXx
+rvV
 jEO
-vqY
-vqY
+wys
+pTH
+pTH
+pTH
 tnL
 oEb
 yhR
@@ -103027,21 +104736,21 @@ yhR
 yhR
 yhR
 bgK
-fJY
-vhR
+wvA
+gfU
 wUS
-eEr
-bfF
-eVf
-pWn
-pWn
-mEc
-mYd
+ihK
+bZQ
+ikf
+sRz
+sRz
+pLZ
+wvA
 uQY
 mYd
-urv
-oVS
-lgc
+wRE
+mwx
+wRE
 yeV
 vQs
 vJu
@@ -103052,26 +104761,26 @@ vSU
 vJu
 vQs
 yeV
-wec
-sFT
+jcR
+lPN
 aFE
 kpo
 wQP
-gvF
-nlB
-lor
-eGH
-pEl
+rGJ
+wvA
+vlM
+rZJ
+rZJ
 nbm
+omD
+xhB
+xhB
+rRl
 jEO
-mnr
-jEO
-jEO
-jEO
+sAG
+oLF
 tYu
-pmg
-tnL
-tnL
+bHd
 tnL
 yhR
 yhR
@@ -103329,21 +105038,21 @@ yhR
 yhR
 yhR
 bgK
-cWL
+foH
 wym
-vhR
+wym
 gfU
-bfF
+bZQ
 hcl
-pWn
-pWn
+sRz
+sRz
 xQC
-nlw
-fJY
-fJY
-nlw
-fJY
-tee
+qui
+yeV
+yeV
+yeV
+yeV
+kzF
 yeV
 yeV
 yeV
@@ -103354,32 +105063,32 @@ vSU
 yeV
 yeV
 yeV
-vJB
-sFT
-lYY
+iVq
+lPN
+lPN
 rMQ
 dkQ
 gCc
-sAG
-lor
-gMF
-beH
-qpS
-tnL
-pEe
-fMp
-lVC
+wvA
+vlM
+rZJ
+rZJ
+vlM
+cPd
+aMc
+cPd
+hSb
 jEO
-tGj
+ohA
 tGj
 xWV
-xWV
+eYs
 tnL
-hTW
-hTW
-hTW
-hTW
-hTW
+yhR
+yhR
+yhR
+yhR
+oEb
 oEb
 oEb
 yhR
@@ -103631,22 +105340,22 @@ yhR
 yhR
 yhR
 bgK
-tee
-tee
-tee
-tee
-tee
-aGI
+fJY
+fJY
+fJY
+fJY
+fJY
+wtD
 cYb
 cYb
-tee
+fJY
 nlw
 rtK
 fAl
 maT
-sjp
-hOG
-hOG
+aRW
+sIW
+sbc
 uVv
 yeV
 kAB
@@ -103654,33 +105363,33 @@ vSU
 vSU
 vSU
 yeV
-yeV
+dxG
 dbi
-vJB
-sFT
-qDb
+iVq
+msR
+lPN
 kev
-wXq
 oKj
-jat
+oKj
+wvA
 pbF
-wsX
-beH
-qpN
-tnL
+rZJ
+rZJ
+vlM
+rej
 xhB
-pEe
-pEe
-jEO
-tGj
-tGj
-tGj
-tGj
-tnL
-eHY
-pUN
-eHY
-joW
+aYn
+vlM
+pmg
+gSj
+gSj
+gSj
+gSj
+gSj
+gSj
+gSj
+hTW
+hTW
 hTW
 oEb
 oEb
@@ -103933,8 +105642,8 @@ yhR
 yhR
 yhR
 bgK
-tee
-vhR
+fJY
+qSB
 vhR
 vhR
 tee
@@ -103943,46 +105652,46 @@ pWn
 pWn
 mDf
 mYy
-eVf
-hmF
+wmp
+jgz
 rRp
 sjp
 rOH
 aRW
-pwo
+uVv
 yeV
 vSU
 vSU
 vSU
 vSU
 yeV
+cHv
 yeV
-jiB
-vJB
 sFT
-lor
-fpr
-oKj
-ePu
+lPN
+lPN
+sFT
+iVq
+iVq
 afp
-lor
+jcR
 wsX
-beH
-qpN
-tnL
-fMp
-kYz
-cjE
-jEO
-ncX
-kRB
+jcR
+jcR
+iVq
+iXk
+iVq
+jcR
+ldy
+gSj
+hTW
 llC
-eOY
-tnL
-eHY
+cZu
+cZu
+xHG
 kuz
-eHY
-qFn
+eha
+joW
 hTW
 oEb
 oEb
@@ -104235,7 +105944,7 @@ yhR
 yhR
 yhR
 bgK
-tee
+fJY
 eEr
 uwi
 vhR
@@ -104249,42 +105958,42 @@ eVf
 hmF
 myz
 jcM
-mwf
+guO
 eCx
-nCC
+pwo
 yeV
 yeV
 yeV
 yeV
 yeV
 yeV
+voq
 yeV
-tXl
+hXs
+lPN
+lPN
 vJB
 lPN
-lor
-yfa
-fXe
-cyF
-umn
-lor
-wsX
-beH
-qpN
-tnL
-imC
-tnL
-tnL
-pmg
-jEO
-jEO
-jEO
-jEO
-jEO
-aMc
-gSj
-gSj
-hTW
+lPN
+ljc
+vJB
+vJB
+xVE
+vJB
+lPN
+vJB
+vJB
+vJB
+vJB
+eAC
+mDe
+oYk
+aLl
+eHY
+eHY
+eHY
+eHY
+eHY
 hTW
 yhR
 yhR
@@ -104537,13 +106246,13 @@ yhR
 yhR
 oEb
 bgK
-tee
+fJY
 eEr
 uwi
 vhR
 xZa
 loq
-pWn
+aqH
 pWn
 oJi
 vsQ
@@ -104553,40 +106262,40 @@ ahf
 sjp
 hfp
 hOG
-wmG
+mwf
+wFz
 yeV
 yeV
 yeV
 yeV
 yeV
-yeV
-yeV
+dbi
 yeV
 jcR
-yeV
-lor
-kRr
+krG
+lPN
+vJB
 iri
-lor
-lor
-lor
+vJB
+ljc
+vJB
 uEh
-beH
-dGq
-lHj
-dGq
-dGq
-hTW
-qSn
+lPN
+lPN
+vJB
+tTK
+lPN
+lPN
+lPN
+jJh
+mDe
 eHY
-aLl
+eHY
+eHY
+eHY
+eHY
+eHY
 wKD
-nbK
-hTW
-eHY
-cZu
-cZu
-sqC
 hTW
 mMm
 yhR
@@ -104839,14 +106548,14 @@ yhR
 yhR
 yhR
 bgK
-tee
+fJY
 eEr
 fOf
 eEr
 tee
 wcC
-pWn
-pWn
+aqH
+aqH
 oJi
 ooN
 eVf
@@ -104857,38 +106566,38 @@ nWa
 gFb
 ixN
 odp
-beH
-beH
+urv
+sRE
 wHI
 iKT
+aJE
 wHI
-beH
 fHN
-lGX
-oNz
-beH
-beH
-beH
-beH
-beH
-beH
-wsX
-beH
-beH
-beH
-beH
-beH
-xLy
-qSn
-eHY
-eHY
-eHY
-eHY
-xLy
-eHY
-eHY
+vma
+iVq
+iVq
+sFT
+iVq
+jcR
+jat
+jcR
+jcR
+jcR
+jcR
+iVq
+iVq
+iVq
+iVq
+sFT
+gSj
+hTW
+sRC
 eHY
 bxZ
+eHY
+eHY
+eHY
+eHY
 xLy
 ohv
 ohv
@@ -105141,9 +106850,9 @@ yhR
 yhR
 yhR
 bgK
-tee
-tee
-tee
+fJY
+fJY
+fJY
 tee
 tee
 kaE
@@ -105159,37 +106868,37 @@ uVv
 xjl
 uVv
 uVv
-quG
-dGq
-dGq
-dGq
-dGq
-dGq
+uVv
+trM
+xDK
+iRK
+xDK
+wHI
 dIT
-dIT
+pEl
 vkW
 dGq
 dGq
 dGq
 dGq
-dGq
-dGq
-aqG
-qrv
-xSj
-cHv
-xSj
-cHv
-iRs
+rgg
+vlM
+rZJ
+rZJ
+vlM
+vlM
+vlM
+vlM
+woS
 qSn
+gSj
+geY
+fHU
 lTM
 eHY
-fHU
-eHY
-jFG
 eHY
 wPT
-eHY
+bqa
 eHY
 xLy
 ohv
@@ -105466,32 +107175,32 @@ pop
 pop
 pop
 pop
-pop
+jYE
 sGT
-sGT
-veX
-pop
-pop
-pop
-pop
-pop
-pop
-aSA
-beH
+fPf
+wyY
+sfM
+wmS
+iRs
+kBQ
+rgg
+vlM
+rZJ
+rZJ
 qpN
-beH
-beH
-beH
+lND
+nZO
+lND
+imC
+jiB
+hTW
+hTW
 hTW
 rhU
 hTW
 gVI
 hTW
 liJ
-hTW
-hTW
-rej
-hTW
 hTW
 hTW
 mMm
@@ -105746,7 +107455,7 @@ yhR
 oEb
 yhR
 yhR
-oEb
+bgK
 fJY
 eCv
 oZF
@@ -105763,39 +107472,39 @@ moa
 nfd
 lGX
 lGX
-dNx
-beH
+uVv
+rIU
 xoQ
-iKT
+wHI
 xoQ
-beH
-mND
+wHI
+dIT
 ygM
 wyY
-beH
-beH
-beH
-beH
-beH
-beH
-wsX
-beH
-qpN
-beH
-beH
-beH
+iRs
+iRs
+iRs
+tUW
+rgg
+vlM
+rZJ
+rZJ
+onR
+aJm
+hTr
+aJm
+aJm
+nAQ
+hTW
+hTW
 hTW
 qWo
 ofQ
-ofQ
-ofQ
-ofQ
-hTW
-yhR
-yhR
-yhR
-yhR
-yhR
+bxc
+bxc
+bxc
+jFG
+jFG
 yhR
 oEb
 oEb
@@ -106048,7 +107757,7 @@ yhR
 yhR
 oEb
 oEb
-oEb
+bgK
 fJY
 gRz
 tid
@@ -106058,46 +107767,46 @@ ach
 hmF
 hmF
 hmF
-hmF
-mEc
+rfL
+ppT
 sjp
-lCH
+ulS
 adq
-hPf
 lGX
+ckn
 uVv
-woS
-woS
-woS
-woS
-woS
-woS
+qoc
+cUj
+hEs
+dlh
+dlh
+uVv
 ois
-woS
+oho
 aij
 fBB
 jpG
 qKa
-lND
-lND
-wsX
-beH
+rgg
+vlM
+rZJ
+rZJ
 mQP
-wsI
-aij
 aJm
+dsc
+aJm
+aJm
+cfI
 hTW
 hTW
 hTW
 hTW
 hTW
-hTW
-hTW
-yhR
-yhR
-oEb
-oEb
-oEb
+jFG
+jFG
+jFG
+jFG
+jFG
 yhR
 yhR
 yhR
@@ -106350,7 +108059,7 @@ yhR
 yhR
 yhR
 yhR
-yhR
+bgK
 fJY
 hXu
 tid
@@ -106360,38 +108069,38 @@ ueC
 skI
 skI
 hmF
-hmF
-rRp
+rfL
+bdL
 sjp
-ykg
+hRe
 nfd
-sBD
 lGX
-jsV
-woS
-erw
-pcg
-pcg
-ikf
-ckn
-ujj
+gqh
+uVv
+xmd
 woS
 woS
 woS
 woS
 woS
+kLY
+abo
 woS
 woS
-tJB
-qdV
-wvA
+woS
+woS
+rgg
+rxQ
+rZJ
+rZJ
+kRr
 upF
-wvA
-wvA
-qui
-bgK
+uBO
+dCx
+bna
+bXw
 aiA
-gho
+xdV
 gho
 gho
 oEb
@@ -106652,48 +108361,48 @@ yhR
 yhR
 yhR
 yhR
-yhR
+bgK
 fJY
 qhz
 tid
 nGh
 eVf
 ueC
-bxc
-bxc
-hmF
-jgz
+skI
+skI
+rfL
+vLp
 fWs
 sjp
 dza
 nfd
 cKw
-lGX
-xmd
+jwK
+uVv
+dNx
 woS
-hEs
 jnJ
-pcg
-pcg
+xFH
+tRN
 inH
-pcg
+laI
 pmS
 axF
 iSH
 oCO
 nhg
-nhg
+eUs
 lUc
 vxp
 vyu
-vyu
-dum
+rgg
+rgg
 phC
-mRZ
-wvA
-bgK
+rgg
+fRI
+woS
 aiA
-yhR
+bgK
 yhR
 yhR
 oEb
@@ -106953,49 +108662,49 @@ oEb
 oEb
 oEb
 oEb
-oEb
-oEb
+bgK
+bgK
 fJY
 wrm
 xBS
 sTT
 eVf
-hmF
+bNx
 ueC
 hmF
-hmF
+xmF
 jgz
 gbm
 uVv
 fId
 qrv
 beH
-beH
-jsV
+juj
+uVv
+ftq
 woS
-bCQ
-cea
-cea
-cea
-cea
-tdC
-cea
+uPD
+hSr
+xvu
+kol
+hsU
+lAQ
 wix
-cea
+erw
 aYb
 aYb
 pNK
 tqN
-ycc
-hig
-hig
-ycc
-iPM
-ycc
-wvA
+bwP
+lvA
+gow
+rwV
+uYQ
+cQW
+rgg
 bgK
-yhR
-yhR
+bgK
+bgK
 oEb
 oEb
 yhR
@@ -107255,7 +108964,7 @@ oEb
 yhR
 oEb
 oEb
-oEb
+bgK
 nlw
 fJY
 fJY
@@ -107269,32 +108978,32 @@ hmF
 jgz
 bBU
 uVv
-xmd
+lAw
 gAb
 aDy
 aDy
 xmd
+dNx
 woS
-bna
 gqZ
 hsU
-iGM
-pcg
-aYu
-aYu
+nZE
+hsU
+kol
+pmS
 kZC
-pcg
-pcg
-pcg
-cea
+nCC
+aYb
+sqC
+uro
 rgg
-ycc
+uvG
 hig
-nnI
-dpa
 iPM
-dpa
-wvA
+ycc
+iPM
+czv
+rgg
 bgK
 yhR
 oEb
@@ -107557,7 +109266,7 @@ yhR
 oEb
 oEb
 oEb
-oEb
+bgK
 fJY
 daZ
 oZF
@@ -107575,28 +109284,28 @@ pag
 nfd
 beH
 beH
-bwP
+uVv
+uVv
 woS
-iCz
-pcg
-pcg
-pcg
-pcg
+aSA
+pqN
+ouH
+kol
 gpL
 lAQ
 nlz
-jIm
-jIm
-aYu
-qCp
+aYb
+iRs
+aYb
+aYb
 rOa
-ycc
+jeP
 hig
 nnI
 dpa
-iPM
-dpa
-wvA
+sQp
+rdL
+rgg
 bgK
 oEb
 yhR
@@ -107859,7 +109568,7 @@ yhR
 yhR
 yhR
 oEb
-oEb
+bgK
 fJY
 baQ
 fat
@@ -107875,30 +109584,30 @@ qOS
 sjp
 tjv
 nfd
-lGX
+cKw
 beH
-ulS
-kLY
+jLF
+beH
 bHN
-pcg
-pcg
-pcg
-pcg
+qFn
+nqA
+aKl
+nqA
 ibr
 jIm
-nhg
+ePu
 gNu
-nhg
+emx
 aYu
-tdC
-fDl
+hJQ
+rgg
 kiv
 hig
 nnI
 dpa
-iPM
-dpa
-wvA
+caN
+uGM
+rgg
 bgK
 oEb
 yhR
@@ -108161,7 +109870,7 @@ yhR
 oEb
 yhR
 oEb
-oEb
+bgK
 fJY
 mfS
 tid
@@ -108179,28 +109888,28 @@ jon
 adq
 qNy
 qrv
-qrv
-fPf
-cea
-cea
-cea
-cea
-cea
+beH
+beH
+voF
+khp
+nsx
+clJ
+aKl
 nqA
-nqA
+ttS
 cea
-cea
-cea
+eYm
+tJB
 ofG
-qCp
+gcr
 eAw
 nDr
 bol
 xZO
-qkl
+ojR
 hlz
 qkl
-qui
+fRI
 bgK
 yhR
 yhR
@@ -108463,7 +110172,7 @@ yhR
 oEb
 yhR
 oEb
-oEb
+bgK
 fJY
 psq
 tid
@@ -108471,7 +110180,7 @@ ecN
 tid
 tid
 eVf
-aIj
+oJx
 oeD
 tid
 tid
@@ -108479,30 +110188,30 @@ thW
 sjp
 ykg
 nfd
-sBD
+lGX
 beH
-xuf
+beH
+hlv
 woS
-qZW
 ggl
 jYX
+qFn
 pcg
-pcg
-iGM
+aKl
 gTI
 iGM
 gcr
-pcg
-pcg
-kZC
+mnr
+jTT
+vkE
 fDl
 xdF
 hig
-hig
+sQp
 ycc
 iPM
-dpa
-yeV
+jeP
+woS
 bgK
 yhR
 yhR
@@ -108765,7 +110474,7 @@ yhR
 oEb
 oEb
 yhR
-yhR
+bgK
 fJY
 dwB
 sMi
@@ -108773,7 +110482,7 @@ nzE
 fDr
 eYa
 eVf
-kZP
+aIj
 vXu
 pSA
 mkj
@@ -108782,13 +110491,13 @@ sjp
 ced
 bcD
 cIr
-beH
+nlB
 jNz
+wXq
 woS
-pMe
 wnm
 ntq
-gBV
+ahe
 tQU
 mNI
 tdC
@@ -108797,14 +110506,14 @@ gBV
 rID
 rcU
 vZG
-woS
+rgg
 sDP
-hig
+qeP
 nnI
 wUP
-qeP
-dpa
-yeV
+nnI
+mpM
+woS
 bgK
 yhR
 yhR
@@ -109067,7 +110776,7 @@ yhR
 yhR
 yhR
 oEb
-yhR
+bgK
 nlw
 fJY
 fJY
@@ -109081,11 +110790,25 @@ fJY
 fJY
 fJY
 oHB
-uVv
-uVv
-uVv
-uVv
-uVv
+sjp
+sjp
+sjp
+sjp
+sjp
+sjp
+rgg
+rgg
+rgg
+rgg
+rgg
+rgg
+rgg
+rgg
+rgg
+rgg
+rgg
+rgg
+rgg
 woS
 woS
 woS
@@ -109093,20 +110816,6 @@ woS
 woS
 woS
 woS
-kLY
-woS
-woS
-woS
-woS
-woS
-woS
-yeV
-yeV
-yeV
-yeV
-yeV
-yeV
-yeV
 bgK
 yhR
 yhR
@@ -109369,8 +111078,6 @@ yhR
 yhR
 oEb
 oEb
-yhR
-yhR
 bgK
 bgK
 bgK
@@ -109407,9 +111114,11 @@ bgK
 bgK
 bgK
 bgK
-kBY
-kBY
-kBY
+bgK
+bgK
+bgK
+bgK
+bgK
 yhR
 yhR
 yhR
@@ -109709,9 +111418,9 @@ yhR
 yhR
 yhR
 yhR
-bYS
-bYS
-bYS
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -110011,9 +111720,9 @@ yhR
 yhR
 yhR
 yhR
-kBY
+bgK
 bhg
-kBY
+bgK
 yhR
 yhR
 yhR


### PR DESCRIPTION
## About The Pull Request
TLC applied to New Town. The Brotherhood's bunker gets a whole new look underground. In the sky, a few tiles were modified to fix occlusion issues with the New Town gatehouses.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Tick these after making the PR. -->

## Changelog
:cl:
tweak: Replaced the NT shop's railings with bars and the windoor with a barred door so you can actually use the counter/lock up behind you.
add: Added a label maker and some cardboard to the NT shop. Packaging!
tweak: Adjusted the NT bedsheet spawns to be randomized, save for one, just for funsies.
tweak: Moved the NT deputy spawns very slightly so you don't spawn on top of the ladders and dump your stuff down there.
add: Added more prep surfaces and a cutting board to NT's kitchen.
tweak: Adjusted the ground-floor NT house curtains so they're only openable from the inside.
tweak: NT workshop yard fiddling.
fix: Corrected the sky-level NT gatehouse floors so they aren't occluded by ground-level walls due to incorrect Z-level alignment.
add: (Almost) completely revamped the Brotherhood of Steel bunker. The underground level has been rebuilt to be a pre-War munitions depot, decommissioned until the advent of power armor, where it was only partially restored before the bombs fell. It features a main artery nominally meant for vehicle traffic to transport produced heavy munitions from one end of the complex to the surface elevator. In the exchange, however, the Brotherhood's starting resources have been somewhat reduced, with incidental spawns of high-end parts and tools being reduced all throughout the bunker in favor of an ethos where they are granted the tools they need to succeed, but required to actually go outside to get the materials to feed them. There are a couple fun secrets, too!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
