### PR TITLE
meta.

### DIFF
--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
@@ -100,6 +100,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/rnd)
+"abs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
 "abx" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -179,6 +186,21 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"acF" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/item/defibrillator,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/obj/item/reagent_containers/medspray/synthflesh,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "adq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -724,6 +746,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
+"ane" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/free_tonto{
+	pixel_x = 32;
+	pixel_y = 16
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "ang" = (
 /obj/effect/landmark/start/f13/vaultdweller,
 /turf/open/floor/plasteel/f13/vault_floor/green/side{
@@ -1016,6 +1050,12 @@
 /mob/living/simple_animal/hostile/raider/ranged/legendary,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"asy" = (
+/obj/item/chair,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "asA" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
@@ -1271,6 +1311,10 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/outpost)
+"awH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/sewer)
 "awN" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/indestructible/vaultdoor,
@@ -2068,6 +2112,14 @@
 /obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"aNY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/gun/ballistic/automatic/pistol/mk23,
+/obj/item/storage/belt/shoulderholster,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "aOb" = (
 /obj/machinery/camera/autoname{
 	dir = 4;
@@ -2993,6 +3045,18 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"bgc" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plating/tunnel,
+/area/f13/bunker)
+"bgh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_y = -2;
+	pixel_x = 19
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "bgt" = (
 /obj/effect/decal/waste{
 	icon_state = "goo5"
@@ -3912,6 +3976,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"bAa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "bAb" = (
 /obj/item/weldingtool/experimental,
 /obj/structure/table,
@@ -4099,6 +4170,13 @@
 /obj/structure/barricade/sandbags,
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
+"bDz" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "bDC" = (
 /obj/machinery/telecomms/server/presets/ncr,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -4871,6 +4949,13 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
+"bTJ" = (
+/mob/living/simple_animal/hostile/securitron/sentrybot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/radiation)
 "bTV" = (
 /mob/living/simple_animal/hostile/handy/assaultron,
 /turf/open/floor/plasteel/dark,
@@ -4986,6 +5071,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"bWy" = (
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/radiation)
 "bWF" = (
 /obj/structure/table,
 /obj/item/book/granter/trait/midsurgery,
@@ -5100,6 +5190,10 @@
 /obj/structure/chair/left,
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
+"bYQ" = (
+/obj/effect/turf_decal/vg_decals/radiation,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "bYS" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/sewer)
@@ -5288,6 +5382,12 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
+"ccO" = (
+/obj/item/ingot/uranium,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "ccS" = (
 /obj/machinery/computer/terminal/stored_password{
 	door_id = "blackout"
@@ -5371,6 +5471,21 @@
 /obj/effect/gibspawner/human,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
+"cew" = (
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "cez" = (
 /turf/closed/indestructible/f13/matrix,
 /area/f13/caves)
@@ -5708,6 +5823,17 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"cli" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/scum{
+	pixel_x = 32
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "clm" = (
 /obj/structure/wreck/trash/four_barrels{
 	pixel_x = 3;
@@ -5926,6 +6052,16 @@
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/water,
 /area/f13/outpost)
+"cpr" = (
+/obj/structure/filingcabinet{
+	pixel_x = -6
+	},
+/obj/structure/filingcabinet{
+	pixel_x = -10;
+	pixel_y = -6
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "cpB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice,
@@ -6979,6 +7115,14 @@
 /obj/structure/wreck/trash/halftire,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
+"cLS" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/radiation)
 "cLZ" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/bunker/bighornbunker)
@@ -7872,6 +8016,12 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/enclave)
+"deu" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "dev" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -7961,6 +8111,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/atrium)
+"dfR" = (
+/obj/effect/overlay/junk/shower{
+	dir = 8
+	},
+/obj/item/ingot/uranium,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "dfW" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -8488,6 +8646,14 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
+"dsH" = (
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "dte" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Head's Quarters";
@@ -9081,6 +9247,14 @@
 	icon_state = "housebase"
 	},
 /area/f13/building/abandoned/o)
+"dFn" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibmid1"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "dFr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/curtain{
@@ -10253,6 +10427,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer/powered)
+"eik" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo5"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "eit" = (
 /obj/structure/table,
 /obj/item/clothing/under/f13/combat,
@@ -10379,6 +10565,19 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
+"ejR" = (
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
+"ejX" = (
+/obj/machinery/vending/engivend,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/radiation)
 "ekj" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 2
@@ -10867,6 +11066,23 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"evD" = (
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -9
+	},
+/obj/effect/turf_decal/big{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "evF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/ammo/fiftypercent,
@@ -10916,6 +11132,11 @@
 /obj/structure/grille/indestructable,
 /turf/open/floor/f13,
 /area/ruin/powered)
+"ewW" = (
+/obj/structure/closet/radiation,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "exg" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/indestructible/ground/inside/subway,
@@ -11161,6 +11382,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkertwo)
+"eBB" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/radiation)
 "eBR" = (
 /obj/effect/overlay/junk/oldpipes{
 	dir = 9
@@ -11563,6 +11790,13 @@
 /obj/machinery/light/small,
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bunkersix)
+"eJO" = (
+/obj/item/mop/advanced,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/radiation)
 "eKa" = (
 /obj/machinery/light/small{
 	brightness = 7;
@@ -12433,6 +12667,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"fbk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/scum{
+	pixel_x = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "fbI" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -12562,6 +12805,13 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"feO" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhighcargo,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
 "fff" = (
 /obj/structure/bed/roller,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -12898,6 +13148,24 @@
 	icon_state = "redmark"
 	},
 /area/f13/sewer/powered)
+"flq" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -9
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "flU" = (
 /obj/structure/closet/crate{
 	anchored = 1
@@ -12934,6 +13202,10 @@
 	dir = 8
 	},
 /area/f13/vault/security)
+"fmP" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "fmS" = (
 /obj/structure/junk/machinery,
 /turf/open/indestructible/ground/inside/subway,
@@ -12976,6 +13248,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"fnA" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/official/cleanliness{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "fnK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -13059,6 +13340,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
 /area/f13/enclave)
+"fpe" = (
+/obj/item/ingot/uranium,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "fpr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -13068,6 +13355,14 @@
 /obj/item/trash/f13/c_ration_1,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
+"fpy" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "fqe" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -13274,6 +13569,11 @@
 /obj/structure/flora/brushwoodalt,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
+"fvZ" = (
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/radiation)
 "fwd" = (
 /obj/machinery/hydroponics/soil/pot,
 /turf/open/indestructible/ground/inside/subway,
@@ -13460,6 +13760,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/sewer/powered)
+"fzy" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "fzB" = (
 /obj/structure/table/wood/poker{
 	name = "felt table"
@@ -13489,6 +13797,22 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault/security/armory)
+"fzS" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -8;
+	pixel_y = -5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -9
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "fAe" = (
 /obj/structure/kitchenspike_frame{
 	name = "Power armor frame";
@@ -13580,6 +13904,10 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"fAU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "fAW" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghoul/scorched/ranged,
@@ -14159,6 +14487,12 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"fOa" = (
+/obj/structure/nest/protectron,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "fOd" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "gib5-old"
@@ -14303,6 +14637,12 @@
 	icon_state = "tunnelchess"
 	},
 /area/f13/enclave)
+"fRh" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "fRp" = (
 /obj/structure/timeddoor,
 /turf/closed/wall/rust,
@@ -14629,6 +14969,15 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"fZe" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "fZf" = (
 /obj/structure/barricade/wooden/strong,
 /turf/closed/mineral/random/high_chance,
@@ -15036,6 +15385,13 @@
 	},
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
+"ghp" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "ghy" = (
 /obj/structure/fence{
 	dir = 1
@@ -15162,6 +15518,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"gkw" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/radiation)
 "gkx" = (
 /obj/machinery/light{
 	dir = 4
@@ -15888,6 +16250,15 @@
 /obj/effect/spawner/lootdrop/f13/attachments,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
+"gyG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "gyJ" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /obj/effect/decal/cleanable/dirt,
@@ -16330,6 +16701,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"gHS" = (
+/obj/effect/overlay/junk/shower{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "gHU" = (
 /obj/item/storage/trash_stack,
 /turf/open/indestructible/ground/inside/subway,
@@ -16677,6 +17055,10 @@
 	dir = 1
 	},
 /area/f13/brotherhood/chemistry)
+"gOn" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "gOy" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/wreck/trash/three_barrels,
@@ -16816,6 +17198,13 @@
 	},
 /turf/open/floor/holofloor/plating,
 /area/f13/brotherhood/armory)
+"gRA" = (
+/obj/machinery/rnd/server,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "gRO" = (
 /obj/structure/sign/poster/contraband/pinup_bed,
 /turf/closed/wall/r_wall/rust,
@@ -17109,6 +17498,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/padded,
 /area/f13/brotherhood/leisure)
+"gXn" = (
+/obj/structure/chair/sofa/right{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "gXr" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -17759,6 +18156,12 @@
 	dir = 8
 	},
 /area/ruin/powered)
+"hjp" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/radiation)
 "hjt" = (
 /obj/structure/table/abductor,
 /obj/item/grenade/plastic/c4{
@@ -18150,6 +18553,14 @@
 "hqq" = (
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"hqs" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "hqB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice,
@@ -18342,6 +18753,13 @@
 /obj/item/pickaxe,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"hvl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/red_rum{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "hvA" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -18727,6 +19145,12 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/enclave)
+"hDu" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
 "hDE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
@@ -19389,6 +19813,12 @@
 /obj/effect/decal/cleanable/ash/large,
 /turf/open/floor/f13,
 /area/ruin/powered)
+"hTG" = (
+/obj/item/clothing/suit/armor/tiered/medium/duster/armoredcoatred,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "hTM" = (
 /obj/structure/girder/reinforced,
 /obj/structure/lattice,
@@ -19828,6 +20258,13 @@
 /obj/structure/table/wood,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
+"ibV" = (
+/obj/item/grenade/f13/radiation,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
 "icl" = (
 /obj/item/chair,
 /turf/open/indestructible/ground/inside/subway,
@@ -19910,6 +20347,16 @@
 /obj/item/clothing/suit/armor/tiered/light/combat/brotherhood/scout,
 /turf/open/floor/holofloor/plating,
 /area/f13/brotherhood/armory)
+"idZ" = (
+/obj/machinery/vending/wallmed{
+	pixel_x = -30
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "ieh" = (
 /obj/item/clothing/head/helmet/riot/vaultsec,
 /obj/item/clothing/suit/armor/tiered/medium/vest/bulletproof/big,
@@ -19976,10 +20423,29 @@
 /obj/item/jammer,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"ifS" = (
+/obj/item/storage/belt/utility/full/engi,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/radiation)
 "igc" = (
 /obj/structure/chair/left,
 /turf/open/floor/wood_mosaic,
 /area/f13/vault/diner)
+"igf" = (
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -9
+	},
+/obj/effect/turf_decal/big{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "igj" = (
 /obj/machinery/light/small{
 	light_color = "red"
@@ -20627,6 +21093,12 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/outpost)
+"iuZ" = (
+/obj/item/clothing/under/lawyer/female,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "iva" = (
 /obj/effect/decal/marking,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -20745,6 +21217,10 @@
 	icon_state = "greenfull"
 	},
 /area/f13/building/abandoned/o)
+"ixl" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/radiation)
 "ixw" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/subway,
@@ -20957,6 +21433,12 @@
 /obj/effect/overlay/junk/oldpipes,
 /turf/open/water,
 /area/f13/outpost)
+"iCE" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "iCV" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -21036,6 +21518,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault/medical/surgery)
+"iFr" = (
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
 "iFD" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/meat/slab/mirelurk,
@@ -21119,6 +21608,26 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/cafeteria,
 /area/f13/bunker/bunkerthree)
+"iGU" = (
+/obj/structure/reagent_dispensers/barrel/dangerous,
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo12"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "iHq" = (
 /mob/living/simple_animal/hostile/raider/junker,
 /obj/machinery/light,
@@ -21127,6 +21636,13 @@
 "iHr" = (
 /turf/closed/indestructible/rock,
 /area/f13/tunnel)
+"iHt" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "iHz" = (
 /mob/living/simple_animal/hostile/centaur,
 /obj/structure/lattice,
@@ -21609,6 +22125,12 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"iTH" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "iTN" = (
 /obj/machinery/light{
 	dir = 4;
@@ -22016,6 +22538,16 @@
 	},
 /turf/open/floor/plating,
 /area/f13/bunker/bunkernine)
+"jbP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/greenglow{
+	pixel_x = 19;
+	pixel_y = -2
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "jbS" = (
 /obj/machinery/light/small{
 	light_color = "red"
@@ -22199,6 +22731,13 @@
 	},
 /turf/open/floor/plating/dirt/dark,
 /area/f13/radiation)
+"jfv" = (
+/obj/item/clothing/suit/bio_suit/hazmat,
+/obj/item/clothing/head/bio_hood/hazmat,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "jfw" = (
 /obj/effect/decal/cleanable/blood{
 	icon_state = "drip1";
@@ -22214,6 +22753,12 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/sewer/powered)
+"jfQ" = (
+/obj/machinery/rnd/destructive_analyzer,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "jfV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22243,11 +22788,24 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
+"jgP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/remains/human,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "jgS" = (
 /obj/structure/fence,
 /obj/effect/overlay/junk/curtain,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"jgX" = (
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "jhk" = (
 /obj/machinery/power/floodlight,
 /obj/structure/cable{
@@ -22327,6 +22885,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"jiE" = (
+/obj/effect/decal/cleanable/chem_pile,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "jiJ" = (
 /obj/machinery/telecomms/processor/preset_two,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -22417,6 +22981,12 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"jlU" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "jme" = (
 /obj/structure/railing{
 	dir = 4
@@ -22431,6 +23001,18 @@
 /obj/machinery/flasher,
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/operations)
+"jmo" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/book/granter/crafting_recipe/gunsmith_two,
+/obj/item/book/granter/crafting_recipe/gunsmith_three,
+/obj/item/book/granter/crafting_recipe/gunsmith_one,
+/obj/item/book/granter/crafting_recipe/gunsmith_four,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "jmG" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -22608,6 +23190,13 @@
 /mob/living/simple_animal/pet/dog/pug,
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/overseer)
+"jqu" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/pinup_vixen{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "jqA" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress5"
@@ -23126,6 +23715,14 @@
 "jAO" = (
 /turf/closed/indestructible/rock,
 /area/f13/building/firestation)
+"jBa" = (
+/obj/item/clothing/under/misc/polyshorts,
+/obj/item/clothing/under/misc/polyshorts,
+/obj/structure/closet/crate/footlocker,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "jBg" = (
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /obj/structure/rack,
@@ -23575,6 +24172,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/bunker/bunkerfive)
+"jMj" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "jMk" = (
 /mob/living/simple_animal/hostile/handy/robobrain{
 	auto_fire_delay = 2;
@@ -23938,6 +24544,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13/wood,
 /area/f13/bunker/bunkersix)
+"jVS" = (
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "jVU" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/waste,
@@ -24981,6 +25591,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/overseer)
+"kpa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "kpg" = (
 /obj/structure/barricade/bars,
 /obj/structure/decoration/rag,
@@ -25204,6 +25820,17 @@
 	name = "dirty floor"
 	},
 /area/f13/sewer/powered)
+"ksZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/suit/bio_suit/hazmat,
+/obj/item/clothing/head/bio_hood/hazmat,
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "gibbearcore"
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "ktj" = (
 /obj/structure/debris/v3{
 	layer = 2
@@ -26008,6 +26635,16 @@
 /obj/item/stack/medical/suture/medicated,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/side,
 /area/f13/vault/medical)
+"kKs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/obj/item/clothing/under/misc/squatter,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "kKu" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -26441,6 +27078,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/brotherhood/chemistry)
+"kRE" = (
+/obj/structure/debris/v3,
+/obj/structure/filingcabinet{
+	pixel_x = 11
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "kRH" = (
 /obj/structure/sign/poster/prewar/poster74{
 	pixel_x = 32
@@ -26895,6 +27539,16 @@
 	},
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/building/abandoned/o)
+"kZJ" = (
+/obj/effect/decal/remains/human,
+/mob/living/simple_animal/hostile/ghoul/glowing/strong/legendary,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "kZK" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -26978,6 +27632,14 @@
 /obj/machinery/telecomms/server/presets/enclave,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"laW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "lbm" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right{
@@ -27305,6 +27967,12 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/mining)
+"liW" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "liY" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -27406,6 +28074,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"lkg" = (
+/obj/item/clothing/head/bio_hood/hazmat,
+/obj/item/clothing/suit/bio_suit/hazmat,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "lki" = (
 /obj/structure/fluff/rug/rug_rubber{
 	icon = 'icons/fallout/objects/64x64_rugs.dmi';
@@ -28063,6 +28737,14 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/brotherhood/armory)
+"lyA" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "lyD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/footlocker,
@@ -28098,6 +28780,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
+"lzb" = (
+/obj/structure/fluff/railing{
+	dir = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -9
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo8";
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/big{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "lzd" = (
 /obj/structure/girder,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -28116,6 +28815,18 @@
 /mob/living/simple_animal/hostile/raider/baseball,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
+"lzO" = (
+/obj/structure/table/reinforced,
+/obj/machinery/vending/wallmed{
+	pixel_x = -30
+	},
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "lzV" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housebase"
@@ -28401,6 +29112,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/building/abandoned/o)
+"lFe" = (
+/obj/machinery/computer/rdconsole,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "lFl" = (
 /obj/structure/sign/poster/contraband/hacking_guide{
 	pixel_x = -32
@@ -28699,6 +29416,26 @@
 /obj/effect/spawner/lootdrop/f13/blueprintVHigh,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"lMc" = (
+/obj/structure/rack/shelf_metal,
+/obj/item/locked_box/armor/tier3_5,
+/obj/item/locked_box/armor/tier3_5,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
+"lMd" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/pinup_funk{
+	pixel_x = 6;
+	pixel_y = 33
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "lMp" = (
 /obj/machinery/light{
 	dir = 1
@@ -28812,6 +29549,12 @@
 	dir = 4
 	},
 /area/f13/vault/atrium)
+"lOJ" = (
+/mob/living/simple_animal/hostile/handy/gutsy,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "lOM" = (
 /obj/structure/rack,
 /obj/effect/spawner/bundle/f13/armor/combat/mk2,
@@ -28855,6 +29598,14 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"lPM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/pinup_pink{
+	pixel_x = -6;
+	pixel_y = 32
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "lPN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -28867,10 +29618,32 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"lQg" = (
+/obj/effect/turf_decal/big/energy{
+	alpha = 200;
+	pixel_x = 32;
+	layer = -10
+	},
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "lQu" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"lQA" = (
+/obj/machinery/vending/wallmed{
+	force_free = 1;
+	pixel_x = 26
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "lQC" = (
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/ruins,
@@ -29074,6 +29847,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/f13/brotherhood/chemistry)
+"lTq" = (
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = -12
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "lTI" = (
 /obj/item/am_containment{
 	pixel_x = 3
@@ -29610,6 +30390,12 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/bunker/bunkerthree)
+"meA" = (
+/obj/machinery/sleeper,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "meB" = (
 /obj/structure/bed/mattress{
 	icon_state = "mattress2"
@@ -29913,6 +30699,10 @@
 	dir = 1
 	},
 /area/ruin/powered)
+"mmY" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "mnh" = (
 /obj/effect/landmark/start/f13/usspecialist,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -30265,6 +31055,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"muX" = (
+/obj/item/ingot/uranium,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "muY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -30312,6 +31107,10 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"mvK" = (
+/obj/structure/table,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "mvT" = (
 /obj/structure/lattice/clockwork,
 /obj/structure/fence/handrail{
@@ -30534,6 +31333,15 @@
 	dir = 1
 	},
 /area/f13/brotherhood/armory)
+"myB" = (
+/obj/item/kirbyplants/photosynthetic,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "myG" = (
 /obj/structure/spacevine,
 /turf/closed/wall/rust,
@@ -30965,6 +31773,16 @@
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/plating/rust,
 /area/f13/caves)
+"mFr" = (
+/obj/structure/fluff/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/big{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "mFw" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/renegade/guardian,
@@ -31078,6 +31896,13 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker/bunkerthree)
+"mHR" = (
+/obj/effect/decal/waste{
+	icon_state = "goo11"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "mIo" = (
 /obj/structure/spacevine,
 /turf/closed/wall/r_wall/rust,
@@ -31432,6 +32257,12 @@
 	name = "dirty floor"
 	},
 /area/f13/building/firestation)
+"mQF" = (
+/obj/structure/chair/booth{
+	icon_state = "bench_center"
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "mQI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -31481,6 +32312,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/brotherhood/operations)
+"mRG" = (
+/obj/structure/closet/crate/trashcart,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/radiation)
 "mRM" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -31498,6 +32335,9 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker/bunkerfive)
+"mRU" = (
+/turf/closed/indestructible/f13vaultrusted,
+/area/f13/radiation)
 "mRZ" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
@@ -31830,6 +32670,15 @@
 	},
 /turf/open/floor/holofloor/plating,
 /area/f13/brotherhood/armory)
+"mYB" = (
+/mob/living/simple_animal/hostile/securitron/sentrybot/pristine/ballistic,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "mYD" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -32171,6 +33020,11 @@
 	name = "ghoul cannibal"
 	},
 /turf/open/indestructible/ground/inside/subway,
+/area/f13/radiation)
+"nfX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
 /area/f13/radiation)
 "ngc" = (
 /obj/structure/fluff/hedge,
@@ -32545,6 +33399,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
+"nmY" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/fakelattice,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/radiation)
 "nnv" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/official/medical_green_cross{
@@ -33180,6 +34039,13 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"nBa" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "nBe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
@@ -33445,6 +34311,14 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"nFs" = (
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "floor3"
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "nFG" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -33607,6 +34481,13 @@
 /obj/machinery/vending/cigarette/syndicate,
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
+"nJn" = (
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "nJv" = (
 /obj/machinery/light{
 	dir = 8
@@ -33718,6 +34599,12 @@
 	icon_state = "yellowsiding"
 	},
 /area/f13/bunker/bunkerthree)
+"nMJ" = (
+/obj/structure/chair/sofa/left,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "nMO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -33738,6 +34625,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
+"nNe" = (
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/obj/effect/decal/waste{
+	icon_state = "goo8"
+	},
+/obj/effect/turf_decal/big{
+	dir = 1
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "nNo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
@@ -33830,6 +34729,14 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
+"nOT" = (
+/obj/structure/sign/poster/contraband/rip_badger{
+	pixel_x = -30
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "nPd" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/dirt{
@@ -33849,6 +34756,14 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/sewer/powered)
+"nPn" = (
+/obj/structure/sign/poster/contraband/atmosia_independence{
+	pixel_y = 32
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "nPq" = (
 /obj/structure/campfire,
 /turf/open/floor/plating/tunnel,
@@ -34421,6 +35336,16 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/bunker/bunkerfive)
+"obO" = (
+/obj/structure/simple_door/bunker,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
+"obP" = (
+/obj/structure/statue/uranium/eng,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "obT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/footlocker,
@@ -34436,6 +35361,12 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/followers)
+"och" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "ocn" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/handrail/g_central{
@@ -34537,6 +35468,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bighornbunker)
+"oep" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "oer" = (
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
@@ -34591,6 +35527,10 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier5,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
+/area/f13/bunker)
+"ofj" = (
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/lowmid,
+/turf/open/floor/f13/wood,
 /area/f13/bunker)
 "ofp" = (
 /obj/structure/table/glass,
@@ -34887,6 +35827,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"okA" = (
+/obj/machinery/water_purifier,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "okC" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -35684,6 +36630,12 @@
 	icon_state = "darkrustysolid"
 	},
 /area/f13/bunker/bunkereight)
+"oBA" = (
+/obj/machinery/door/poddoor/shutters/radiation,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/radiation)
 "oBI" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -35818,6 +36770,12 @@
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"oEp" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "oEz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -36466,6 +37424,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/caves)
+"oRL" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "oRM" = (
 /obj/item/flag/outlaw,
 /turf/open/floor/f13{
@@ -36699,6 +37664,17 @@
 /obj/structure/lattice,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/enclave)
+"oWc" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhigh,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/superhighcargo,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "oWe" = (
 /obj/structure/simple_door/metal,
 /turf/open/floor/plating/tunnel,
@@ -36748,6 +37724,16 @@
 /obj/effect/spawner/lootdrop/f13/blueprintLowMid,
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/bunker/bunkereight)
+"oXN" = (
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/big{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "oXS" = (
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
@@ -36937,6 +37923,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/green/greenchess/greenchess2,
 /area/f13/enclave)
+"pbt" = (
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/big{
+	dir = 1
+	},
+/obj/structure/wreck/trash/brokenvendor,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "pbu" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -37021,6 +38017,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall/rust,
 /area/f13/brotherhood/operations)
+"pcZ" = (
+/obj/effect/decal/cleanable/robot_debris{
+	pixel_y = 22
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "pdc" = (
 /mob/living/simple_animal/hostile/giantantqueen,
 /turf/open/indestructible/ground/inside/mountain,
@@ -37613,6 +38617,12 @@
 /obj/structure/debris/v1,
 /turf/closed/wall/rust,
 /area/f13/followers)
+"pqJ" = (
+/obj/item/m2flamethrowertank,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "pqN" = (
 /obj/machinery/rnd/production/protolathe,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
@@ -37703,6 +38713,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"ptm" = (
+/obj/item/clothing/under/rank/civilian/lawyer/female/skirt,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "pto" = (
 /obj/item/storage/trash_stack,
 /obj/effect/decal/cleanable/dirt,
@@ -38508,6 +39524,12 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/f13/wood,
 /area/f13/sewer)
+"pJm" = (
+/obj/machinery/rnd/production/protolathe,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "pJo" = (
 /obj/structure/rack,
 /obj/item/locked_box/misc/money/all/high{
@@ -38810,6 +39832,14 @@
 /obj/effect/decal/cleanable/blood/gibs/human/body,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side,
 /area/f13/sewer)
+"pQj" = (
+/obj/machinery/vending/wallmed{
+	pixel_y = 30
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/radiation)
 "pQs" = (
 /obj/structure/girder,
 /obj/structure/grille/broken,
@@ -40284,6 +41314,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/brotherhood/rnd)
+"qpO" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "qpS" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -40706,6 +41740,16 @@
 /obj/effect/landmark/start/f13/vaultheadofsecurity,
 /turf/open/floor/carpet/royalblue,
 /area/f13/vault/security)
+"qxg" = (
+/obj/effect/spawner/lootdrop/f13/attachments,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
 "qxi" = (
 /obj/structure/cargocrate{
 	icon_state = "cargocrate4"
@@ -40730,6 +41774,15 @@
 "qxM" = (
 /turf/closed/wall/f13/wood,
 /area/f13/sewer)
+"qxU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "qxZ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
@@ -40907,6 +41960,18 @@
 	dir = 1
 	},
 /area/f13/vault/medical/breakroom)
+"qBE" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/obj/effect/spawner/lootdrop/f13/medical/vault/meds,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "qBI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -41118,6 +42183,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating/f13,
 /area/f13/brotherhood/reactor)
+"qFL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "qFR" = (
 /obj/structure/nest/ghoul{
 	layer = 2.07
@@ -42217,6 +43292,10 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"rbI" = (
+/obj/item/ingot/uranium,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "rcd" = (
 /obj/structure/spacevine,
 /turf/closed/wall/rust,
@@ -42256,6 +43335,16 @@
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
+"rcG" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = 6;
+	pixel_y = -5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -9
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "rcM" = (
 /obj/structure/table,
 /obj/item/book/granter/crafting_recipe/blueprint/fh_46,
@@ -42761,6 +43850,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	icon_state = "floorrustysolid"
+	},
+/area/f13/bunker)
+"rnn" = (
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
 	},
 /area/f13/bunker)
 "rnD" = (
@@ -43582,6 +44678,13 @@
 	dir = 8
 	},
 /area/f13/brotherhood/operations)
+"rFk" = (
+/obj/machinery/vending/wallmed{
+	pixel_x = -30
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "rFo" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass,
@@ -44134,6 +45237,12 @@
 /obj/structure/sign/radiation,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/followers)
+"rPL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
 "rPN" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/dark,
@@ -44178,6 +45287,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/yellow/corner,
 /area/f13/sewer)
+"rQe" = (
+/obj/machinery/water_purifier,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "rQg" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gibup1"
@@ -44192,6 +45308,12 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"rQv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "rQD" = (
 /obj/machinery/processor,
 /obj/structure/cable{
@@ -44211,6 +45333,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
+"rQP" = (
+/obj/effect/decal/cleanable/blood/old{
+	pixel_x = 12
+	},
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "rQV" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 1
@@ -44483,6 +45613,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
+"rWE" = (
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "rWQ" = (
 /obj/machinery/hydroponics/soil/pot,
 /obj/machinery/light,
@@ -44512,6 +45648,12 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"rXD" = (
+/obj/structure/simple_door/metal/ventilation,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "rXN" = (
 /obj/structure/window{
 	dir = 8
@@ -44928,6 +46070,15 @@
 "sgJ" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker/bunkerthree)
+"sgX" = (
+/obj/machinery/sleeper,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "sgY" = (
 /obj/machinery/light{
 	dir = 1;
@@ -44959,6 +46110,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker/bunkereight)
+"shz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "shP" = (
 /obj/structure/bed/oldalt,
 /obj/structure/lattice,
@@ -45642,6 +46800,13 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer/powered)
+"svT" = (
+/obj/item/locked_box/armor/tier3_5,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
 "swG" = (
 /obj/structure/handrail/g_central{
 	dir = 8;
@@ -46571,6 +47736,16 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"sPD" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/effect/spawner/lootdrop/f13/resourcespawner,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "sPS" = (
 /obj/effect/decal/waste,
 /obj/effect/decal/waste,
@@ -46799,6 +47974,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/ruin/powered)
+"sVb" = (
+/obj/structure/handrail/g_central{
+	dir = 1;
+	pixel_y = 23
+	},
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "sVu" = (
 /obj/item/bedsheet{
 	icon_state = "sheethos"
@@ -46891,6 +48074,15 @@
 	icon_state = "floordirty"
 	},
 /area/f13/bunker/bunkerthree)
+"sXD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/clothing/suit/bio_suit/hazmat,
+/obj/item/clothing/head/bio_hood/hazmat,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/f13{
+	icon_state = "floordirtysolid"
+	},
+/area/f13/bunker)
 "sXN" = (
 /obj/structure/wreck/trash/halftire,
 /obj/structure/barricade/bars,
@@ -47882,6 +49074,10 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/sewer)
+"trq" = (
+/obj/structure/simple_door/metal/ventilation,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "trD" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
@@ -47895,6 +49091,10 @@
 	},
 /turf/open/floor/plasteel/f13/stone,
 /area/f13/brotherhood/operating)
+"trS" = (
+/obj/structure/chair/stool/retro/tan,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "trV" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -49107,6 +50307,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/sewer)
+"tQl" = (
+/obj/machinery/door/poddoor/shutters/radiation,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/radiation)
 "tQo" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/plasteel/f13,
@@ -49547,6 +50754,14 @@
 	name = "dirty floor"
 	},
 /area/f13/sewer/powered)
+"tXH" = (
+/obj/effect/decal/waste{
+	pixel_x = -5;
+	pixel_y = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "tXL" = (
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/dirt/dark,
@@ -50639,6 +51854,13 @@
 	},
 /turf/open/floor/plasteel/sepia,
 /area/f13/vault/overseer)
+"usW" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "usX" = (
 /obj/structure/chair/right{
 	dir = 1
@@ -52004,6 +53226,17 @@
 "uSZ" = (
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/building/abandoned/o)
+"uTc" = (
+/obj/structure/table/reinforced,
+/obj/structure/sign/poster/contraband/smoke{
+	pixel_x = -32
+	},
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "uTm" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8;
@@ -52266,6 +53499,10 @@
 /obj/effect/spawner/lootdrop/low_tools,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
+"uZr" = (
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall/r_wall/rust,
+/area/f13/radiation)
 "uZx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52829,6 +54066,13 @@
 	dir = 4
 	},
 /area/f13/brotherhood/operating)
+"vkY" = (
+/obj/machinery/rnd/science_lab,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "vkZ" = (
 /mob/living/simple_animal/hostile/renegade/soldier,
 /turf/open/indestructible/ground/inside/subway,
@@ -53092,6 +54336,12 @@
 	dir = 8
 	},
 /area/f13/tcoms)
+"vpG" = (
+/obj/structure/table,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "vqd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
@@ -53634,6 +54884,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/overseer)
+"vAA" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/radiation)
 "vAI" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -54375,6 +55631,14 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/carpet/orange,
 /area/f13/vault/security)
+"vQl" = (
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "vQn" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plasteel/twenty,
@@ -54881,6 +56145,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/vault/science)
+"wak" = (
+/obj/structure/chair/booth{
+	icon_state = "bench";
+	dir = 8
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "wao" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -54968,6 +56239,13 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/sewer)
+"wcY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/robot_debris,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "wcZ" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_3"
@@ -55523,6 +56801,15 @@
 	dir = 4
 	},
 /area/f13/brotherhood/rnd)
+"wnn" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "wnF" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/armor/randomraiderhead,
@@ -55568,6 +56855,16 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/mirelurk,
 /turf/open/floor/plasteel/freezer,
 /area/f13/bunker)
+"wok" = (
+/obj/item/clothing/under/misc/poly_tanktop,
+/obj/item/clothing/under/misc/poly_tanktop,
+/obj/item/clothing/under/misc/poly_tanktop/female,
+/obj/item/clothing/under/misc/poly_tanktop/female,
+/obj/structure/closet/crate/footlocker,
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "woo" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/corner,
 /area/ruin/powered)
@@ -55624,6 +56921,10 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/bunker/bighornbunker)
+"wqj" = (
+/obj/structure/window/fulltile/ruins,
+/turf/closed/wall/r_wall/rust,
+/area/f13/radiation)
 "wql" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
 	dir = 4
@@ -55680,6 +56981,13 @@
 /obj/structure/barricade/bars,
 /turf/open/water,
 /area/f13/sewer)
+"wri" = (
+/obj/structure/chair/booth{
+	icon_state = "bench";
+	dir = 4
+	},
+/turf/open/floor/f13/wood,
+/area/f13/bunker)
 "wrm" = (
 /obj/item/clothing/mask/gas/sechailer,
 /obj/item/clothing/mask/gas/sechailer,
@@ -56138,6 +57446,10 @@
 "wAm" = (
 /turf/closed/wall/rust,
 /area/f13/building/firestation)
+"wAr" = (
+/obj/effect/turf_decal/vg_decals/radiation,
+/turf/closed/wall/r_wall/rust,
+/area/f13/sewer)
 "wAx" = (
 /obj/structure/table/reinforced,
 /obj/item/lock_construct,
@@ -56424,6 +57736,9 @@
 /obj/structure/barricade/bars,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bar/heaven)
+"wGw" = (
+/turf/closed/wall/r_wall/rust,
+/area/f13/radiation)
 "wGz" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -57204,6 +58519,10 @@
 	dir = 10
 	},
 /area/f13/vault/security)
+"wWf" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
+/area/f13/radiation)
 "wWm" = (
 /obj/machinery/plumbing/output,
 /obj/machinery/light/fo13colored/Red{
@@ -57299,6 +58618,11 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"wYf" = (
+/turf/open/floor/f13{
+	icon_state = "greenrustyfull"
+	},
+/area/f13/radiation)
 "wYx" = (
 /obj/structure/table,
 /obj/item/trash/plate,
@@ -57373,6 +58697,15 @@
 	},
 /turf/open/water,
 /area/f13/bunker/bunkereight)
+"wZs" = (
+/obj/machinery/computer/terminal{
+	dir = 8
+	},
+/obj/structure/table,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "wZt" = (
 /obj/structure/shelf_wood,
 /obj/effect/spawner/lootdrop/ammo/military,
@@ -57655,6 +58988,13 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker/bighornbunker)
+"xff" = (
+/mob/living/simple_animal/hostile/ghoul/glowing,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/f13{
+	icon_state = "darkrusty"
+	},
+/area/f13/radiation)
 "xfh" = (
 /obj/structure/rack/shelf_metal{
 	name = "Energy"
@@ -58059,6 +59399,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/ruin/powered)
+"xmN" = (
+/obj/machinery/autolathe,
+/turf/open/floor/f13{
+	color = "#ffe9de";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "xmO" = (
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
@@ -58580,6 +59928,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/vault/reactor)
+"xyb" = (
+/mob/living/simple_animal/hostile/securitron/sentrybot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
 "xyc" = (
 /mob/living/simple_animal/hostile/handy/assaultron/nsb,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -59392,6 +60747,14 @@
 /obj/effect/gibspawner/human,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
+"xPy" = (
+/mob/living/simple_animal/hostile/handy/protectron,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "xPD" = (
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood,
@@ -60209,6 +61572,10 @@
 	},
 /turf/open/floor/f13,
 /area/f13/vault)
+"yhN" = (
+/obj/structure/decoration/vent/rusty,
+/turf/closed/wall/r_wall/rust,
+/area/f13/bunker)
 "yhR" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -125249,45 +126616,45 @@ rHs
 rkI
 kse
 jYz
-lQD
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
-aQY
+sVC
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
+ehh
 aQY
 lWI
 lWI
@@ -125551,45 +126918,45 @@ kyK
 pNV
 csp
 jYz
-lQD
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+sVC
+qFL
+kpa
+jgP
+sXD
+sVC
+wGw
+wGw
+wGw
+ewW
+ewW
+ewW
+wGw
+wGw
+wGw
+wGw
+fOa
+nfX
+nfX
+oEp
+rXD
+fAU
+wGw
+vkY
+wYf
+wYf
+idZ
+nJn
+nJn
+mRU
+bWy
+bTJ
+eBB
+eBB
+mRU
+abs
+rPL
+svT
+ehh
 yhR
 yhR
 yhR
@@ -125851,47 +127218,47 @@ oht
 lQD
 kyK
 pNV
-csp
+sVb
 jYz
-lQD
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+sVC
+qxU
+iHt
+kpa
+aNY
+sVC
+bDz
+rFk
+oep
+muX
+fAU
+mUQ
+mUQ
+fAU
+eik
+wGw
+nfX
+nfX
+nfX
+nfX
+wGw
+jqu
+wGw
+pJm
+rQv
+lFe
+nJn
+lQg
+nJn
+fzy
+bWy
+bWy
+eBB
+eBB
+hDu
+ibV
+rPL
+rPL
+ehh
 yhR
 yhR
 yhR
@@ -126155,45 +127522,45 @@ kyK
 pNV
 csp
 jYz
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+sVC
+kKs
+ksZ
+kpa
+kpa
+bAa
+fAU
+bgh
+fAU
+tXH
+mUQ
+mUQ
+jVS
+rbI
+mUQ
+nmY
+nfX
+pqJ
+ccO
+ccO
+wGw
+lMd
+wGw
+jfQ
+rQv
+rQv
+laW
+laW
+xPy
+mRU
+bWy
+bWy
+bWy
+eBB
+mRU
+rPL
+rPL
+iFr
+ehh
 yhR
 yhR
 yhR
@@ -126457,45 +127824,45 @@ kyK
 pNV
 eyL
 jYz
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+sVC
+fZe
+kpa
+gyG
+kpa
+sVC
+iGU
+muX
+fAU
+fAU
+fAU
+fAU
+oep
+mUQ
+mUQ
+wGw
+ccO
+nfX
+jfv
+nfX
+wGw
+lPM
+wGw
+jMj
+dsH
+cew
+laW
+laW
+laW
+mRU
+wGw
+bWy
+bWy
+mRU
+mRU
+feO
+xyb
+rPL
+ehh
 yhR
 yhR
 yhR
@@ -126758,46 +128125,46 @@ lQD
 kyK
 pNV
 eyL
-jYz
-qBv
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+wAr
+sVC
+sVC
+sVC
+rnn
+bYQ
+sVC
+wGw
+wGw
+wGw
+gHS
+dfR
+gHS
+wGw
+gOn
+wGw
+wGw
+wGw
+wGw
+wGw
+rXD
+wGw
+hvl
+wGw
+okA
+rQv
+rQv
+wnn
+laW
+mYB
+lMc
+wGw
+bWy
+bWy
+ixl
+rPL
+rPL
+rPL
+ibV
+ehh
 yhR
 yhR
 yhR
@@ -127060,46 +128427,46 @@ lQD
 kyK
 pNV
 eyL
-jYz
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+kse
+awH
+sVC
+sVC
+qvt
+lkg
+sVC
+sVC
+sVC
+wGw
+wGw
+wGw
+wGw
+wGw
+jbP
+fRh
+nNe
+flq
+fAU
+fAU
+fAU
+wGw
+fAU
+wGw
+rQe
+rQv
+gRA
+laW
+cli
+laW
+oWc
+wGw
+bWy
+bWy
+mRU
+qxg
+rPL
+svT
+rPL
+ehh
 yhR
 yhR
 yhR
@@ -127362,46 +128729,46 @@ lQD
 kse
 pNV
 kse
-jYz
-qBv
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+kse
+awH
+awH
+sVC
+fmP
+qvt
+ofj
+wri
+sVC
+deu
+nFs
+kZJ
+jTX
+wGw
+jTX
+fRh
+pbt
+mUQ
+oRL
+mHR
+fAU
+wGw
+trq
+wGw
+wWf
+wGw
+wGw
+wGw
+wGw
+wGw
+wGw
+wGw
+bWy
+bWy
+mRU
+mRU
+mRU
+ixl
+mRU
+ehh
 yhR
 yhR
 yhR
@@ -127663,47 +129030,47 @@ yhR
 lQD
 kse
 pNV
-mUF
-jYz
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+kse
+awH
+kse
+awH
+sVC
+xhz
+qvt
+xhz
+mQF
+sVC
+nPn
+nBa
+hTG
+asy
+wqj
+liW
+pcZ
+oXN
+obP
+qpO
+qpO
+oep
+wGw
+cLS
+vAA
+mRG
+wGw
+meA
+nOT
+lOJ
+qBE
+shz
+wGw
+bWy
+bWy
+mRU
+sPD
+lzO
+xmN
+uTc
+ehh
 yhR
 yhR
 yhR
@@ -127966,46 +129333,46 @@ lQD
 kse
 pNV
 kse
-jYz
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+wAr
+kse
+awH
+bgc
+qvt
+xhz
+qvt
+wak
+sVC
+dFn
+rWE
+wZs
+fpy
+wqj
+jgX
+jTX
+oXN
+rbI
+mUQ
+fzS
+nfX
+wGw
+pQj
+fvZ
+eJO
+wWf
+acF
+wYf
+jiE
+wYf
+wYf
+obO
+bWy
+bWy
+mRU
+lyA
+ejR
+ejR
+ejR
+ehh
 yhR
 yhR
 yhR
@@ -128269,45 +129636,45 @@ kse
 pNV
 kse
 jYz
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+jYz
+awH
+sVC
+mvK
+vpG
+qvt
+mmY
+yhN
+jTX
+iTH
+iuZ
+jlU
+wqj
+jTX
+jgX
+igf
+rcG
+mHR
+fAU
+fpe
+wGw
+ejX
+fvZ
+ifS
+wGw
+sgX
+wYf
+wYf
+wok
+jBa
+wGw
+bWy
+bWy
+mRU
+jmo
+ejR
+ejR
+vQl
+ehh
 yhR
 yhR
 yhR
@@ -128571,45 +129938,45 @@ kse
 pNV
 kse
 jYz
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+jYz
+sVC
+sVC
+trS
+qvt
+qvt
+ghp
+sVC
+och
+jlU
+jTX
+iuZ
+wGw
+fnA
+jTX
+lzb
+evD
+mFr
+mFr
+mFr
+wGw
+wGw
+gkw
+uZr
+wGw
+wGw
+obO
+wGw
+wGw
+wGw
+wGw
+bWy
+bWy
+mRU
+mRU
+mRU
+hqs
+mRU
+ehh
 yhR
 yhR
 yhR
@@ -128873,45 +130240,45 @@ kse
 pNV
 kse
 jYz
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
+xlB
+sVC
+kRE
+qvt
+qvt
+fmP
+qvt
+sVC
+nMJ
+ptm
+jTX
+rQP
+iCE
+fRh
+fRh
+fRh
+jTX
+jTX
+jTX
+fRh
+fRh
+xff
+wcY
+fRh
+fRh
+fRh
+fRh
+fRh
+tQl
+eBB
+bWy
+bWy
+bWy
+bWy
+bWy
+bWy
+bWy
+bWy
+ehh
 yhR
 yhR
 yhR
@@ -129173,59 +130540,59 @@ yhR
 lQD
 kse
 pNV
-kse
+mUF
 jYz
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
+xlB
+sVC
+cpr
+xhz
+qvt
+qvt
+lTq
+sVC
+myB
+gXn
+ane
+iTH
+wGw
+usW
+fbk
+fRh
+lQA
+jgX
+jTX
+jTX
+fRh
+fRh
+fRh
+fRh
+fRh
+fRh
+fRh
+fRh
+oBA
+bWy
+bWy
+hjp
+bWy
+bWy
+bWy
+bWy
+bWy
+bWy
+ehh
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -129477,7 +130844,7 @@ kse
 pNV
 kse
 jYz
-bgK
+uvH
 xSK
 xSK
 xSK

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
@@ -242,6 +242,12 @@
 /obj/structure/barricade/bars,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/bunker)
+"adZ" = (
+/obj/structure/closet/crate/footlocker,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "aea" = (
 /obj/machinery/workbench,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid{
@@ -619,6 +625,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/sewer/powered)
+"akl" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = -2
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "akt" = (
 /obj/effect/spawner/lootdrop/f13/blueprintMid,
 /obj/item/book/granter/crafting_recipe/blueprint/trapper,
@@ -729,12 +742,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/sewer)
-"amX" = (
-/obj/machinery/light/fo13colored/Red,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "amZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -752,13 +759,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
-"anc" = (
-/obj/structure/rack/shelf_metal,
-/obj/effect/spawner/lootdrop/f13/blueprintHigh,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "ane" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -1780,10 +1780,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/sewer)
-"aGA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "aGI" = (
 /obj/item/clothing/glasses/sunglasses/blindfold,
 /obj/item/clothing/glasses/sunglasses/blindfold,
@@ -1834,12 +1830,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/dorms)
-"aIf" = (
-/obj/structure/debris/v4{
-	pixel_x = -27
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "aIg" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks,
@@ -2173,10 +2163,6 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/royalblue,
 /area/f13/vault/overseer)
-"aOH" = (
-/obj/structure/table,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "aOO" = (
 /obj/structure/wreck/trash/two_barrels{
 	pixel_y = 12
@@ -2341,12 +2327,6 @@
 	name = "dirty floor"
 	},
 /area/f13/building/abandoned/o)
-"aRO" = (
-/obj/machinery/autolathe/ammo,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "aRS" = (
 /obj/item/reagent_containers/food/drinks/bottle/instatea{
 	pixel_x = -9;
@@ -2816,6 +2796,10 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"bav" = (
+/obj/item/trash/candle,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "baz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -3173,6 +3157,12 @@
 	icon_state = "2-i"
 	},
 /area/f13/vault/science)
+"bid" = (
+/obj/machinery/pdapainter,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "bie" = (
 /obj/structure/simple_door/bunker,
 /turf/open/floor/plasteel/dark,
@@ -3190,12 +3180,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"bil" = (
-/obj/structure/closet/crate/bin/trashbin,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "bin" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3560,6 +3544,13 @@
 	},
 /turf/open/floor/plating/dirt/dark,
 /area/f13/radiation)
+"boH" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/bundle/f13/armor/combat/mk2,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "boI" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -3595,6 +3586,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"bpY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/den)
 "bqa" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -4115,12 +4110,6 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
-"bBG" = (
-/obj/structure/noticeboard{
-	pixel_y = 28
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "bBN" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -4988,6 +4977,14 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/maintenance/disposal)
+"bTh" = (
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "bTt" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -5344,6 +5341,13 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"cbb" = (
+/obj/structure/table/glass,
+/obj/item/gun/ballistic/revolver/colt357,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "cbs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -5809,15 +5813,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
-"cjs" = (
-/obj/structure/chair/folding{
-	dir = 8
-	},
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "cju" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
@@ -6150,10 +6145,6 @@
 /obj/structure/bed/dogbed,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
-"cqX" = (
-/obj/structure/rack/shelf_metal,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "cqZ" = (
 /obj/structure/wreck/trash/five_tires,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6682,6 +6673,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"cBL" = (
+/obj/structure/decoration/vent,
+/turf/closed/wall/f13/store/constructed,
+/area/f13/den)
 "cBT" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -6922,12 +6917,6 @@
 	icon_state = "floordirty"
 	},
 /area/f13/bunker/bunkerthree)
-"cGm" = (
-/obj/machinery/photocopier,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "cGq" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plating/tunnel,
@@ -6985,12 +6974,6 @@
 	dir = 1
 	},
 /area/f13/vault/diner)
-"cIa" = (
-/obj/structure/simple_door/metal/barred,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "cIf" = (
 /mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/indestructible/ground/inside/subway,
@@ -7164,6 +7147,10 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"cLp" = (
+/obj/structure/chair,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "cLr" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7728,6 +7715,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/storage)
+"cXj" = (
+/mob/living/simple_animal/hostile/eyebot,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "cXm" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -8454,6 +8445,14 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"dmG" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "dmZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spider/stickyweb,
@@ -8731,6 +8730,13 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/dorms)
+"dtk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/den)
 "dtl" = (
 /obj/effect/decal/cleanable/blood/old{
 	pixel_x = 12
@@ -8848,14 +8854,6 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/followers)
-"dwl" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "dwn" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/indestructible/ground/inside/subway,
@@ -8921,13 +8919,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
-"dxh" = (
-/obj/item/stack/sheet/mineral/uranium/twentyfive,
-/obj/structure/rack/shelf_metal,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "dxr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/toilet{
@@ -8949,6 +8940,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"dxz" = (
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "dxG" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt{
@@ -9788,13 +9787,6 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/subway,
 /area/maintenance/disposal)
-"dQm" = (
-/obj/structure/table/glass,
-/obj/item/gun/ballistic/automatic/m1garand/sks,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "dQs" = (
 /obj/item/scalpel,
 /obj/item/surgical_drapes,
@@ -10001,12 +9993,7 @@
 	},
 /area/f13/bunker/bunkerthree)
 "dVc" = (
-/obj/structure/guncase{
-	anchored = 1
-	},
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
-/obj/item/gun/ballistic/automatic/type93,
+/obj/structure/chair/office/light,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -10313,6 +10300,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"ebZ" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/druggie_pill,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "eck" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
@@ -10337,13 +10329,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/ruin/powered)
-"ecv" = (
-/obj/machinery/turnstile{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "ecL" = (
 /obj/effect/gibspawner/human,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -10386,6 +10371,17 @@
 /obj/structure/decoration/rads,
 /turf/closed/wall/rust,
 /area/f13/sewer)
+"edA" = (
+/obj/structure/guncase{
+	anchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/obj/item/gun/ballistic/automatic/type93,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "edM" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -10495,11 +10491,8 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "ehl" = (
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/turf/open/floor/plating/tunnel,
+/area/f13/followers)
 "ehq" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -11245,6 +11238,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
+"exa" = (
+/obj/structure/closet/cabinet,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "exg" = (
 /obj/structure/wreck/trash/four_barrels,
 /turf/open/indestructible/ground/inside/subway,
@@ -11724,10 +11727,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
-"eFJ" = (
-/obj/structure/chair,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "eFS" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -12341,6 +12340,14 @@
 /obj/structure/simple_door/metal,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
+"eRA" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "eRI" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/gutsy/flamer,
@@ -12848,13 +12855,6 @@
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/outpost)
-"fcC" = (
-/obj/structure/bed/wooden,
-/obj/item/bedsheet/blanket/blanketalt,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "fcJ" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -12965,6 +12965,14 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"ffr" = (
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ffB" = (
 /obj/structure/barricade/wooden/strong,
 /turf/open/floor/f13{
@@ -13297,6 +13305,14 @@
 "flV" = (
 /turf/closed/wall/f13/wood,
 /area/f13/building/abandoned/o)
+"fmd" = (
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "fmw" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -13371,6 +13387,9 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_y = 32
+	},
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -13546,12 +13565,6 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/custodial)
-"frK" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "frS" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
@@ -13979,6 +13992,9 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
+"fAu" = (
+/turf/closed/wall/f13/store/constructed,
+/area/f13/caves)
 "fAB" = (
 /mob/living/simple_animal/hostile/handy/protectron{
 	auto_fire_delay = 2;
@@ -14029,6 +14045,15 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer)
+"fAS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
+/turf/open/floor/plating/tunnel{
+	icon_state = "tunnelrusty"
+	},
+/area/f13/radiation)
 "fAU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/tunnel,
@@ -14454,12 +14479,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/reactor)
-"fKj" = (
-/obj/structure/chair/sofa/right,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "fKl" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/dirt,
@@ -14732,6 +14751,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker/bunkerthree)
+"fPW" = (
+/obj/machinery/light/fo13colored/Red{
+	dir = 8
+	},
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "fQi" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -15482,14 +15507,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
-"ggM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/simple_door/bunker,
-/obj/machinery/door/poddoor/shutters/preopen,
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 4
-	},
-/area/f13/den)
 "ggU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -16140,6 +16157,10 @@
 	},
 /turf/open/floor/holofloor/plating,
 /area/f13/brotherhood/armory)
+"gul" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/den)
 "guv" = (
 /obj/structure/barricade/security,
 /turf/open/floor/f13,
@@ -16661,10 +16682,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
-"gEn" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/white,
-/area/f13/den)
 "gEy" = (
 /mob/living/simple_animal/hostile/renegade/doc,
 /turf/open/indestructible/ground/inside/subway,
@@ -16678,6 +16695,12 @@
 /obj/structure/toilet,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkernine)
+"gEJ" = (
+/obj/machinery/autolathe,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "gEN" = (
 /obj/structure/closet/radiation{
 	anchored = 1
@@ -16712,6 +16735,14 @@
 	dir = 4
 	},
 /area/f13/vault/science)
+"gFP" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "gFT" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/waste{
@@ -17041,6 +17072,13 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
+"gLw" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "gLy" = (
 /turf/open/floor/f13{
 	dir = 8;
@@ -17064,11 +17102,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"gLQ" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "gMi" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/dark,
@@ -17513,6 +17546,12 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
+"gUC" = (
+/obj/machinery/photocopier,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "gUG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -17562,6 +17601,13 @@
 	name = "dirty floor"
 	},
 /area/f13/building/firestation)
+"gVG" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "gVI" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 3;
@@ -17650,6 +17696,9 @@
 /obj/structure/chair/sofa/right{
 	dir = 8
 	},
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -17668,13 +17717,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
-"gXw" = (
-/obj/structure/table/booth,
-/obj/item/storage/box/medicine/stimpaks/stimpaks5,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "gXL" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/vault/security/checkpoint)
@@ -18255,13 +18297,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"hhJ" = (
-/obj/structure/table/glass,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "hhM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -18320,6 +18355,9 @@
 /area/ruin/powered)
 "hjp" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
+/obj/machinery/light/fo13colored/Red{
+	dir = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "bluerustysolid"
 	},
@@ -19446,12 +19484,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
-"hGz" = (
-/obj/structure/table/reinforced,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "hGD" = (
 /mob/living/simple_animal/hostile/handy/gutsy{
 	faction = list("hostile")
@@ -19461,6 +19493,12 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/ruin/powered)
+"hGE" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "hGJ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -19479,6 +19517,12 @@
 	},
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"hHM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/fakelattice,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/plating/tunnel,
+/area/f13/radiation)
 "hHO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/poddoor/shutters/old{
@@ -19501,12 +19545,6 @@
 /obj/structure/junk/cabinet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
-"hId" = (
-/obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "hIj" = (
 /obj/item/storage/trash_stack{
 	icon_state = "Junk_9";
@@ -19678,13 +19716,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/f13/bunker/bunkersix)
-"hMi" = (
-/obj/structure/curtain{
-	color = "#363636"
-	},
-/obj/structure/simple_door/metal/barred,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "hMC" = (
 /obj/machinery/door/locked/easy/trapped,
 /turf/open/floor/plasteel/dark,
@@ -19841,10 +19872,6 @@
 	name = "dirty floor"
 	},
 /area/f13/building/firestation)
-"hQe" = (
-/obj/structure/campfire,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "hQl" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -19946,6 +19973,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/brotherhood/operations)
+"hSc" = (
+/obj/structure/debris/v4,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "hSf" = (
 /obj/structure/sign/flag_china,
 /turf/closed/wall/rust,
@@ -19986,6 +20017,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/brotherhood/rnd)
+"hTt" = (
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "hTu" = (
 /obj/machinery/vending/dinnerware,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20316,6 +20354,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"hYM" = (
+/obj/structure/table/glass,
+/obj/item/gun/ballistic/automatic/m1garand/sks,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "hYN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/simple_door/metal/barred,
@@ -20375,6 +20420,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"iaR" = (
+/obj/structure/fluff/rug/rug_rubber{
+	icon = 'icons/fallout/objects/64x64_rugs.dmi';
+	icon_state = "rug_fancy"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "iaT" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/glass,
@@ -21369,9 +21423,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/corner,
 /area/f13/vault/atrium)
 "iwH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/f13/store/constructed,
-/area/f13/den)
+/obj/structure/debris/v4{
+	pixel_x = -27
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "iwL" = (
 /obj/structure/fluff/rails,
 /obj/structure/handrail/g_central{
@@ -21520,14 +21576,6 @@
 /mob/living/simple_animal/hostile/ghoul/scorched/ranged,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker/bighornbunker)
-"iAr" = (
-/obj/structure/debris/v3{
-	layer = 2;
-	pixel_x = -10;
-	pixel_y = -4
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "iAv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22004,8 +22052,11 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "iLR" = (
-/turf/closed/wall/f13/store/constructed,
-/area/f13/caves)
+/obj/structure/simple_door/house,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "iLS" = (
 /obj/structure/window{
 	dir = 8
@@ -23150,11 +23201,6 @@
 /obj/effect/spawner/lootdrop/druggie_pill,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/outpost)
-"jkV" = (
-/obj/effect/decal/cleanable/crayon,
-/obj/effect/gibspawner/human/bodypartless,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "jkW" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -23165,13 +23211,6 @@
 	},
 /turf/open/water,
 /area/f13/radiation)
-"jlb" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/alcoholspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "jlR" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
@@ -23488,6 +23527,10 @@
 /obj/structure/flora/grass/jungle,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
+"jsJ" = (
+/obj/structure/campfire,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "jsM" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkerthree)
@@ -23587,6 +23630,13 @@
 /obj/machinery/door/locked/easy/maybe_trapped,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"jtW" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "jtX" = (
 /obj/structure/wreck/trash/five_tires{
 	pixel_y = 11
@@ -23721,22 +23771,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer/powered)
-"jwn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
-"jww" = (
-/obj/structure/simple_door/bunker,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/poddoor/shutters/preopen,
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 8
-	},
-/area/f13/den)
 "jwH" = (
 /obj/machinery/workbench/advanced,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -24082,12 +24116,6 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
-"jFg" = (
-/obj/machinery/vending/snack,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "jFi" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/bunker/bunkereight)
@@ -24466,10 +24494,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/f13/bunker/bunkersix)
-"jNO" = (
-/mob/living/simple_animal/hostile/eyebot,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "jNP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -24507,11 +24531,6 @@
 /obj/structure/girder/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/vault)
-"jOG" = (
-/obj/machinery/turnstile,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "jOH" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -24652,12 +24671,6 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
-"jSA" = (
-/obj/machinery/pdapainter,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "jSD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/garbagetomid,
@@ -24742,10 +24755,8 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "jUO" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 1
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "jUT" = (
@@ -25236,6 +25247,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"keP" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "kfa" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -25369,6 +25386,14 @@
 	dir = 4
 	},
 /area/f13/brotherhood/rnd)
+"khr" = (
+/obj/structure/fireaxecabinet{
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "khv" = (
 /obj/effect/turf_decal/box,
 /obj/effect/decal/cleanable/dirt{
@@ -25432,13 +25457,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless/floorgrime,
 /area/f13/bunker/bunkerthree)
-"khW" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "kib" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb,
@@ -25484,8 +25502,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/radiation)
 "kjb" = (
-/turf/closed/indestructible/f13/obsidian,
-/area/f13/bunker/bunkerthree)
+/obj/structure/chair/folding{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "kjA" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/dark,
@@ -26084,6 +26107,10 @@
 /obj/structure/wreck/car,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"ktm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/store/constructed,
+/area/f13/den)
 "ktv" = (
 /obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/indestructible/ground/inside/subway,
@@ -26192,27 +26219,10 @@
 /obj/structure/simple_door/repaired,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
-"kvR" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/spawner/lootdrop/f13/cash_random_high,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "kwa" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
-"kwh" = (
-/obj/structure/fluff/hedge{
-	name = "plastic hedge"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "kwu" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -26683,14 +26693,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/vault/custodial)
-"kFE" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 28
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "kFI" = (
 /obj/structure/chair{
 	dir = 4
@@ -27228,10 +27230,6 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered)
-"kQj" = (
-/obj/item/trash/candle,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "kQk" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -27319,8 +27317,12 @@
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/brotherhood/rnd)
 "kRs" = (
-/turf/closed/wall/f13/store/constructed,
-/area/f13/den)
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/obj/structure/simple_door/metal/barred,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "kRy" = (
 /obj/machinery/light{
 	dir = 4;
@@ -27367,17 +27369,6 @@
 	dir = 4
 	},
 /area/f13/vault/science)
-"kRM" = (
-/obj/structure/table/reinforced,
-/obj/item/statuebust,
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "kRQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/small/bed2,
@@ -27413,14 +27404,6 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker/bunkerthree)
-"kSG" = (
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "kSH" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/decal/cleanable/dirt,
@@ -27446,6 +27429,15 @@
 /obj/structure/spacevine,
 /turf/open/floor/plating/dirt,
 /area/f13/caves)
+"kTl" = (
+/obj/structure/table,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
+	},
+/obj/effect/spawner/lootdrop/druggie_pill,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "kTp" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -27532,6 +27524,14 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/enclave)
+"kUG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/den)
 "kUK" = (
 /turf/open/floor/plating/tunnel{
 	icon_state = "tunnelrusty"
@@ -27879,6 +27879,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
+"lam" = (
+/obj/item/stack/sheet/mineral/uranium/twentyfive,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "lax" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/hooch,
@@ -28079,6 +28086,11 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"ldM" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/den)
 "ldO" = (
 /obj/item/radio/intercom{
 	dir = 8;
@@ -28272,13 +28284,6 @@
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"ljb" = (
-/obj/structure/bedsheetbin,
-/obj/structure/table/booth,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "ljc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28315,15 +28320,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
-"ljJ" = (
-/obj/machinery/power/apc/fusebox/east,
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "ljL" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/subway,
@@ -28715,13 +28711,6 @@
 	icon_state = "housebase"
 	},
 /area/f13/bunker/bighornbunker)
-"lrk" = (
-/obj/structure/table/glass,
-/obj/effect/spawner/bundle/f13/armor/combat/mk2,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "lrw" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/assaultron,
@@ -28748,6 +28737,15 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/redchess,
 /area/f13/vault/security/checkpoint)
+"lsu" = (
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "lsy" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/reagent_dispensers/barrel/four,
@@ -29136,6 +29134,9 @@
 	pixel_x = -30
 	},
 /obj/effect/spawner/lootdrop/f13/resourcespawner,
+/obj/machinery/light/fo13colored/Red{
+	dir = 8
+	},
 /turf/open/floor/f13{
 	color = "#ffe9de";
 	icon_state = "darkrusty";
@@ -29635,12 +29636,6 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker/bunkerthree)
-"lKp" = (
-/obj/structure/punching_bag,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "lKt" = (
 /obj/structure/table/wood/poker,
 /obj/item/locked_box/weapon/range/unique,
@@ -29872,16 +29867,13 @@
 /area/f13/vault/atrium)
 "lOJ" = (
 /mob/living/simple_animal/hostile/handy/gutsy,
+/obj/machinery/light/fo13colored/Red{
+	dir = 8
+	},
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
 /area/f13/radiation)
-"lOK" = (
-/obj/structure/chair/stool/retro/black,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "lOM" = (
 /obj/structure/rack,
 /obj/effect/spawner/bundle/f13/armor/combat/mk2,
@@ -30225,16 +30217,6 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/sewer)
-"lTY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/terminal{
-	dir = 1;
-	termtag = "Business"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "lUc" = (
 /obj/structure/lattice{
 	layer = 3
@@ -30621,13 +30603,6 @@
 /obj/machinery/light/fo13colored/Red,
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker/bunkerthree)
-"mbY" = (
-/obj/structure/debris/v3{
-	pixel_x = -12;
-	pixel_y = -10
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "mbZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
@@ -30780,11 +30755,6 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/enclave)
-"mfy" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/turf/open/floor/plasteel/f13/vault_floor/red/side,
-/area/f13/den)
 "mfE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/indestructible/opshuttle{
@@ -32572,6 +32542,14 @@
 	icon_state = "yellowdirtyfull"
 	},
 /area/f13/bunker/bunkerfive)
+"mPc" = (
+/obj/structure/debris/v3{
+	layer = 2;
+	pixel_x = -10;
+	pixel_y = -4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "mPd" = (
 /obj/structure/showcase/horrific_experiment{
 	icon_state = "pod_1"
@@ -33071,6 +33049,13 @@
 /obj/item/reagent_containers/glass/bucket/plastic,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault/garden)
+"mZp" = (
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "mZw" = (
 /obj/effect/mob_spawn/human/corpse/charredskeleton,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -33355,6 +33340,12 @@
 	},
 /turf/open/water,
 /area/f13/radiation)
+"nfv" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nfK" = (
 /obj/structure/closet/cabinet{
 	anchored = 1
@@ -33710,6 +33701,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/atrium)
+"nmk" = (
+/obj/structure/chair/sofa/left,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nmm" = (
 /obj/structure/sink/kitchen{
 	desc = "Strictly for filling up mop buckets.";
@@ -33851,6 +33848,15 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/sewer)
+"nqu" = (
+/obj/machinery/power/apc/fusebox/east,
+/obj/structure/cable/orange{
+	icon_state = "0-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nqA" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 9
@@ -33944,6 +33950,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/neutral/side,
 /area/f13/sewer)
+"nsn" = (
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/obj/effect/overlay/junk/curtain,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nsx" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
@@ -34278,6 +34291,17 @@
 "nyy" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/bunker)
+"nyP" = (
+/obj/structure/fluff/rug/rug_rubber{
+	icon = 'icons/fallout/objects/64x64_rugs.dmi';
+	icon_state = "rug_red";
+	pixel_y = -30;
+	pixel_x = 13
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nyW" = (
 /obj/structure/simple_door/tentflap_cloth,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -34505,12 +34529,6 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/outpost)
-"nCO" = (
-/obj/structure/closet/crate/footlocker,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "nCU" = (
 /mob/living/simple_animal/hostile/handy/gutsy/nsb,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -34609,15 +34627,6 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
-"nEm" = (
-/obj/structure/fluff/rug/rug_rubber{
-	icon = 'icons/fallout/objects/64x64_rugs.dmi';
-	icon_state = "rug_fancy"
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "nEy" = (
 /obj/structure/window/reinforced/fulltile/indestructable{
 	can_be_unanchored = 0
@@ -34678,6 +34687,9 @@
 "nFs" = (
 /obj/effect/decal/cleanable/blood/old{
 	icon_state = "floor3"
+	},
+/obj/machinery/light/fo13colored/Red{
+	dir = 8
 	},
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
@@ -35143,11 +35155,10 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
 "nPV" = (
-/obj/structure/fluff/rug/rug_rubber{
-	icon = 'icons/fallout/objects/64x64_rugs.dmi';
-	icon_state = "rug_red";
-	pixel_y = -30;
-	pixel_x = 13
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
 	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -35523,6 +35534,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/radiation)
+"nXU" = (
+/obj/effect/overlay/junk/curtain,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nXY" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/food/drinks/mug/coco{
@@ -35578,6 +35595,13 @@
 	icon_state = "greenfull"
 	},
 /area/f13/building/abandoned/o)
+"nZg" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nZi" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random,
 /turf/open/indestructible/ground/inside/subway,
@@ -35995,6 +36019,13 @@
 	},
 /turf/open/water,
 /area/f13/sewer)
+"ogL" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/blanket/blanketalt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ogN" = (
 /obj/machinery/porta_turret/f13/turret_556/hostile,
 /turf/open/floor/f13{
@@ -36122,14 +36153,6 @@
 	desc = "This one looks like it won't ever open."
 	},
 /area/ruin/powered)
-"oiL" = (
-/obj/structure/fireaxecabinet{
-	pixel_y = 28
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "oiN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/barricade/wooden/strong,
@@ -36558,6 +36581,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red,
 /area/f13/brotherhood/armory)
+"oqX" = (
+/obj/structure/punching_bag,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "oqY" = (
 /obj/machinery/power/terminal,
 /obj/machinery/power/terminal{
@@ -36694,6 +36723,15 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/bunker/bunkerthree)
+"oti" = (
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "oty" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/small{
@@ -36946,21 +36984,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
-"oAf" = (
-/obj/item/candle{
-	pixel_y = -13;
-	pixel_x = 14
-	},
-/obj/item/candle{
-	pixel_y = -10;
-	pixel_x = 9
-	},
-/obj/item/candle{
-	pixel_y = -2;
-	pixel_x = 13
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "oAh" = (
 /obj/structure/rack,
 /obj/item/stack/spacecash/c1000,
@@ -37066,11 +37089,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
-"oCq" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/druggie_pill,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "oCr" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/mortar{
@@ -37175,13 +37193,6 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
-"oEv" = (
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/obj/effect/overlay/junk/curtain,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "oEz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -37364,14 +37375,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
-"oHS" = (
-/obj/structure/chair/folding{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "oIb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/destructible/tribal_torch/wall{
@@ -37686,12 +37689,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
-"oPG" = (
-/obj/machinery/autolathe,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "oPI" = (
 /mob/living/simple_animal/hostile/raider/junker,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -37962,6 +37959,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
+"oUI" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/den)
 "oUK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -38581,12 +38584,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
-"phk" = (
-/obj/effect/overlay/junk/curtain,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "phl" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/barricade/concrete,
@@ -39391,14 +39388,6 @@
 	dir = 9
 	},
 /area/f13/vault/atrium)
-"pyo" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "pyr" = (
 /obj/structure/barricade/train,
 /turf/closed/indestructible/f13vaultrusted,
@@ -40079,6 +40068,12 @@
 /obj/effect/spawner/lootdrop/mre,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer/powered)
+"pMF" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "pMI" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -40367,13 +40362,6 @@
 "pRI" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
-"pRT" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/lootdrop/f13/cash_random_med,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "pRU" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -42174,6 +42162,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue,
 /area/f13/vault/overseer)
+"qwW" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "qxd" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -42181,6 +42173,13 @@
 /obj/effect/landmark/start/f13/vaultheadofsecurity,
 /turf/open/floor/carpet/royalblue,
 /area/f13/vault/security)
+"qxe" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "qxg" = (
 /obj/effect/spawner/lootdrop/f13/attachments,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -42218,6 +42217,9 @@
 "qxU" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/pew{
+	dir = 1
+	},
+/obj/machinery/light/fo13colored/Red{
 	dir = 1
 	},
 /turf/open/floor/f13{
@@ -42370,6 +42372,10 @@
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/followers)
+"qBg" = (
+/obj/structure/table,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "qBp" = (
 /obj/structure/closet/crate/radiation,
 /obj/item/geiger_counter,
@@ -42556,6 +42562,12 @@
 "qEd" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/side,
 /area/ruin/powered)
+"qEr" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "qEs" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/light/small{
@@ -42906,15 +42918,6 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
-"qKR" = (
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/port_gen/pacman/super,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "qKX" = (
 /obj/machinery/ticket_machine{
 	name = "busted ticket machine";
@@ -43699,6 +43702,18 @@
 	dir = 6
 	},
 /area/f13/brotherhood/chemistry)
+"ral" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ran" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/sheet/metal/ten,
@@ -44816,12 +44831,6 @@
 	icon_state = "dark"
 	},
 /area/f13/building/abandoned/o)
-"ryg" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "rys" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -44936,6 +44945,13 @@
 /obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/plasteel/f13/vault_floor/blue/bluechess,
 /area/f13/vault/medical/surgery)
+"rBM" = (
+/obj/machinery/turnstile{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/den)
 "rBO" = (
 /obj/structure/handrail/g_central{
 	layer = 2.7;
@@ -45725,6 +45741,14 @@
 	},
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/building/abandoned/o)
+"rPW" = (
+/obj/structure/fluff/hedge{
+	name = "plastic hedge"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "rPX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic{
@@ -46375,13 +46399,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
 /area/f13/enclave)
-"sel" = (
-/obj/structure/table,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "sem" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -47391,10 +47408,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
 /area/f13/enclave)
-"sze" = (
-/obj/structure/decoration/vent,
-/turf/closed/wall/f13/store/constructed,
-/area/f13/den)
 "szl" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/water,
@@ -47436,16 +47449,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/outpost)
-"szG" = (
-/obj/structure/closet/cabinet,
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "szK" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/wreck/trash/two_tire,
@@ -47786,6 +47789,14 @@
 "sGX" = (
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/sewer/powered)
+"sHc" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/item/crafting/coffee_pot,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "sHe" = (
 /obj/structure/lattice,
 /obj/structure/wreck/trash/two_barrels,
@@ -47978,6 +47989,12 @@
 	},
 /turf/open/water,
 /area/f13/outpost)
+"sLM" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "sLS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/debris/v3,
@@ -48146,10 +48163,8 @@
 /turf/open/floor/f13/wood,
 /area/f13/vault/dormitory)
 "sOA" = (
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
+/turf/closed/indestructible/f13/obsidian,
+/area/f13/bunker/bunkerthree)
 "sOF" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -49791,18 +49806,6 @@
 "twn" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
-"twz" = (
-/obj/structure/closet/fridge,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "twD" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -49824,6 +49827,10 @@
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
+"txj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/den)
 "txn" = (
 /obj/structure/closet/locker/oldstyle,
 /obj/item/clothing/suit/bio_suit/enclave,
@@ -50009,7 +50016,9 @@
 	},
 /area/ruin/powered)
 "tAh" = (
-/obj/structure/table/booth,
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
@@ -50092,14 +50101,6 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/vault,
 /area/f13/vault/security/armory)
-"tCA" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "tCE" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/bundle/f13/greasegun,
@@ -50107,6 +50108,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"tCV" = (
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "tCZ" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/water,
@@ -50571,6 +50578,13 @@
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"tMs" = (
+/obj/structure/table/booth,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "tMQ" = (
 /obj/structure/reagent_dispensers/barrel/three,
 /turf/open/water,
@@ -50723,6 +50737,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow{
 	icon_state = "yellowrustyfull"
 	},
+/area/f13/sewer)
+"tPi" = (
+/obj/structure/debris/v3{
+	pixel_x = -12;
+	pixel_y = -10
+	},
+/turf/open/indestructible/ground/inside/subway,
 /area/f13/sewer)
 "tPj" = (
 /obj/structure/table/booth,
@@ -51110,12 +51131,6 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
-"tVe" = (
-/obj/structure/simple_door/house,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "tVt" = (
 /turf/closed/indestructible/opshuttle{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -51241,6 +51256,21 @@
 	dir = 4
 	},
 /area/f13/brotherhood/operations)
+"tWZ" = (
+/obj/item/candle{
+	pixel_y = -13;
+	pixel_x = 14
+	},
+/obj/item/candle{
+	pixel_y = -10;
+	pixel_x = 9
+	},
+/obj/item/candle{
+	pixel_y = -2;
+	pixel_x = 13
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "tXg" = (
 /obj/structure/simple_door/bunker/glass,
 /turf/open/indestructible/ground/inside/subway,
@@ -51809,11 +51839,28 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"ukd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/f13{
+	color = "#d9c4b9";
+	icon_state = "darkrusty";
+	name = "dirty floor"
+	},
+/area/f13/radiation)
 "ukn" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/raider_leather,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker)
+"uko" = (
+/obj/structure/simple_door/bunker,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters/preopen,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/den)
 "ukq" = (
 /obj/machinery/porta_turret/f13/turret_9mm/burstfire/raider,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -51983,6 +52030,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
+"umE" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "umH" = (
 /obj/machinery/microwave{
 	pixel_y = 8
@@ -52108,14 +52163,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/side,
 /area/f13/brotherhood/armory)
-"uoN" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "uoQ" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/item/toy/figure/botanist{
@@ -52221,6 +52268,12 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/followers)
+"uqi" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "uqn" = (
 /obj/machinery/light{
 	dir = 1;
@@ -52384,8 +52437,10 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "utp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
 /area/f13/den)
 "utw" = (
 /obj/effect/decal/waste{
@@ -52550,6 +52605,12 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
+"uvQ" = (
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "uvR" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/lattice/catwalk,
@@ -52575,6 +52636,17 @@
 	},
 /turf/open/water,
 /area/f13/outpost)
+"uwe" = (
+/obj/structure/table/reinforced,
+/obj/item/statuebust,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "uwi" = (
 /obj/machinery/light/floor,
 /turf/open/floor/plating/rust,
@@ -52931,6 +53003,14 @@
 	icon_state = "redmark"
 	},
 /area/f13/sewer/powered)
+"uCA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker,
+/obj/machinery/door/poddoor/shutters/preopen,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/den)
 "uCV" = (
 /obj/machinery/light{
 	dir = 1;
@@ -54013,6 +54093,12 @@
 /obj/effect/spawner/lootdrop/low_tools,
 /turf/open/floor/plasteel/f13/vault_floor/yellow/yellowchess,
 /area/f13/brotherhood/reactor)
+"uZq" = (
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "uZr" = (
 /obj/structure/sign/poster/contraband/tools,
 /turf/closed/wall/r_wall/rust,
@@ -55022,12 +55108,6 @@
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/plasteel/f13,
 /area/f13/sewer)
-"vta" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "vtb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -55155,12 +55235,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
-"vuX" = (
-/obj/structure/chair/office/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "vuY" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -55363,6 +55437,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker)
+"vzj" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "vzn" = (
 /obj/structure/sign/flag_america_pristine{
 	pixel_y = 29
@@ -55412,6 +55492,9 @@
 /area/f13/vault/overseer)
 "vAA" = (
 /mob/living/simple_animal/hostile/handy/protectron,
+/obj/machinery/light/fo13colored/Red{
+	dir = 8
+	},
 /turf/open/floor/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -55546,15 +55629,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
-"vDA" = (
-/obj/structure/table,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8;
-	light_color = "#f4e3b0"
-	},
-/obj/effect/spawner/lootdrop/druggie_pill,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "vDK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55562,7 +55636,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/garden)
 "vDS" = (
-/obj/structure/chair/sofa/left,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -55626,11 +55702,7 @@
 	},
 /area/f13/building/abandoned/o)
 "vFV" = (
-/obj/structure/table/glass,
-/obj/item/gun/ballistic/revolver/colt357,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
+/turf/closed/wall/f13/store/constructed,
 /area/f13/den)
 "vFZ" = (
 /turf/open/floor/f13{
@@ -56036,10 +56108,6 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
-"vNs" = (
-/obj/structure/debris/v4,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "vNx" = (
 /obj/machinery/porta_turret/f13/turret_556/burstfire/raider{
 	dir = 6
@@ -56103,14 +56171,6 @@
 "vOm" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
-"vOn" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "vOs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic{
@@ -56513,13 +56573,6 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/brotherhood/operations)
-"vWv" = (
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8;
-	light_color = "#f4e3b0"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "vWB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56549,6 +56602,11 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/enclave)
+"vXg" = (
+/obj/machinery/turnstile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/den)
 "vXm" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -56709,6 +56767,7 @@
 	icon_state = "bench";
 	dir = 8
 	},
+/obj/machinery/light/fo13colored/Red,
 /turf/open/floor/f13/wood,
 /area/f13/bunker)
 "wao" = (
@@ -57201,6 +57260,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"wkY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "bluerustysolid"
+	},
+/area/f13/radiation)
 "wlk" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel/dark,
@@ -57621,6 +57689,11 @@
 	},
 /turf/open/floor/holofloor/plating,
 /area/f13/brotherhood/armory)
+"wrt" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/den)
 "wrD" = (
 /obj/structure/sign/poster/prewar/poster80{
 	pixel_x = 32
@@ -58463,14 +58536,6 @@
 	icon_state = "floordirty"
 	},
 /area/f13/bunker/bunkerthree)
-"wJM" = (
-/obj/structure/chair/folding{
-	dir = 4
-	},
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "wJR" = (
 /turf/closed/indestructible/f13vaultrusted{
 	name = "rusty reinforced wall"
@@ -58955,14 +59020,6 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/radiation)
-"wSy" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
-/obj/item/crafting/coffee_pot,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "wSH" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -59176,14 +59233,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
-"wXH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	brightness = 7;
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/floor,
-/area/f13/den)
 "wXX" = (
 /mob/living/simple_animal/hostile/handy/robobrain{
 	auto_fire_delay = 2;
@@ -59795,9 +59844,6 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
-"xiT" = (
-/turf/open/floor/plating/tunnel,
-/area/f13/followers)
 "xiZ" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -60317,12 +60363,12 @@
 	},
 /area/f13/followers)
 "xth" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2";
-	pixel_y = -2
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
+/area/f13/den)
 "xtj" = (
 /obj/effect/landmark/start/f13/vaultscientist,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -60390,6 +60436,12 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/enclave)
+"xuW" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "xvo" = (
 /mob/living/simple_animal/hostile/supermutant/meleemutant,
 /obj/effect/decal/cleanable/dirt,
@@ -60496,14 +60548,6 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
-"xxR" = (
-/obj/structure/debris/v3{
-	pixel_x = -15;
-	pixel_y = 6
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/sewer)
 "xxW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -60857,6 +60901,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/enclave)
+"xDz" = (
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "xDI" = (
 /obj/structure/kitchenspike,
 /obj/effect/gibspawner/human/bodypartless,
@@ -60889,6 +60939,14 @@
 /obj/structure/lattice,
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
+"xEe" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "xEh" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/indestructible/ground/inside/mountain,
@@ -60931,6 +60989,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/royalblue,
 /area/f13/vault/overseer)
+"xFE" = (
+/obj/effect/decal/cleanable/crayon,
+/obj/effect/gibspawner/human/bodypartless,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "xFF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/wreck/trash/brokenvendor,
@@ -62030,9 +62093,10 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
 "yem" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/f13/vault_floor/red/side{
-	dir = 1
+/obj/structure/bedsheetbin,
+/obj/structure/table/booth,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
 /area/f13/den)
 "yeo" = (
@@ -62116,6 +62180,13 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/sewer/powered)
+"yfL" = (
+/obj/structure/table,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "yfP" = (
 /obj/structure/table/wood/settler,
 /obj/item/paper_bin{
@@ -62130,13 +62201,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/building/abandoned/o)
-"yfU" = (
-/mob/living/simple_animal/hostile/ghoul/soldier/armored,
-/obj/machinery/light,
-/turf/open/floor/f13{
-	icon_state = "floorrusty"
-	},
-/area/f13/den)
 "ygn" = (
 /obj/effect/landmark/start/f13/offduty,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -63900,7 +63964,7 @@ tnz
 tnz
 tnz
 tnz
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -64202,7 +64266,7 @@ tnz
 sgJ
 sgJ
 cuW
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -64504,7 +64568,7 @@ cuW
 obL
 sgJ
 sgJ
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -64806,7 +64870,7 @@ cuW
 xXO
 nHO
 sgJ
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -65108,7 +65172,7 @@ cuW
 fqJ
 pRI
 cuW
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -65410,7 +65474,7 @@ cuW
 tDe
 kwC
 cuW
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -65712,7 +65776,7 @@ cuW
 aIn
 gzw
 cuW
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -66014,7 +66078,7 @@ cuW
 eAl
 gsv
 cuW
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -66316,7 +66380,7 @@ kwC
 iWy
 pHw
 sgJ
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -66618,7 +66682,7 @@ ryd
 pas
 gmX
 sgJ
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -66920,7 +66984,7 @@ cuW
 tVR
 aIg
 cuW
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -67222,7 +67286,7 @@ tVR
 kSE
 txM
 cuW
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -67524,7 +67588,7 @@ cuW
 ryd
 sgJ
 cuW
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -67826,7 +67890,7 @@ cuW
 eAl
 mHN
 cuW
-kjb
+sOA
 yhR
 yhR
 yhR
@@ -68105,30 +68169,30 @@ lQD
 kse
 kse
 dCc
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
-kjb
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
+sOA
 yhR
 yhR
 yhR
@@ -79581,17 +79645,17 @@ lQD
 kse
 kse
 lQD
-xxR
-vWv
+dxz
+gLw
 kse
-aIf
+iwH
 sNQ
-oCq
-oCq
-aOH
-vDA
+ebZ
+ebZ
+qBg
+kTl
 kse
-iAr
+mPc
 lQD
 kse
 kse
@@ -79883,13 +79947,13 @@ lQD
 kse
 kse
 lQD
-cqX
-jNO
+qwW
+cXj
 kse
 kse
 kse
 kse
-eFJ
+cLp
 kse
 kse
 kse
@@ -80185,7 +80249,7 @@ lQD
 kse
 kse
 lQD
-cqX
+qwW
 kse
 kse
 kse
@@ -80486,19 +80550,19 @@ mIB
 lQD
 kse
 kse
-hMi
+kRs
 kse
 kse
 kse
 kse
 kse
 kse
-oAf
-kQj
+tWZ
+bav
 kse
 kse
 kse
-hMi
+kRs
 kse
 kse
 lQD
@@ -80788,19 +80852,19 @@ mIB
 lQD
 kse
 kse
-hMi
+kRs
 kse
 kse
 kse
 kse
 kse
 kse
-kQj
-jkV
+bav
+xFE
 kse
 kse
 kse
-hMi
+kRs
 kse
 kse
 lQD
@@ -81091,11 +81155,11 @@ lQD
 kse
 kse
 lQD
-bBG
+uZq
 kse
 kse
 kse
-hQe
+jsJ
 kse
 kse
 kse
@@ -81395,7 +81459,7 @@ kse
 lQD
 kse
 kse
-frK
+hGE
 kse
 kse
 kse
@@ -81695,17 +81759,17 @@ lQD
 kse
 kse
 lQD
-vNs
-oCq
-sel
-aOH
-oCq
+hSc
+ebZ
+yfL
+qBg
+ebZ
 kse
-aIf
-mbY
+iwH
+tPi
 kse
-aIf
-xth
+iwH
+akl
 lQD
 kse
 kse
@@ -82005,7 +82069,7 @@ lQD
 lQD
 lQD
 sNQ
-aIf
+iwH
 lQD
 lQD
 lQD
@@ -83205,17 +83269,17 @@ bgK
 bgK
 bgK
 bgK
-iLR
-kRs
-kRs
-kRs
-kRs
-kRs
-kRs
-iwH
-ggM
-iwH
-kRs
+fAu
+vFV
+vFV
+vFV
+vFV
+vFV
+vFV
+ktm
+uCA
+ktm
+vFV
 lQD
 kse
 kse
@@ -83507,17 +83571,17 @@ cNy
 cNy
 cNy
 cNy
-iLR
-qKR
-dxh
-sze
-sOA
-hId
-hGz
-utp
-gEn
-yem
-kRs
+fAu
+lsu
+lam
+cBL
+jUO
+nfv
+uqi
+gul
+bpY
+oUI
+vFV
 lQD
 kse
 kse
@@ -83809,17 +83873,17 @@ wCz
 qkm
 aFR
 cNy
-iLR
-dwl
-amX
-kRs
-pyo
-lOK
-kvR
-mfy
-gEn
-jUO
-kRs
+fAu
+eRA
+xDz
+vFV
+umE
+xuW
+tAh
+ldM
+bpY
+dtk
+vFV
 lQD
 kse
 kse
@@ -84111,17 +84175,17 @@ iFO
 dxU
 wdw
 cNy
-iLR
-ljJ
-sOA
-kRs
-sOA
-sOA
-lTY
-utp
-gEn
-yem
-kRs
+fAu
+nqu
+jUO
+vFV
+jUO
+jUO
+nPV
+gul
+bpY
+oUI
+vFV
 lQD
 kse
 kse
@@ -84413,17 +84477,17 @@ dZm
 uBc
 yfn
 cNy
+fAu
+vFV
 iLR
-kRs
-tVe
-kRs
-tVe
-kRs
-kRs
-utp
-gEn
-yem
-kRs
+vFV
+iLR
+vFV
+vFV
+gul
+bpY
+oUI
+vFV
 lQD
 kse
 kse
@@ -84716,16 +84780,16 @@ lwy
 vsn
 cNy
 bgK
-kRs
-sOA
-sOA
-sOA
-kwh
-kRs
-kRs
-jww
-kRs
-kRs
+vFV
+jUO
+jUO
+jUO
+rPW
+vFV
+vFV
+uko
+vFV
+vFV
 lQD
 dzT
 kse
@@ -85018,16 +85082,16 @@ lwy
 kqr
 cNy
 bgK
-kRs
-pRT
-sOA
-sOA
-sOA
-jOG
-aGA
-aGA
-gLQ
-kRs
+vFV
+qxe
+jUO
+jUO
+jUO
+vXg
+txj
+txj
+wrt
+vFV
 lQD
 kse
 kse
@@ -85320,16 +85384,16 @@ lcW
 qkm
 cNy
 bgK
-kRs
-kRM
-ehl
-sOA
-sOA
-kRs
-aGA
-aGA
-aGA
-kRs
+vFV
+uwe
+utp
+jUO
+jUO
+vFV
+txj
+txj
+txj
+vFV
 lQD
 kse
 kse
@@ -85622,16 +85686,16 @@ lcW
 aug
 cNy
 bgK
-kRs
-jlb
-sOA
-sOA
-sOA
-ecv
-gLQ
-wXH
-aGA
-kRs
+vFV
+nZg
+jUO
+jUO
+jUO
+rBM
+wrt
+kUG
+txj
+vFV
 lQD
 kse
 kse
@@ -85924,16 +85988,16 @@ lwy
 xmL
 cNy
 bgK
-kRs
-kwh
-sOA
-sOA
-kwh
-kRs
-kRs
-sze
-kRs
-kRs
+vFV
+rPW
+jUO
+jUO
+rPW
+vFV
+vFV
+cBL
+vFV
+vFV
 lQD
 kse
 kse
@@ -85946,8 +86010,8 @@ yhR
 rxM
 hYG
 kSe
-xiT
-xiT
+ehl
+ehl
 rxM
 yhR
 yhR
@@ -86226,16 +86290,16 @@ lwy
 fbb
 cNy
 bgK
-kRs
-kRs
-tVe
-kRs
-kRs
-kRs
-dVc
-oPG
-anc
-kRs
+vFV
+vFV
+iLR
+vFV
+vFV
+vFV
+edA
+gEJ
+gVG
+vFV
 lQD
 kse
 kse
@@ -86249,7 +86313,7 @@ rxM
 ueV
 bnt
 pPm
-xiT
+ehl
 rxM
 yhR
 yhR
@@ -86528,16 +86592,16 @@ hZx
 wdw
 cNy
 bgK
-kRs
-sOA
-sOA
-sOA
-sOA
-cIa
-ehl
-sOA
-yfU
-kRs
+vFV
+jUO
+jUO
+jUO
+jUO
+uvQ
+utp
+jUO
+hTt
+vFV
 lQD
 kse
 kse
@@ -86830,16 +86894,16 @@ nlJ
 yfn
 cNy
 bgK
-kRs
-oiL
-vOn
-sOA
-sOA
-kRs
-sOA
-ehl
-sOA
-kRs
+vFV
+khr
+dmG
+jUO
+jUO
+vFV
+jUO
+utp
+jUO
+vFV
 lQD
 kse
 kse
@@ -87131,17 +87195,17 @@ wCz
 spL
 qkm
 cNy
-iLR
-kRs
-kFE
-dQm
+fAu
 vFV
-sOA
-kRs
-kRs
-aRO
-vta
-kRs
+gFP
+hYM
+cbb
+jUO
+vFV
+vFV
+tCV
+keP
+vFV
 lQD
 kse
 kse
@@ -87433,17 +87497,17 @@ cNy
 cNy
 cNy
 cNy
-iLR
-cGm
-vuX
-lrk
-hhJ
-sOA
-sOA
-kRs
-kRs
-kRs
-kRs
+fAu
+gUC
+dVc
+boH
+xth
+jUO
+jUO
+vFV
+vFV
+vFV
+vFV
 lQD
 kse
 kse
@@ -87735,17 +87799,17 @@ bgK
 bgK
 bgK
 bgK
-iLR
-jSA
-sOA
-ehl
-tCA
-sOA
-sOA
-sOA
-sOA
-wJM
-kRs
+fAu
+bid
+jUO
+utp
+xEe
+jUO
+jUO
+jUO
+jUO
+kjb
+vFV
 lQD
 kse
 kse
@@ -88037,17 +88101,17 @@ bgK
 bgK
 bgK
 bgK
-iLR
-kRs
-sOA
-jwn
-sOA
-sOA
-sOA
-sOA
-sOA
-tAh
-kRs
+fAu
+vFV
+jUO
+vDS
+jUO
+jUO
+jUO
+jUO
+jUO
+mZp
+vFV
 lQD
 kse
 kse
@@ -88340,16 +88404,16 @@ wAm
 wAm
 yhR
 yhR
-kRs
-kRs
-kRs
-kRs
-kRs
-khW
-ehl
-sOA
-cjs
-kRs
+vFV
+vFV
+vFV
+vFV
+vFV
+jtW
+utp
+jUO
+oti
+vFV
 lQD
 kse
 kse
@@ -88646,12 +88710,12 @@ wAm
 wAm
 wAm
 wAm
-kRs
-bil
-sOA
-sOA
-wJM
-kRs
+vFV
+qEr
+jUO
+jUO
+kjb
+vFV
 lQD
 kse
 kse
@@ -88948,12 +89012,12 @@ cPW
 ogS
 fLw
 wAm
-kRs
-wSy
-sOA
-sOA
-gXw
-kRs
+vFV
+sHc
+jUO
+jUO
+tMs
+vFV
 lQD
 kse
 kse
@@ -89250,12 +89314,12 @@ dxf
 nuv
 uvO
 wAm
-kRs
-twz
-sOA
-sOA
-oHS
-kRs
+vFV
+ral
+jUO
+jUO
+bTh
+vFV
 lQD
 kse
 kse
@@ -89552,12 +89616,12 @@ pXM
 nhE
 dyQ
 wAm
-kRs
-kRs
-oEv
-phk
-kRs
-kRs
+vFV
+vFV
+nsn
+nXU
+vFV
+vFV
 lQD
 kse
 kse
@@ -89854,12 +89918,12 @@ uSn
 wAm
 wAm
 wAm
-kRs
-ryg
-sOA
-ehl
-uoN
-kRs
+vFV
+pMF
+jUO
+utp
+fmd
+vFV
 lQD
 kse
 kse
@@ -90155,13 +90219,13 @@ wAm
 kDq
 ncc
 wAm
-kRs
-kRs
-jFg
-nPV
-sOA
-kSG
-kRs
+vFV
+vFV
+vzj
+nyP
+jUO
+ffr
+vFV
 lQD
 kse
 kse
@@ -90457,13 +90521,13 @@ oSc
 emA
 gSM
 wAm
-kRs
-fKj
-sOA
-sOA
-sOA
-ljb
-kRs
+vFV
+sLM
+jUO
+jUO
+jUO
+yem
+vFV
 lQD
 kse
 kse
@@ -90759,13 +90823,13 @@ neG
 lXT
 sxY
 wAm
-kRs
-vDS
-sOA
-sOA
-sOA
-sOA
-kRs
+vFV
+nmk
+jUO
+jUO
+jUO
+jUO
+vFV
 lQD
 kse
 kse
@@ -91061,13 +91125,13 @@ wAm
 nuv
 uvO
 wAm
-kRs
-lKp
-sOA
-jwn
-sOA
-sOA
-kRs
+vFV
+oqX
+jUO
+vDS
+jUO
+jUO
+vFV
 lQD
 kse
 kse
@@ -91363,13 +91427,13 @@ mvc
 nuv
 uvO
 wAm
-kRs
-kRs
-tVe
-kRs
-kRs
-tVe
-kRs
+vFV
+vFV
+iLR
+vFV
+vFV
+iLR
+vFV
 lQD
 kse
 kse
@@ -91665,13 +91729,13 @@ tvg
 eTX
 cbY
 wAm
-kRs
-szG
-ehl
-kRs
-szG
-sOA
-kRs
+vFV
+exa
+utp
+vFV
+exa
+jUO
+vFV
 lQD
 kse
 kse
@@ -91967,13 +92031,13 @@ wAm
 wAm
 wAm
 wAm
-kRs
-nCO
-nEm
-sze
-nCO
-nEm
-kRs
+vFV
+adZ
+iaR
+cBL
+adZ
+iaR
+vFV
 lQD
 kse
 kse
@@ -92269,13 +92333,13 @@ qBv
 yhR
 yhR
 yhR
-kRs
-fcC
-sOA
-kRs
-fcC
-sOA
-kRs
+vFV
+ogL
+jUO
+vFV
+ogL
+jUO
+vFV
 lQD
 kse
 kse
@@ -92571,13 +92635,13 @@ yhR
 yhR
 yhR
 yhR
-kRs
-kRs
-kRs
-kRs
-kRs
-kRs
-kRs
+vFV
+vFV
+vFV
+vFV
+vFV
+vFV
+vFV
 lQD
 kse
 kse
@@ -127557,7 +127621,7 @@ nJn
 mRU
 bWy
 bTJ
-eBB
+wkY
 eBB
 mRU
 abs
@@ -127839,14 +127903,14 @@ oep
 muX
 fAU
 mUQ
-mUQ
+fPW
 fAU
 eik
 wGw
 nfX
 nfX
 nfX
-nfX
+hHM
 wGw
 jqu
 wGw
@@ -128459,7 +128523,7 @@ dsH
 cew
 laW
 laW
-laW
+ukd
 mRU
 wGw
 bWy
@@ -129070,7 +129134,7 @@ bWy
 bWy
 mRU
 qxg
-rPL
+fAS
 svT
 rPL
 ehh

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
@@ -421,7 +421,7 @@
 	pixel_y = -5
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "agY" = (
 /obj/structure/debris/v1,
 /turf/open/indestructible/ground/inside/subway,
@@ -729,6 +729,12 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/f13/vault_floor/red/whiteredfull,
 /area/f13/sewer)
+"amX" = (
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "amZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -746,6 +752,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
+"anc" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ane" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -1400,7 +1413,7 @@
 	pixel_y = 13
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "azN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/booth,
@@ -1767,6 +1780,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/sewer)
+"aGA" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/den)
 "aGI" = (
 /obj/item/clothing/glasses/sunglasses/blindfold,
 /obj/item/clothing/glasses/sunglasses/blindfold,
@@ -1817,6 +1834,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood_common,
 /area/f13/brotherhood/dorms)
+"aIf" = (
+/obj/structure/debris/v4{
+	pixel_x = -27
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "aIg" = (
 /obj/structure/simple_door/bunker,
 /obj/structure/barricade/wooden/planks,
@@ -2150,6 +2173,10 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/royalblue,
 /area/f13/vault/overseer)
+"aOH" = (
+/obj/structure/table,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "aOO" = (
 /obj/structure/wreck/trash/two_barrels{
 	pixel_y = 12
@@ -2314,6 +2341,12 @@
 	name = "dirty floor"
 	},
 /area/f13/building/abandoned/o)
+"aRO" = (
+/obj/machinery/autolathe/ammo,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "aRS" = (
 /obj/item/reagent_containers/food/drinks/bottle/instatea{
 	pixel_x = -9;
@@ -2738,7 +2771,7 @@
 	pixel_y = 16
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "aZp" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -3157,6 +3190,12 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"bil" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "bin" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -3337,7 +3376,7 @@
 "bmu" = (
 /obj/structure/wreck/trash/engine,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/followers)
 "bmJ" = (
 /obj/item/trash/f13/mre{
 	pixel_y = 6
@@ -3405,7 +3444,7 @@
 /obj/effect/decal/cleanable/greenglow,
 /obj/item/stack/sheet/mineral/uranium,
 /turf/open/floor/plating/rust,
-/area/f13/caves)
+/area/f13/followers)
 "bnx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human,
@@ -3683,7 +3722,7 @@
 	pixel_y = 11
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "btN" = (
 /obj/structure/table/wood,
 /obj/item/stack/f13Cash/caps/twofivezero,
@@ -4076,6 +4115,12 @@
 /obj/effect/spawner/lootdrop/f13/armor/tier2,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"bBG" = (
+/obj/structure/noticeboard{
+	pixel_y = 28
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "bBN" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -5764,6 +5809,15 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"cjs" = (
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "cju" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/inside/subway,
@@ -5932,7 +5986,7 @@
 "cml" = (
 /obj/structure/barricade/bars,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/followers)
 "cmM" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Security Checkpoint";
@@ -6096,6 +6150,10 @@
 /obj/structure/bed/dogbed,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkersix)
+"cqX" = (
+/obj/structure/rack/shelf_metal,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "cqZ" = (
 /obj/structure/wreck/trash/five_tires,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -6553,7 +6611,7 @@
 /obj/item/clothing/gloves/color/light_brown,
 /obj/item/flashlight/seclite,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "czG" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -6864,6 +6922,12 @@
 	icon_state = "floordirty"
 	},
 /area/f13/bunker/bunkerthree)
+"cGm" = (
+/obj/machinery/photocopier,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "cGq" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /turf/open/floor/plating/tunnel,
@@ -6921,6 +6985,12 @@
 	dir = 1
 	},
 /area/f13/vault/diner)
+"cIa" = (
+/obj/structure/simple_door/metal/barred,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "cIf" = (
 /mob/living/simple_animal/hostile/handy/protectron,
 /turf/open/indestructible/ground/inside/subway,
@@ -8627,7 +8697,7 @@
 	pixel_y = -5
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "dsz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/unique,
@@ -8778,6 +8848,14 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/followers)
+"dwl" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "dwn" = (
 /obj/structure/simple_door/metal/ventilation,
 /turf/open/indestructible/ground/inside/subway,
@@ -8843,6 +8921,13 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
+"dxh" = (
+/obj/item/stack/sheet/mineral/uranium/twentyfive,
+/obj/structure/rack/shelf_metal,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "dxr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/junk/toilet{
@@ -8988,7 +9073,7 @@
 "dzT" = (
 /mob/living/simple_animal/hostile/ghoul,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/area/f13/sewer)
 "dzW" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -9703,6 +9788,13 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/subway,
 /area/maintenance/disposal)
+"dQm" = (
+/obj/structure/table/glass,
+/obj/item/gun/ballistic/automatic/m1garand/sks,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "dQs" = (
 /obj/item/scalpel,
 /obj/item/surgical_drapes,
@@ -9909,9 +10001,16 @@
 	},
 /area/f13/bunker/bunkerthree)
 "dVc" = (
-/obj/structure/decoration/warning,
-/turf/closed/wall/rust,
-/area/f13/caves)
+/obj/structure/guncase{
+	anchored = 1
+	},
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/obj/item/gun/ballistic/automatic/type93,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "dVu" = (
 /mob/living/simple_animal/hostile/renegade/meister,
 /obj/effect/decal/cleanable/dirt,
@@ -10238,6 +10337,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/ruin/powered)
+"ecv" = (
+/obj/machinery/turnstile{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/den)
 "ecL" = (
 /obj/effect/gibspawner/human,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -10389,9 +10495,11 @@
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/bunker)
 "ehl" = (
-/mob/living/simple_animal/hostile/ghoul/soldier,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ehq" = (
 /obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
@@ -11616,6 +11724,10 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
+"eFJ" = (
+/obj/structure/chair,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "eFS" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/floor/f13{
@@ -12689,7 +12801,7 @@
 	icon_state = "floor3"
 	},
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/followers)
 "fcb" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/cable{
@@ -12736,6 +12848,13 @@
 /obj/machinery/autolathe/ammo,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/outpost)
+"fcC" = (
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/blanket/blanketalt,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "fcJ" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -13427,6 +13546,12 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/custodial)
+"frK" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "frS" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
@@ -14329,6 +14454,12 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/reactor)
+"fKj" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "fKl" = (
 /obj/structure/reagent_dispensers/barrel/four,
 /obj/effect/decal/cleanable/dirt,
@@ -14739,7 +14870,7 @@
 	icon_state = "goo12"
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "fTn" = (
 /obj/machinery/microwave/stove,
 /obj/effect/decal/cleanable/dirt,
@@ -15108,7 +15239,7 @@
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "gcg" = (
 /obj/machinery/door/poddoor{
 	id = 103;
@@ -15351,6 +15482,14 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/brotherhood/leisure)
+"ggM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker,
+/obj/machinery/door/poddoor/shutters/preopen,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 4
+	},
+/area/f13/den)
 "ggU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -16522,6 +16661,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/f13/enclave)
+"gEn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/white,
+/area/f13/den)
 "gEy" = (
 /mob/living/simple_animal/hostile/renegade/doc,
 /turf/open/indestructible/ground/inside/subway,
@@ -16632,7 +16775,7 @@
 /area/f13/enclave)
 "gGT" = (
 /turf/open/floor/f13/wood,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "gGV" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/enclave)
@@ -16921,6 +17064,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"gLQ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/den)
 "gMi" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/floor/plasteel/dark,
@@ -17458,7 +17606,7 @@
 	pixel_y = 7
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "gWz" = (
 /turf/open/floor/plasteel/f13/vault_floor/yellow/side{
 	dir = 1
@@ -17520,6 +17668,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/vault)
+"gXw" = (
+/obj/structure/table/booth,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "gXL" = (
 /turf/closed/indestructible/vaultdoor,
 /area/f13/vault/security/checkpoint)
@@ -17934,7 +18089,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "hfp" = (
 /obj/structure/table{
 	layer = 2.9
@@ -18100,6 +18255,13 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"hhJ" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "hhM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -18792,7 +18954,7 @@
 	pixel_y = 12
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "hwL" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -19284,6 +19446,12 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"hGz" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "hGD" = (
 /mob/living/simple_animal/hostile/handy/gutsy{
 	faction = list("hostile")
@@ -19333,6 +19501,12 @@
 /obj/structure/junk/cabinet,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
+"hId" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "hIj" = (
 /obj/item/storage/trash_stack{
 	icon_state = "Junk_9";
@@ -19504,6 +19678,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/f13/bunker/bunkersix)
+"hMi" = (
+/obj/structure/curtain{
+	color = "#363636"
+	},
+/obj/structure/simple_door/metal/barred,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "hMC" = (
 /obj/machinery/door/locked/easy/trapped,
 /turf/open/floor/plasteel/dark,
@@ -19660,6 +19841,10 @@
 	name = "dirty floor"
 	},
 /area/f13/building/firestation)
+"hQe" = (
+/obj/structure/campfire,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "hQl" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -19913,7 +20098,7 @@
 	id = "SEWSW"
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/area/f13/sewer)
 "hUB" = (
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
@@ -20123,7 +20308,7 @@
 "hYG" = (
 /obj/machinery/computer,
 /turf/open/floor/plating/rust,
-/area/f13/caves)
+/area/f13/followers)
 "hYL" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer,
@@ -21184,9 +21369,9 @@
 /turf/open/floor/plasteel/f13/vault_floor/red/corner,
 /area/f13/vault/atrium)
 "iwH" = (
-/obj/structure/simple_door/bunker,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/f13/store/constructed,
+/area/f13/den)
 "iwL" = (
 /obj/structure/fluff/rails,
 /obj/structure/handrail/g_central{
@@ -21335,6 +21520,14 @@
 /mob/living/simple_animal/hostile/ghoul/scorched/ranged,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white,
 /area/f13/bunker/bighornbunker)
+"iAr" = (
+/obj/structure/debris/v3{
+	layer = 2;
+	pixel_x = -10;
+	pixel_y = -4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "iAv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -21719,7 +21912,7 @@
 "iJl" = (
 /obj/machinery/door/locked/easy/maybe_trapped,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/followers)
 "iJu" = (
 /obj/effect/decal/waste{
 	icon_state = "goo10"
@@ -21811,13 +22004,8 @@
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
 "iLR" = (
-/obj/item/storage/trash_stack{
-	icon_state = "Junk_9";
-	pixel_x = 5;
-	pixel_y = 20
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/turf/closed/wall/f13/store/constructed,
+/area/f13/caves)
 "iLS" = (
 /obj/structure/window{
 	dir = 8
@@ -22094,7 +22282,7 @@
 	faction = list("neutral","china")
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/followers)
 "iSC" = (
 /obj/machinery/door/locked/easy/maybe_trapped,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -22665,7 +22853,7 @@
 /obj/effect/decal/cleanable/glass,
 /obj/item/broken_bottle,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/area/f13/sewer)
 "jet" = (
 /obj/item/storage/firstaid/fire,
 /obj/structure/table,
@@ -22908,7 +23096,7 @@
 "jjr" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/followers)
 "jjA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/simple_door/metal/ventilation,
@@ -22962,6 +23150,11 @@
 /obj/effect/spawner/lootdrop/druggie_pill,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/outpost)
+"jkV" = (
+/obj/effect/decal/cleanable/crayon,
+/obj/effect/gibspawner/human/bodypartless,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "jkW" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -22972,6 +23165,13 @@
 	},
 /turf/open/water,
 /area/f13/radiation)
+"jlb" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/alcoholspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "jlR" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/blueprintHigh,
@@ -23521,6 +23721,22 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating/tunnel,
 /area/f13/sewer/powered)
+"jwn" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
+"jww" = (
+/obj/structure/simple_door/bunker,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters/preopen,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 8
+	},
+/area/f13/den)
 "jwH" = (
 /obj/machinery/workbench/advanced,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -23866,6 +24082,12 @@
 /obj/effect/spawner/lootdrop/f13/cash_random_med,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"jFg" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "jFi" = (
 /turf/closed/wall/f13/tunnel,
 /area/f13/bunker/bunkereight)
@@ -24244,6 +24466,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/f13/bunker/bunkersix)
+"jNO" = (
+/mob/living/simple_animal/hostile/eyebot,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "jNP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/spacevine,
@@ -24281,6 +24507,11 @@
 /obj/structure/girder/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/vault)
+"jOG" = (
+/obj/machinery/turnstile,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/den)
 "jOH" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -24421,6 +24652,12 @@
 	icon_state = "reddirtyfull"
 	},
 /area/f13/bunker)
+"jSA" = (
+/obj/machinery/pdapainter,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "jSD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/garbagetomid,
@@ -24505,11 +24742,12 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
 "jUO" = (
-/obj/structure/reagent_dispensers/barrel/four{
-	pixel_y = 11
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
 	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/den)
 "jUT" = (
 /obj/structure/chair/bench,
 /mob/living/simple_animal/hostile/raider/junker/creator,
@@ -25194,6 +25432,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/airless/floorgrime,
 /area/f13/bunker/bunkerthree)
+"khW" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "kib" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb,
@@ -25239,8 +25484,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/yellow,
 /area/f13/radiation)
 "kjb" = (
-/turf/closed/wall/f13/ruins,
-/area/f13/bunker/bighornbunker)
+/turf/closed/indestructible/f13/obsidian,
+/area/f13/bunker/bunkerthree)
 "kjA" = (
 /obj/structure/bonfire/prelit,
 /turf/open/floor/plasteel/dark,
@@ -25947,10 +26192,27 @@
 /obj/structure/simple_door/repaired,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/caves)
+"kvR" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "kwa" = (
 /obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/f13/tcoms)
+"kwh" = (
+/obj/structure/fluff/hedge{
+	name = "plastic hedge"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "kwu" = (
 /obj/machinery/light{
 	light_color = "#e8eaff"
@@ -26421,6 +26683,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/purple/whitepurplefull,
 /area/f13/vault/custodial)
+"kFE" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "kFI" = (
 /obj/structure/chair{
 	dir = 4
@@ -26958,6 +27228,10 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak/super,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered)
+"kQj" = (
+/obj/item/trash/candle,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "kQk" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -27045,11 +27319,8 @@
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/brotherhood/rnd)
 "kRs" = (
-/obj/structure/wreck/trash/machinepiletwo{
-	pixel_y = 6
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/turf/closed/wall/f13/store/constructed,
+/area/f13/den)
 "kRy" = (
 /obj/machinery/light{
 	dir = 4;
@@ -27096,6 +27367,17 @@
 	dir = 4
 	},
 /area/f13/vault/science)
+"kRM" = (
+/obj/structure/table/reinforced,
+/obj/item/statuebust,
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "kRQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/small/bed2,
@@ -27106,7 +27388,7 @@
 "kSe" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating/rust,
-/area/f13/caves)
+/area/f13/followers)
 "kSm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27131,6 +27413,14 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/bunker/bunkerthree)
+"kSG" = (
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "kSH" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/decal/cleanable/dirt,
@@ -27552,6 +27842,8 @@
 "kZK" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/followers)
 "kZP" = (
@@ -27980,6 +28272,13 @@
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"ljb" = (
+/obj/structure/bedsheetbin,
+/obj/structure/table/booth,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ljc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28016,6 +28315,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/bunker/bunkerseven)
+"ljJ" = (
+/obj/machinery/power/apc/fusebox/east,
+/obj/structure/cable/orange{
+	icon_state = "0-8"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ljL" = (
 /obj/effect/spawner/lootdrop/trash,
 /turf/open/indestructible/ground/inside/subway,
@@ -28407,6 +28715,13 @@
 	icon_state = "housebase"
 	},
 /area/f13/bunker/bighornbunker)
+"lrk" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/bundle/f13/armor/combat/mk2,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "lrw" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy/assaultron,
@@ -29320,6 +29635,12 @@
 	icon_state = "yellowrustyfull"
 	},
 /area/f13/bunker/bunkerthree)
+"lKp" = (
+/obj/structure/punching_bag,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "lKt" = (
 /obj/structure/table/wood/poker,
 /obj/item/locked_box/weapon/range/unique,
@@ -29555,6 +29876,12 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/radiation)
+"lOK" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "lOM" = (
 /obj/structure/rack,
 /obj/effect/spawner/bundle/f13/armor/combat/mk2,
@@ -29898,6 +30225,16 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/sewer)
+"lTY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/computer/terminal{
+	dir = 1;
+	termtag = "Business"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "lUc" = (
 /obj/structure/lattice{
 	layer = 3
@@ -30284,6 +30621,13 @@
 /obj/machinery/light/fo13colored/Red,
 /turf/closed/mineral/random/low_chance,
 /area/f13/bunker/bunkerthree)
+"mbY" = (
+/obj/structure/debris/v3{
+	pixel_x = -12;
+	pixel_y = -10
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "mbZ" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkereight)
@@ -30436,6 +30780,11 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/enclave)
+"mfy" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/den)
 "mfE" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/indestructible/opshuttle{
@@ -30493,7 +30842,7 @@
 /obj/item/stock_parts/cell,
 /obj/item/stock_parts/cell,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "mgo" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood4-broken"
@@ -31483,7 +31832,7 @@
 "mBw" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/followers)
 "mBD" = (
 /obj/structure/campfire/barrel,
 /turf/open/indestructible/ground/inside/subway,
@@ -31834,7 +32183,7 @@
 	pixel_y = 10
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "mHk" = (
 /mob/living/simple_animal/hostile/deathclaw,
 /turf/open/floor/f13{
@@ -33780,7 +34129,7 @@
 	pixel_y = -7
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "nvY" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/armor/tiered/heavy/salvaged_pa/tier3/recycled,
@@ -34156,6 +34505,12 @@
 /obj/structure/simple_door/metal/barred,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/outpost)
+"nCO" = (
+/obj/structure/closet/crate/footlocker,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nCU" = (
 /mob/living/simple_animal/hostile/handy/gutsy/nsb,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -34254,6 +34609,15 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
+"nEm" = (
+/obj/structure/fluff/rug/rug_rubber{
+	icon = 'icons/fallout/objects/64x64_rugs.dmi';
+	icon_state = "rug_fancy"
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nEy" = (
 /obj/structure/window/reinforced/fulltile/indestructable{
 	can_be_unanchored = 0
@@ -34779,9 +35143,16 @@
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/bunker/bunkersix)
 "nPV" = (
-/obj/structure/wreck/trash/three_barrels,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/obj/structure/fluff/rug/rug_rubber{
+	icon = 'icons/fallout/objects/64x64_rugs.dmi';
+	icon_state = "rug_red";
+	pixel_y = -30;
+	pixel_x = 13
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "nQa" = (
 /obj/structure/barricade/bars,
 /obj/structure/table,
@@ -35179,7 +35550,7 @@
 	icon_state = "goo5"
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "nYu" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -35467,7 +35838,7 @@
 	pixel_y = 1
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "oep" = (
 /mob/living/simple_animal/hostile/ghoul/glowing,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -35751,6 +36122,14 @@
 	desc = "This one looks like it won't ever open."
 	},
 /area/ruin/powered)
+"oiL" = (
+/obj/structure/fireaxecabinet{
+	pixel_y = 28
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "oiN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/barricade/wooden/strong,
@@ -36411,7 +36790,7 @@
 /area/f13/bunker/bunkersix)
 "ovK" = (
 /turf/closed/wall/f13/tunnel,
-/area/f13/tunnel)
+/area/f13/sewer)
 "owh" = (
 /obj/structure/fence{
 	dir = 1
@@ -36567,6 +36946,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/vault)
+"oAf" = (
+/obj/item/candle{
+	pixel_y = -13;
+	pixel_x = 14
+	},
+/obj/item/candle{
+	pixel_y = -10;
+	pixel_x = 9
+	},
+/obj/item/candle{
+	pixel_y = -2;
+	pixel_x = 13
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "oAh" = (
 /obj/structure/rack,
 /obj/item/stack/spacecash/c1000,
@@ -36672,6 +37066,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker/bunkernine)
+"oCq" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/druggie_pill,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "oCr" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/mortar{
@@ -36776,6 +37175,13 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/tunnel,
 /area/f13/radiation)
+"oEv" = (
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/obj/effect/overlay/junk/curtain,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "oEz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -36901,7 +37307,7 @@
 	},
 /obj/item/trash/sosjerky,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/followers)
 "oGZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -36958,6 +37364,14 @@
 	icon_state = "yellowsiding"
 	},
 /area/ruin/powered)
+"oHS" = (
+/obj/structure/chair/folding{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "oIb" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/destructible/tribal_torch/wall{
@@ -37272,6 +37686,12 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/ruin/powered)
+"oPG" = (
+/obj/machinery/autolathe,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "oPI" = (
 /mob/living/simple_animal/hostile/raider/junker,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -37280,7 +37700,7 @@
 /area/f13/bunker)
 "oPL" = (
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/followers)
 "oQa" = (
 /obj/structure/barricade/bars{
 	max_integrity = 800;
@@ -38161,6 +38581,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/brotherhood/operations)
+"phk" = (
+/obj/effect/overlay/junk/curtain,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "phl" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/barricade/concrete,
@@ -38965,6 +39391,14 @@
 	dir = 9
 	},
 /area/f13/vault/atrium)
+"pyo" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "pyr" = (
 /obj/structure/barricade/train,
 /turf/closed/indestructible/f13vaultrusted,
@@ -39766,11 +40200,11 @@
 /area/f13/brotherhood/operations)
 "pPm" = (
 /turf/open/floor/plating/rust,
-/area/f13/caves)
+/area/f13/followers)
 "pPu" = (
 /obj/machinery/light/small,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/area/f13/sewer)
 "pPw" = (
 /turf/closed/wall/r_wall/f13vault{
 	icon_state = "2-i"
@@ -39933,6 +40367,13 @@
 "pRI" = (
 /turf/open/floor/plating/tunnel,
 /area/f13/bunker/bunkerthree)
+"pRT" = (
+/obj/structure/table/reinforced,
+/obj/effect/spawner/lootdrop/f13/cash_random_med,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "pRU" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -41376,7 +41817,7 @@
 /obj/structure/guncase,
 /obj/item/gun/ballistic/automatic/type93,
 /turf/open/floor/plating,
-/area/f13/caves)
+/area/f13/followers)
 "qrv" = (
 /obj/structure/girder,
 /turf/open/indestructible/ground/inside/mountain,
@@ -41886,7 +42327,7 @@
 	dir = 4
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/area/f13/sewer)
 "qzP" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/f13/advcrafting,
@@ -41918,7 +42359,7 @@
 	pixel_y = -7
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "qAF" = (
 /obj/structure/barricade/wooden,
 /obj/effect/decal/cleanable/dirt,
@@ -41928,7 +42369,7 @@
 /mob/living/simple_animal/hostile/chinese,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/followers)
 "qBp" = (
 /obj/structure/closet/crate/radiation,
 /obj/item/geiger_counter,
@@ -42465,6 +42906,15 @@
 	name = "dirty floor"
 	},
 /area/f13/bunker/bunkerthree)
+"qKR" = (
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/port_gen/pacman/super,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "qKX" = (
 /obj/machinery/ticket_machine{
 	name = "busted ticket machine";
@@ -43233,7 +43683,7 @@
 "qZO" = (
 /obj/item/storage/trash_stack,
 /turf/open/floor/f13/wood,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "qZW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger{
@@ -43314,7 +43764,7 @@
 	},
 /obj/structure/table,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/followers)
 "rcp" = (
 /obj/machinery/light/fo13colored/Red{
 	dir = 4
@@ -44146,7 +44596,7 @@
 	icon_state = "Junk_8"
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "rsO" = (
 /obj/machinery/camera/autoname{
 	name = "Security Camera";
@@ -44366,6 +44816,12 @@
 	icon_state = "dark"
 	},
 /area/f13/building/abandoned/o)
+"ryg" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "rys" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45919,6 +46375,13 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/purple/white,
 /area/f13/enclave)
+"sel" = (
+/obj/structure/table,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "sem" = (
 /obj/structure/ladder/unbreakable{
 	height = 1;
@@ -46928,6 +47391,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/green/whitegreenfull,
 /area/f13/enclave)
+"sze" = (
+/obj/structure/decoration/vent,
+/turf/closed/wall/f13/store/constructed,
+/area/f13/den)
 "szl" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /turf/open/water,
@@ -46969,6 +47436,16 @@
 /obj/structure/lattice/catwalk,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/outpost)
+"szG" = (
+/obj/structure/closet/cabinet,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "szK" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/wreck/trash/two_tire,
@@ -47164,7 +47641,7 @@
 	icon_state = "Junk_11"
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/area/f13/sewer)
 "sEw" = (
 /obj/machinery/gear_painter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -47669,9 +48146,10 @@
 /turf/open/floor/f13/wood,
 /area/f13/vault/dormitory)
 "sOA" = (
-/obj/structure/wreck/trash/brokenvendor,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "sOF" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -48314,12 +48792,12 @@
 "tbv" = (
 /obj/structure/statue/uranium/nuke,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/followers)
 "tbw" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/area/f13/sewer)
 "tbO" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -49313,6 +49791,18 @@
 "twn" = (
 /turf/closed/mineral/random/high_chance,
 /area/f13/tunnel)
+"twz" = (
+/obj/structure/closet/fridge,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "twD" = (
 /obj/effect/decal/cleanable/blood/gibs/down{
 	icon_state = "gib1-old"
@@ -49487,7 +49977,7 @@
 "tzt" = (
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/plating/rust,
-/area/f13/caves)
+/area/f13/followers)
 "tzA" = (
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/vault/diner)
@@ -49519,10 +50009,12 @@
 	},
 /area/ruin/powered)
 "tAh" = (
-/turf/closed/indestructible/f13vaultrusted{
-	name = "rusty reinforced wall"
+/obj/structure/table/booth,
+/obj/effect/spawner/lootdrop/f13/cash_random_high,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
 	},
-/area/f13/caves)
+/area/f13/den)
 "tAl" = (
 /obj/structure/chair/office,
 /turf/open/floor/plasteel/dark,
@@ -49600,6 +50092,14 @@
 /obj/structure/rack/shelf_metal,
 /turf/open/floor/plasteel/vault,
 /area/f13/vault/security/armory)
+"tCA" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "tCE" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/bundle/f13/greasegun,
@@ -49900,7 +50400,7 @@
 	pixel_y = 12
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "tIS" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -50610,6 +51110,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/o)
+"tVe" = (
+/obj/structure/simple_door/house,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "tVt" = (
 /turf/closed/indestructible/opshuttle{
 	icon = 'icons/turf/walls/reinforced_wall.dmi';
@@ -51002,6 +51508,8 @@
 /area/f13/radiation)
 "ueo" = (
 /obj/structure/table,
+/obj/item/gun/energy/disabler,
+/obj/item/gun/energy/disabler,
 /turf/open/indestructible/ground/inside/subway,
 /area/f13/followers)
 "uer" = (
@@ -51024,7 +51532,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/plating/rust,
-/area/f13/caves)
+/area/f13/followers)
 "ueX" = (
 /obj/effect/landmark/start/f13/raider,
 /turf/open/indestructible/ground/inside/mountain,
@@ -51032,7 +51540,7 @@
 "ufe" = (
 /obj/structure/barricade/wooden,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/area/f13/sewer)
 "ufi" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/mineral/plastitanium,
@@ -51600,6 +52108,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/side,
 /area/f13/brotherhood/armory)
+"uoN" = (
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "uoQ" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/item/toy/figure/botanist{
@@ -51868,11 +52384,9 @@
 /turf/open/floor/wood_common/wood_common_dark,
 /area/f13/brotherhood/leisure)
 "utp" = (
-/obj/structure/bed/mattress{
-	icon_state = "mattress2"
-	},
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/side,
+/area/f13/den)
 "utw" = (
 /obj/effect/decal/waste{
 	icon_state = "goo8"
@@ -52880,7 +53394,7 @@
 "uMZ" = (
 /obj/structure/wreck/trash/autoshaft,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "uNk" = (
 /obj/structure/rack,
 /obj/item/clothing/under/f13/vault13,
@@ -54231,7 +54745,7 @@
 "vol" = (
 /obj/structure/wreck/trash/bus_door,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/followers)
 "vov" = (
 /obj/machinery/porta_turret/f13/turret_9mm/raider{
 	dir = 1
@@ -54508,6 +55022,12 @@
 /obj/structure/window/fulltile/house/broken,
 /turf/open/floor/plasteel/f13,
 /area/f13/sewer)
+"vta" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "vtb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -54635,6 +55155,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
+"vuX" = (
+/obj/structure/chair/office/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "vuY" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -55020,6 +55546,15 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/brotherhood/operations)
+"vDA" = (
+/obj/structure/table,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
+	},
+/obj/effect/spawner/lootdrop/druggie_pill,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "vDK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55027,9 +55562,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/garden)
 "vDS" = (
-/obj/structure/wreck/trash/machinepile,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/obj/structure/chair/sofa/left,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "vDX" = (
 /obj/item/soap{
 	pixel_y = -4
@@ -55089,9 +55626,12 @@
 	},
 /area/f13/building/abandoned/o)
 "vFV" = (
-/obj/effect/decal/remains/human,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/obj/structure/table/glass,
+/obj/item/gun/ballistic/revolver/colt357,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "vFZ" = (
 /turf/open/floor/f13{
 	dir = 1;
@@ -55496,6 +56036,10 @@
 	},
 /turf/open/floor/plating/tunnel,
 /area/f13/building/firestation)
+"vNs" = (
+/obj/structure/debris/v4,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "vNx" = (
 /obj/machinery/porta_turret/f13/turret_556/burstfire/raider{
 	dir = 6
@@ -55559,6 +56103,14 @@
 "vOm" = (
 /turf/closed/wall/r_wall/rust,
 /area/f13/caves)
+"vOn" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "vOs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic{
@@ -55862,7 +56414,7 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/tunnel)
+/area/f13/sewer)
 "vUs" = (
 /obj/effect/decal/cleanable/blood/gibs/human,
 /turf/open/indestructible/ground/inside/subway,
@@ -55961,6 +56513,13 @@
 	},
 /turf/open/floor/plasteel/cult,
 /area/f13/brotherhood/operations)
+"vWv" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "vWB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56653,7 +57212,7 @@
 "wlP" = (
 /mob/living/simple_animal/hostile/chinese/ranged/assault,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/followers)
 "wlR" = (
 /obj/structure/chair/sofa/right{
 	dir = 8
@@ -57153,7 +57712,7 @@
 "wtg" = (
 /obj/structure/wreck/car,
 /turf/open/indestructible/ground/inside/subway,
-/area/f13/caves)
+/area/f13/followers)
 "wtj" = (
 /obj/item/storage/box/medicine/stimpaks/stimpaks5,
 /obj/structure/rack/shelf_metal,
@@ -57904,6 +58463,14 @@
 	icon_state = "floordirty"
 	},
 /area/f13/bunker/bunkerthree)
+"wJM" = (
+/obj/structure/chair/folding{
+	dir = 4
+	},
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "wJR" = (
 /turf/closed/indestructible/f13vaultrusted{
 	name = "rusty reinforced wall"
@@ -58358,7 +58925,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/f13/wood,
-/area/f13/bunker/bighornbunker)
+/area/f13/sewer)
 "wSg" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -58388,6 +58955,14 @@
 	icon_state = "floorrustysolid"
 	},
 /area/f13/radiation)
+"wSy" = (
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/obj/item/crafting/coffee_pot,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "wSH" = (
 /mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -58601,6 +59176,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"wXH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	brightness = 7;
+	dir = 4
+	},
+/turf/open/floor/plasteel/f13/vault_floor/floor,
+/area/f13/den)
 "wXX" = (
 /mob/living/simple_animal/hostile/handy/robobrain{
 	auto_fire_delay = 2;
@@ -59212,6 +59795,9 @@
 	icon_state = "housewood2"
 	},
 /area/f13/bunker)
+"xiT" = (
+/turf/open/floor/plating/tunnel,
+/area/f13/followers)
 "xiZ" = (
 /turf/open/floor/f13{
 	icon_state = "darkdirtysolid"
@@ -59731,8 +60317,12 @@
 	},
 /area/f13/followers)
 "xth" = (
-/turf/closed/mineral/random/no_caves,
-/area/f13/tunnel)
+/obj/structure/bed/mattress{
+	icon_state = "mattress2";
+	pixel_y = -2
+	},
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "xtj" = (
 /obj/effect/landmark/start/f13/vaultscientist,
 /turf/open/floor/plasteel/f13/vault_floor/purple,
@@ -59906,6 +60496,14 @@
 /obj/structure/reagent_dispensers/barrel/explosive,
 /turf/open/floor/plasteel/dark,
 /area/f13/bunker/bunkereight)
+"xxR" = (
+/obj/structure/debris/v3{
+	pixel_x = -15;
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/indestructible/ground/inside/subway,
+/area/f13/sewer)
 "xxW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -61432,9 +62030,11 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/sewer)
 "yem" = (
-/obj/structure/wreck/trash/engine,
-/turf/open/indestructible/ground/inside/subway,
-/area/f13/bunker/bighornbunker)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/f13/vault_floor/red/side{
+	dir = 1
+	},
+/area/f13/den)
 "yeo" = (
 /obj/structure/chair/f13chair1{
 	dir = 8
@@ -61530,6 +62130,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/building/abandoned/o)
+"yfU" = (
+/mob/living/simple_animal/hostile/ghoul/soldier/armored,
+/obj/machinery/light,
+/turf/open/floor/f13{
+	icon_state = "floorrusty"
+	},
+/area/f13/den)
 "ygn" = (
 /obj/effect/landmark/start/f13/offduty,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
@@ -62865,109 +63472,109 @@ yhR
 yhR
 yhR
 yhR
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-tAh
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+dCc
 yhR
 yhR
 yhR
@@ -63167,133 +63774,133 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-tAh
-aKq
+lQD
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+dCc
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+tnz
+kjb
 yhR
 yhR
 yhR
@@ -63469,109 +64076,109 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+dCc
 sgJ
 sgJ
 sgJ
@@ -63595,7 +64202,7 @@ tnz
 sgJ
 sgJ
 cuW
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -63771,109 +64378,109 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
+lQD
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
 ufe
-vFV
+hco
 ufe
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-tAh
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+dCc
 sgJ
 sgJ
 sgJ
@@ -63897,7 +64504,7 @@ cuW
 obL
 sgJ
 sgJ
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -64073,109 +64680,109 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-dVc
+lQD
+kse
+kse
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+wnd
 tbw
-dVc
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-cJF
-cJF
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-cJF
-cJF
-tAh
+wnd
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+kse
+kse
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+kse
+kse
+dCc
 sgJ
 sgJ
 cuW
@@ -64199,7 +64806,7 @@ cuW
 xXO
 nHO
 sgJ
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -64375,10 +64982,10 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -64474,10 +65081,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+dCc
 sgJ
 sLS
 sgJ
@@ -64501,7 +65108,7 @@ cuW
 fqJ
 pRI
 cuW
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -64677,10 +65284,10 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -64776,10 +65383,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+dCc
 sgJ
 hZb
 uCp
@@ -64803,7 +65410,7 @@ cuW
 tDe
 kwC
 cuW
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -64979,10 +65586,10 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -65078,10 +65685,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+dCc
 sgJ
 sgJ
 uiM
@@ -65105,7 +65712,7 @@ cuW
 aIn
 gzw
 cuW
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -65281,10 +65888,10 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -65380,10 +65987,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+dCc
 sgJ
 sgJ
 wSp
@@ -65407,7 +66014,7 @@ cuW
 eAl
 gsv
 cuW
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -65583,10 +66190,10 @@ bgK
 bgK
 bgK
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -65682,10 +66289,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+dCc
 sgJ
 sgJ
 uiM
@@ -65709,7 +66316,7 @@ kwC
 iWy
 pHw
 sgJ
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -65885,10 +66492,10 @@ wzk
 wzk
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -65984,10 +66591,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+dCc
 sgJ
 sgJ
 sgJ
@@ -66011,7 +66618,7 @@ ryd
 pas
 gmX
 sgJ
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -66187,10 +66794,10 @@ dpJ
 wzk
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -66286,10 +66893,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+dCc
 sgJ
 sgJ
 sgJ
@@ -66313,7 +66920,7 @@ cuW
 tVR
 aIg
 cuW
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -66489,10 +67096,10 @@ wBs
 hYk
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -66588,10 +67195,10 @@ lWI
 lWI
 lWI
 yhR
-qBv
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+dCc
 sdO
 wIg
 sgJ
@@ -66615,7 +67222,7 @@ tVR
 kSE
 txM
 cuW
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -66791,10 +67398,10 @@ aSb
 fcl
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -66890,10 +67497,10 @@ bPs
 lWI
 lWI
 yhR
-qBv
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+dCc
 bPw
 izd
 wSp
@@ -66917,7 +67524,7 @@ cuW
 ryd
 sgJ
 cuW
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -67093,10 +67700,10 @@ eKA
 dpJ
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -67192,10 +67799,10 @@ bPs
 bPs
 bPs
 yhR
-qBv
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+dCc
 sgJ
 kwC
 tpg
@@ -67219,7 +67826,7 @@ cuW
 eAl
 mHN
 cuW
-aKq
+kjb
 yhR
 yhR
 yhR
@@ -67395,10 +68002,10 @@ wxP
 fcl
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -67494,34 +68101,34 @@ cju
 lZt
 bPs
 bPs
-qBv
-cJF
-cJF
-tAh
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
-aKq
+lQD
+kse
+kse
+dCc
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
+kjb
 yhR
 yhR
 yhR
@@ -67697,10 +68304,10 @@ eKA
 iJu
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -67796,10 +68403,10 @@ jXz
 cju
 cju
 bPs
-qBv
-cJF
-cJF
-tAh
+lQD
+kse
+kse
+dCc
 tnz
 phO
 lLG
@@ -67999,10 +68606,10 @@ eKA
 wBs
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -68098,10 +68705,10 @@ pEE
 cju
 cju
 bPs
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 tnz
 vDk
 nWi
@@ -68301,10 +68908,10 @@ wzk
 wzk
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 bgK
@@ -68400,10 +69007,10 @@ vBd
 ljL
 jXz
 bPs
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 tnz
 wtB
 uKn
@@ -68603,10 +69210,10 @@ dpJ
 dpJ
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 bgK
@@ -68702,10 +69309,10 @@ bPs
 jXz
 jXz
 bPs
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 tnz
 wtB
 avb
@@ -68905,10 +69512,10 @@ dpJ
 dXD
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 bgK
@@ -69004,10 +69611,10 @@ clI
 jXz
 jXz
 bPs
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 tnz
 aHW
 cXm
@@ -69207,10 +69814,10 @@ aze
 ijK
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 bgK
@@ -69306,10 +69913,10 @@ fmS
 jXz
 jXz
 bPs
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 tnz
 gUb
 gHW
@@ -69509,10 +70116,10 @@ wzk
 wzk
 wzk
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 bgK
 bgK
 bgK
@@ -69608,10 +70215,10 @@ jXz
 jXz
 jXz
 bPs
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 tnz
 mUK
 mUK
@@ -69811,10 +70418,10 @@ bgK
 bgK
 bgK
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 bgK
 bgK
 bgK
@@ -69910,10 +70517,10 @@ jXz
 jXz
 jXz
 bPs
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 wQG
 cas
 gqO
@@ -70113,10 +70720,10 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 bgK
 bgK
 bgK
@@ -70212,10 +70819,10 @@ cju
 jXz
 jXz
 bPs
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 xSK
 nxN
@@ -70415,10 +71022,10 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 bgK
 bgK
 cNy
@@ -70514,10 +71121,10 @@ hov
 bPs
 bPs
 bPs
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 dji
 oLO
@@ -70717,10 +71324,10 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 bgK
 bgK
 cNy
@@ -70816,10 +71423,10 @@ cju
 jXz
 jXz
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 fpa
 ihW
@@ -71019,10 +71626,10 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 bgK
 bgK
 cNy
@@ -71118,10 +71725,10 @@ cju
 jXz
 jXz
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 sgY
 ihW
@@ -71321,10 +71928,10 @@ lQD
 lQD
 lQD
 lQD
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 bgK
 bgK
 bgK
@@ -71420,10 +72027,10 @@ eLJ
 jXz
 bgK
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 deC
 wtB
@@ -71624,9 +72231,9 @@ pNV
 pNV
 pNV
 pNV
-cJF
-cJF
-qBv
+kse
+kse
+lQD
 bgK
 bgK
 bgK
@@ -71722,10 +72329,10 @@ cju
 jXz
 vBd
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 xBq
 wtB
@@ -71926,9 +72533,9 @@ kse
 kse
 kse
 kse
-cJF
-cJF
-qBv
+kse
+kse
+lQD
 bgK
 bgK
 bgK
@@ -72024,10 +72631,10 @@ cju
 jXz
 vBd
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 xSK
 xSK
@@ -72326,10 +72933,10 @@ jXz
 jXz
 bgK
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 oLO
 tVT
@@ -72628,10 +73235,10 @@ cju
 jXz
 bgK
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 wtB
 wtB
@@ -72930,10 +73537,10 @@ nvj
 vBd
 bgK
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+lPp
+kse
+lQD
 xSK
 qKM
 tnk
@@ -73232,10 +73839,10 @@ vBd
 bgK
 bgK
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 xSK
 xSK
@@ -73534,10 +74141,10 @@ bPs
 bgK
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 fwT
 tdJ
@@ -73836,10 +74443,10 @@ bgK
 bgK
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 xBm
 wPO
@@ -74138,10 +74745,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 xBm
 fNT
@@ -74440,10 +75047,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 xqX
 kzr
@@ -74742,10 +75349,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 xSK
 jtv
@@ -75044,10 +75651,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 vaB
 dMt
@@ -75346,10 +75953,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 xrw
 oAz
@@ -75648,10 +76255,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 umA
 kzr
@@ -75950,10 +76557,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 xSK
 rlI
@@ -76252,10 +76859,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 caA
 pAV
@@ -76554,10 +77161,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 kTX
 kzr
@@ -76856,10 +77463,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 dUv
 fhT
@@ -77158,10 +77765,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 uqn
 kzr
@@ -77460,10 +78067,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 kzr
 kzr
@@ -77762,10 +78369,10 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 kzr
 pAV
@@ -78064,10 +78671,10 @@ bgK
 bgK
 bgK
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 nxV
 vJG
@@ -78366,10 +78973,10 @@ bgK
 bgK
 bgK
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 cYc
 hST
@@ -78668,10 +79275,10 @@ aNw
 aNw
 aNw
 bgK
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
 xSK
 xSK
 xSK
@@ -78970,25 +79577,25 @@ qXH
 asI
 gyW
 bgK
-qBv
-cJF
-cJF
-qBv
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
+xxR
+vWv
+kse
+aIf
+sNQ
+oCq
+oCq
+aOH
+vDA
+kse
+iAr
+lQD
+kse
+kse
+lQD
 aKq
 aKq
 aKq
@@ -79272,25 +79879,25 @@ bLC
 vMA
 vPM
 bgK
-qBv
-cJF
-cJF
-qBv
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
+cqX
+jNO
+kse
+kse
+kse
+kse
+eFJ
+kse
+kse
+kse
+kse
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -79574,25 +80181,25 @@ vMA
 tDl
 gyW
 bgK
-qBv
-cJF
-cJF
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
+cqX
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -79876,25 +80483,25 @@ qMI
 cjQ
 cjQ
 mIB
-qBv
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+hMi
+kse
+kse
+kse
+kse
+kse
+kse
+oAf
+kQj
+kse
+kse
+kse
+hMi
+kse
+kse
+lQD
 yhR
 yhR
 aKq
@@ -80178,25 +80785,25 @@ tDl
 tDl
 bET
 mIB
-qBv
-cJF
-eYF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+hMi
+kse
+kse
+kse
+kse
+kse
+kse
+kQj
+jkV
+kse
+kse
+kse
+hMi
+kse
+kse
+lQD
 yhR
 yhR
 aKq
@@ -80480,25 +81087,25 @@ vMA
 bET
 toa
 cNy
-qBv
-cJF
-cJF
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
+bBG
+kse
+kse
+kse
+hQe
+kse
+kse
+kse
+kse
+kse
+mUF
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 aKq
@@ -80782,25 +81389,25 @@ guH
 vMA
 uju
 cNy
-qBv
-cJF
-cJF
-qBv
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
+kse
+kse
+frK
+kse
+kse
+kse
+kse
+kse
+sNQ
+kse
+kse
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 aKq
@@ -81084,25 +81691,25 @@ eUR
 jKq
 nzB
 cNy
-qBv
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
+vNs
+oCq
+sel
+aOH
+oCq
+kse
+aIf
+mbY
+kse
+aIf
+xth
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 aKq
@@ -81386,25 +81993,25 @@ vMA
 vMA
 kiQ
 cNy
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+sNQ
+aIf
+lQD
+lQD
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 aKq
@@ -81688,25 +82295,25 @@ vMA
 vMA
 kHX
 cNy
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 aKq
@@ -81990,25 +82597,25 @@ cbO
 sLt
 eIw
 cNy
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 aKq
@@ -82292,25 +82899,25 @@ cNy
 cNy
 cNy
 cNy
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lPp
+lQD
+lQD
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -82598,21 +83205,21 @@ bgK
 bgK
 bgK
 bgK
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+iLR
+kRs
+kRs
+kRs
+kRs
+kRs
+kRs
+iwH
+ggM
+iwH
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -82900,33 +83507,33 @@ cNy
 cNy
 cNy
 cNy
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+iLR
+qKR
+dxh
+sze
+sOA
+hId
+hGz
+utp
+gEn
+yem
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
+rxM
+rxM
+rxM
+rxM
+rxM
+rxM
+rxM
+rxM
 rxM
 rcS
 rcS
@@ -83202,32 +83809,32 @@ wCz
 qkm
 aFR
 cNy
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+iLR
+dwl
+amX
+kRs
+pyo
+lOK
+kvR
+mfy
+gEn
+jUO
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
-qBv
+rxM
 vol
-plQ
-plQ
-plQ
-plQ
-plQ
+rcS
+rcS
+rcS
+rcS
+rcS
 wtg
 pef
 rcS
@@ -83504,32 +84111,32 @@ iFO
 dxU
 wdw
 cNy
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+iLR
+ljJ
+sOA
+kRs
+sOA
+sOA
+lTY
+utp
+gEn
+yem
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
-qBv
-plQ
-plQ
-plQ
-plQ
+rxM
+rcS
+rcS
+rcS
+rcS
 mBw
-plQ
+rcS
 bmu
 rxM
 rPB
@@ -83806,33 +84413,33 @@ dZm
 uBc
 yfn
 cNy
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+iLR
+kRs
+tVe
+kRs
+tVe
+kRs
+kRs
+utp
+gEn
+yem
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
-qBv
-qBv
-qBv
-iwH
-qBv
-qBv
-qBv
-qBv
+rxM
+rxM
+rxM
+pef
+rxM
+rxM
+rxM
+rxM
 rxM
 rYQ
 gdl
@@ -84109,31 +84716,31 @@ lwy
 vsn
 cNy
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
+kRs
+sOA
+sOA
+sOA
+kwh
+kRs
+kRs
+jww
+kRs
+kRs
+lQD
 dzT
-cJF
-qBv
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
 yhR
-qBv
+rxM
 rcj
-plQ
-plQ
+rcS
+rcS
 iSq
-qBv
+rxM
 yhR
 pqI
 agY
@@ -84411,31 +85018,31 @@ lwy
 kqr
 cNy
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+pRT
+sOA
+sOA
+sOA
+jOG
+aGA
+aGA
+gLQ
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
 yhR
-qBv
+rxM
 jjr
-plQ
+rcS
 mBw
 tbv
-qBv
+rxM
 yhR
 qBv
 cWw
@@ -84713,31 +85320,31 @@ lcW
 qkm
 cNy
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+kRM
+ehl
+sOA
+sOA
+kRs
+aGA
+aGA
+aGA
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
 yhR
-qBv
+rxM
 qAQ
-utp
+meB
 oGS
 wlP
-qBv
+rxM
 yhR
 qBv
 tTn
@@ -85015,31 +85622,31 @@ lcW
 aug
 cNy
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+jlb
+sOA
+sOA
+sOA
+ecv
+gLQ
+wXH
+aGA
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
 yhR
-qBv
-qBv
-qBv
-qBv
-iwH
-qBv
+rxM
+rxM
+rxM
+rxM
+pef
+rxM
 yhR
 vYY
 vYY
@@ -85317,31 +85924,31 @@ lwy
 xmL
 cNy
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+kwh
+sOA
+sOA
+kwh
+kRs
+kRs
+sze
+kRs
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
 yhR
-qBv
+rxM
 hYG
 kSe
-pvy
-pvy
-qBv
+xiT
+xiT
+rxM
 yhR
 yhR
 qJP
@@ -85619,31 +86226,31 @@ lwy
 fbb
 cNy
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+kRs
+tVe
+kRs
+kRs
+kRs
+dVc
+oPG
+anc
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
 yhR
-qBv
+rxM
 ueV
 bnt
 pPm
-pvy
-qBv
+xiT
+rxM
 yhR
 yhR
 yhR
@@ -85921,31 +86528,31 @@ hZx
 wdw
 cNy
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+sOA
+sOA
+sOA
+sOA
+cIa
+ehl
+sOA
+yfU
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
 yhR
-qBv
+rxM
 tzt
 kSe
 pPm
 pPm
-qBv
+rxM
 yhR
 yhR
 yhR
@@ -86223,31 +86830,31 @@ nlJ
 yfn
 cNy
 bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+oiL
+vOn
+sOA
+sOA
+kRs
+sOA
+ehl
+sOA
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
 yhR
-qBv
+rxM
 cml
 cml
 cml
 iJl
-qBv
+rxM
 yhR
 yhR
 yhR
@@ -86524,32 +87131,32 @@ wCz
 spL
 qkm
 cNy
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+iLR
+kRs
+kFE
+dQm
+vFV
+sOA
+kRs
+kRs
+aRO
+vta
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
 yhR
-qBv
+rxM
 qrp
 fbV
 oPL
 oPL
-qBv
+rxM
 yhR
 yhR
 yhR
@@ -86826,32 +87433,32 @@ cNy
 cNy
 cNy
 cNy
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+iLR
+cGm
+vuX
+lrk
+hhJ
+sOA
+sOA
+kRs
+kRs
+kRs
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
 aKq
 yhR
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
+rxM
+rxM
+rxM
+rxM
+rxM
+rxM
 yhR
 yhR
 yhR
@@ -87128,24 +87735,24 @@ bgK
 bgK
 bgK
 bgK
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
-qBv
-qBv
-qBv
+iLR
+jSA
+sOA
+ehl
+tCA
+sOA
+sOA
+sOA
+sOA
+wJM
+kRs
+lQD
+kse
+kse
+lQD
+lQD
+lQD
+lQD
 aKq
 yhR
 yhR
@@ -87430,24 +88037,24 @@ bgK
 bgK
 bgK
 bgK
-bgK
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+iLR
+kRs
+sOA
+jwn
+sOA
+sOA
+sOA
+sOA
+sOA
+tAh
+kRs
+lQD
+kse
+kse
+lQD
 jer
-vFV
-qBv
+hco
+lQD
 aKq
 yhR
 yhR
@@ -87733,23 +88340,23 @@ wAm
 wAm
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-jOg
-cJF
+kRs
+kRs
+kRs
+kRs
+kRs
+khW
+ehl
+sOA
+cjs
+kRs
+lQD
+kse
+kse
+qGI
+kse
 hUz
-qBv
+lQD
 aKq
 yhR
 yhR
@@ -88039,19 +88646,19 @@ wAm
 wAm
 wAm
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
-cJF
-cJF
-qBv
+kRs
+bil
+sOA
+sOA
+wJM
+kRs
+lQD
+kse
+kse
+lQD
+kse
+kse
+lQD
 aKq
 yhR
 yhR
@@ -88341,19 +88948,19 @@ cPW
 ogS
 fLw
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
-qBv
-qBv
-qBv
+kRs
+wSy
+sOA
+sOA
+gXw
+kRs
+lQD
+kse
+kse
+lQD
+lQD
+lQD
+lQD
 aKq
 yhR
 yhR
@@ -88643,16 +89250,16 @@ dxf
 nuv
 uvO
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+twz
+sOA
+sOA
+oHS
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -88945,16 +89552,16 @@ pXM
 nhE
 dyQ
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+kRs
+oEv
+phk
+kRs
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -89247,16 +89854,16 @@ uSn
 wAm
 wAm
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+ryg
+sOA
+ehl
+uoN
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -89548,17 +90155,17 @@ wAm
 kDq
 ncc
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+kRs
+jFg
+nPV
+sOA
+kSG
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -89850,17 +90457,17 @@ oSc
 emA
 gSM
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+fKj
+sOA
+sOA
+sOA
+ljb
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -90152,17 +90759,17 @@ neG
 lXT
 sxY
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+vDS
+sOA
+sOA
+sOA
+sOA
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -90454,17 +91061,17 @@ wAm
 nuv
 uvO
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+lKp
+sOA
+jwn
+sOA
+sOA
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -90756,17 +91363,17 @@ mvc
 nuv
 uvO
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+kRs
+tVe
+kRs
+kRs
+tVe
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -91058,17 +91665,17 @@ tvg
 eTX
 cbY
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+szG
+ehl
+kRs
+szG
+sOA
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -91360,17 +91967,17 @@ wAm
 wAm
 wAm
 wAm
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+nCO
+nEm
+sze
+nCO
+nEm
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -91662,17 +92269,17 @@ qBv
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+fcC
+sOA
+kRs
+fcC
+sOA
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -91964,17 +92571,17 @@ yhR
 yhR
 yhR
 yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-yhR
-qBv
-cJF
-cJF
-qBv
+kRs
+kRs
+kRs
+kRs
+kRs
+kRs
+kRs
+lQD
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -92258,31 +92865,31 @@ jFG
 hQa
 sCG
 mlR
-wAm
-wAm
-wAm
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-cJF
-cJF
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+kse
+kse
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
 yhR
 yhR
 yhR
@@ -92560,31 +93167,31 @@ jFG
 hQa
 eWK
 wAm
-qBv
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -92862,31 +93469,31 @@ gVn
 gBZ
 sCG
 wAm
-qBv
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-eYF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+lPp
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -93164,31 +93771,31 @@ wAm
 pNN
 wAm
 wAm
-qBv
-iYe
-cJF
-cJF
-cJF
+lQD
+scV
+kse
+kse
+kse
 qzN
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
+kse
+kse
+kse
+kse
+kse
+kse
+kse
 qzN
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-cJF
-qBv
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -93466,31 +94073,31 @@ yhR
 yhR
 yhR
 yhR
-qBv
-cJF
-cJF
-cJF
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-qBv
-cJF
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+kse
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+lQD
+kse
+kse
+kse
+lQD
 yhR
 yhR
 yhR
@@ -93768,11 +94375,11 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+kse
+lQD
 lWI
 lWI
 lWI
@@ -93790,8 +94397,8 @@ lWI
 lWI
 lQD
 sEd
-cJF
-cJF
+kse
+kse
 lQD
 bgK
 oEb
@@ -94070,11 +94677,11 @@ lWI
 lWI
 lWI
 lWI
-qBv
-cJF
-cJF
-cJF
-qBv
+lQD
+kse
+kse
+kse
+lQD
 lWI
 lWI
 lWI
@@ -94092,7 +94699,7 @@ lWI
 lWI
 lQD
 vUe
-cJF
+kse
 pPu
 lQD
 bgK
@@ -94373,10 +94980,10 @@ lQD
 lQD
 lQD
 lQD
-xth
-cJF
-cJF
-qBv
+kse
+kse
+kse
+lQD
 lWI
 lWI
 lWI
@@ -94393,9 +95000,9 @@ lQD
 lQD
 lQD
 lQD
-cJF
-cJF
-cJF
+kse
+kse
+kse
 lQD
 bgK
 bgK
@@ -94677,8 +95284,8 @@ kse
 kse
 gUy
 tUQ
-cJF
-qBv
+kse
+lQD
 lWI
 lWI
 lWI
@@ -94693,11 +95300,11 @@ qQy
 cLZ
 cLZ
 cLZ
-cLZ
-pcq
-pcq
-pcq
-pcq
+ovK
+kse
+kse
+kse
+kse
 lQD
 lQD
 lQD
@@ -94980,7 +95587,7 @@ kse
 oQX
 kse
 hdd
-qBv
+lQD
 lWI
 lWI
 lWI
@@ -94995,13 +95602,13 @@ qWU
 qWU
 qWU
 qWU
-fvu
-pcq
-pcq
-pcq
+jRB
+kse
+kse
+kse
 oen
 nYk
-gzT
+eok
 cLZ
 lWI
 lWI
@@ -95282,7 +95889,7 @@ lQD
 lQD
 lQD
 lQD
-qBv
+lQD
 lWI
 lWI
 lWI
@@ -95297,11 +95904,11 @@ uWn
 uyT
 qWU
 wCO
-cLZ
-ehl
-pcq
-pcq
-pcq
+ovK
+vOa
+kse
+kse
+kse
 qAy
 fTa
 cLZ
@@ -95599,13 +96206,13 @@ qWU
 heZ
 qWU
 aTy
-cLZ
-cLZ
-pcq
-pcq
-pcq
-pcq
-bRg
+ovK
+ovK
+kse
+kse
+kse
+kse
+giY
 cLZ
 lWI
 lWI
@@ -95902,12 +96509,12 @@ qWU
 uGh
 mlU
 uyT
-cLZ
-qbG
-pcq
-pcq
-pcq
-mrD
+ovK
+scV
+kse
+kse
+kse
+pPu
 cLZ
 lWI
 lWI
@@ -96204,12 +96811,12 @@ uGh
 vsy
 heZ
 vJF
-cLZ
-pcq
-pcq
-pcq
-ehl
-sOA
+ovK
+kse
+kse
+kse
+vOa
+tUQ
 cLZ
 lWI
 lWI
@@ -96506,12 +97113,12 @@ nSo
 tfe
 uyT
 wCO
-cLZ
-pcq
-pcq
-pcq
-yem
-okU
+ovK
+kse
+kse
+kse
+oQX
+vPe
 cLZ
 cLZ
 cLZ
@@ -96808,12 +97415,12 @@ sBP
 buX
 uGh
 qWU
-cLZ
-pcq
-pcq
-uQR
-pcq
-rPU
+ovK
+kse
+kse
+rDF
+kse
+txQ
 cLZ
 tNl
 jpo
@@ -97110,12 +97717,12 @@ wVb
 rTq
 vsy
 heZ
-cLZ
+ovK
 btG
-pcq
-pcq
-pcq
-pcq
+kse
+kse
+kse
+kse
 cLZ
 fQu
 jrQ
@@ -97412,12 +98019,12 @@ xLx
 qWU
 nMh
 qWU
-cLZ
-iLR
-pcq
-pcq
-pcq
-pcq
+ovK
+xLe
+kse
+kse
+kse
+kse
 mJi
 dzx
 jrQ
@@ -97714,12 +98321,12 @@ heZ
 uGh
 uyT
 qWU
-cLZ
-jUO
-pcq
-pcq
-pcq
-pcq
+ovK
+hdd
+kse
+kse
+kse
+kse
 mJi
 dzx
 jrQ
@@ -98016,12 +98623,12 @@ vsy
 vsy
 tmZ
 drv
-cLZ
-kRs
-pcq
-pcq
-pcq
-pcq
+ovK
+gUy
+kse
+kse
+kse
+kse
 cLZ
 dlJ
 jrQ
@@ -98318,12 +98925,12 @@ nSo
 vsy
 nMh
 uyT
-cLZ
-vDS
-pcq
-pcq
-pcq
-pcq
+ovK
+fKm
+kse
+kse
+kse
+kse
 cLZ
 lAP
 oju
@@ -98620,11 +99227,11 @@ nUo
 bXy
 nSo
 uGs
-cLZ
-kRs
-pcq
-pcq
-pcq
+ovK
+gUy
+kse
+kse
+kse
 rsJ
 cLZ
 cLZ
@@ -98922,12 +99529,12 @@ qJV
 qJV
 qJV
 rTq
-cLZ
+ovK
 hfk
 hwx
-pcq
-pcq
-pcq
+kse
+kse
+kse
 ovK
 lWI
 lWI
@@ -99212,24 +99819,24 @@ lWI
 lWI
 lWI
 lWI
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
 nvy
-pcq
-pcq
-ehl
-mrD
+kse
+kse
+vOa
+pPu
 ovK
 lWI
 lWI
@@ -99509,29 +100116,29 @@ nXz
 nXz
 nXz
 bgK
-kjb
-kjb
-kjb
-kjb
-kjb
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
+hjZ
+hjZ
+hjZ
+hjZ
+hjZ
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
 aYM
-pcq
-bRg
+kse
+giY
 gWr
-gzT
+eok
 ovK
 lWI
 lWI
@@ -99811,29 +100418,29 @@ nXz
 nXz
 nXz
 bgK
-kjb
+hjZ
 mgl
 qZO
 gGT
-kjb
-qbG
-pcq
-pcq
-pcq
-pcq
-pcq
-pcq
-pcq
-pcq
-rPU
+hjZ
+scV
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+txQ
 dsw
-okU
+vPe
 gWr
-pcq
-pcq
-pcq
+kse
+kse
+kse
 tIQ
-buf
+wvg
 ovK
 lWI
 lWI
@@ -100113,28 +100720,28 @@ nXz
 nXz
 nXz
 bgK
-kjb
+hjZ
 wRO
 gGT
 gGT
-fvu
-pcq
-pcq
-pcq
-nPV
+jRB
+kse
+kse
+kse
+lWy
 agW
 azE
-pcq
-pcq
-pcq
-pcq
-pcq
-pcq
-pcq
-pcq
-pcq
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
+kse
 uMZ
-pcq
+kse
 mGT
 ovK
 lWI
@@ -100415,29 +101022,29 @@ nXz
 nXz
 nXz
 bgK
-kjb
+hjZ
 gbW
 czE
 gGT
-kjb
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
-cLZ
+hjZ
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
+ovK
 ovK
 lWI
 lWI
@@ -100717,11 +101324,11 @@ nXz
 nXz
 nXz
 bgK
-kjb
-kjb
-djq
-kjb
-kjb
+hjZ
+hjZ
+oIz
+hjZ
+hjZ
 lWI
 lWI
 lWI
@@ -130883,18 +131490,18 @@ xSK
 xSK
 xSK
 xSK
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-bgK
+sgJ
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -131184,19 +131791,19 @@ oUK
 rBG
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -131487,18 +132094,18 @@ cIm
 kaL
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -131789,18 +132396,18 @@ cIm
 kIq
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -132091,18 +132698,18 @@ hJs
 sgJ
 kIq
 kIq
-hJs
-hJs
-hJs
-hJs
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -132381,30 +132988,30 @@ mJr
 xZc
 sSf
 xSK
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
 sgJ
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -132683,7 +133290,7 @@ pTM
 mJd
 sSf
 xSK
-auJ
+sgJ
 sgJ
 sgJ
 sgJ
@@ -132695,18 +133302,18 @@ sgJ
 sgJ
 kaL
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -132985,7 +133592,7 @@ pTM
 mJd
 sSf
 xSK
-auJ
+sgJ
 sgJ
 sgJ
 sgJ
@@ -132997,18 +133604,18 @@ sgJ
 sgJ
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -133287,30 +133894,30 @@ pTM
 mJr
 cRO
 xSK
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+kIq
+kIq
+kIq
 auJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-kIq
-kIq
-kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -133589,30 +134196,30 @@ xTU
 uUN
 sgJ
 xSK
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+kIq
+kIq
+kIq
+kIq
+kIq
 auJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-kIq
-kIq
-kIq
-kIq
-kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -133891,7 +134498,7 @@ peH
 auJ
 auJ
 xSK
-auJ
+sgJ
 sgJ
 sgJ
 sgJ
@@ -133902,19 +134509,19 @@ kIq
 kIq
 kIq
 kaL
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+auJ
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -134193,7 +134800,7 @@ auJ
 auJ
 auJ
 xSK
-auJ
+sgJ
 sgJ
 sgJ
 sgJ
@@ -134203,20 +134810,20 @@ kaL
 kIq
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+auJ
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -134495,30 +135102,30 @@ auJ
 auJ
 xyr
 xSK
+sgJ
+sgJ
+sgJ
+sgJ
+kIq
+kIq
+kIq
+kIq
+kIq
 auJ
-sgJ
-sgJ
-sgJ
-kIq
-kIq
-kIq
-kIq
-kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -134797,30 +135404,30 @@ auJ
 uZG
 maY
 xSK
+sgJ
+sgJ
+sgJ
+sgJ
+kIq
+kIq
+kIq
+kIq
+kIq
 auJ
-sgJ
-sgJ
-sgJ
-kIq
-kIq
-kIq
-kIq
-kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -135099,30 +135706,30 @@ uZG
 uYB
 sgJ
 xSK
+sgJ
+sgJ
+sgJ
+sgJ
+kIq
+kIq
+kIq
+kIq
+kIq
 auJ
-sgJ
-sgJ
-sgJ
-kIq
-kIq
-kIq
-kIq
-kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -135401,7 +136008,7 @@ vFZ
 fvK
 sgJ
 xSK
-auJ
+sgJ
 sgJ
 sgJ
 sgJ
@@ -135410,21 +136017,21 @@ kaL
 kIq
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -135703,30 +136310,30 @@ dty
 mJd
 sSf
 xSK
+sgJ
+sgJ
+sgJ
+sgJ
+kIq
+kIq
+kIq
+kIq
+kIq
 auJ
-sgJ
-sgJ
-sgJ
-kIq
-kIq
-kIq
-kIq
-kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 auJ
-bgK
+auJ
+auJ
+auJ
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -136005,7 +136612,7 @@ ify
 mJd
 gKT
 xSK
-auJ
+sgJ
 sgJ
 sgJ
 sgJ
@@ -136014,21 +136621,21 @@ kIq
 kIq
 kIq
 kaL
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
+auJ
+yhR
+yhR
+yhR
+yhR
+yhR
+auJ
+auJ
 kIq
 sRu
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -136307,30 +136914,30 @@ yif
 gKT
 gKT
 xSK
+sgJ
+sgJ
+sgJ
+kIq
+kIq
+kIq
+kIq
+kIq
+kIq
 auJ
-sgJ
-sgJ
-kIq
-kIq
-kIq
-kIq
-kIq
-kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-kIq
-kIq
-kIq
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+auJ
+auJ
+kIq
+kIq
+kIq
+auJ
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -136609,7 +137216,7 @@ jNF
 uVn
 jNF
 xSK
-auJ
+sgJ
 sgJ
 kIq
 kIq
@@ -136619,20 +137226,20 @@ kaL
 kIq
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
+auJ
+yhR
+yhR
+auJ
+auJ
 kIq
 kaL
 kIq
 kIq
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -136911,30 +137518,30 @@ tDb
 xZc
 isW
 xSK
+sgJ
+sgJ
+kIq
+kIq
+kIq
+kIq
+kIq
+kIq
+kIq
+kIq
 auJ
-sgJ
-kIq
-kIq
-kIq
-kIq
-kIq
-kIq
-kIq
-kIq
-sgJ
-sgJ
-sgJ
-sgJ
-kIq
-kIq
-kIq
-kIq
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+auJ
+auJ
+kIq
+kIq
+kIq
+kIq
+auJ
+auJ
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -137213,7 +137820,7 @@ pTM
 mJd
 sSf
 xSK
-auJ
+sgJ
 sgJ
 kIq
 kaL
@@ -137230,13 +137837,13 @@ kIq
 kIq
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+auJ
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -137515,7 +138122,7 @@ gKT
 mJd
 sSf
 xSK
-auJ
+sgJ
 sgJ
 kIq
 kIq
@@ -137531,14 +138138,14 @@ kaL
 kIq
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+auJ
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -137817,7 +138424,7 @@ gKT
 mJd
 gKT
 xSK
-auJ
+sgJ
 sgJ
 kIq
 kIq
@@ -137827,20 +138434,20 @@ kIq
 kaL
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+auJ
+auJ
+auJ
+auJ
+auJ
+auJ
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -138119,7 +138726,7 @@ pTM
 gKT
 sSf
 xSK
-auJ
+sgJ
 sgJ
 kaL
 kIq
@@ -138129,20 +138736,20 @@ kIq
 kIq
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -138421,7 +139028,7 @@ pTM
 mJd
 gKT
 xSK
-auJ
+sgJ
 sgJ
 sgJ
 kIq
@@ -138430,21 +139037,21 @@ kIq
 kIq
 kIq
 kIq
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
-sgJ
 auJ
 auJ
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 yhR
 yhR
 yhR
@@ -138723,7 +139330,6 @@ pTM
 mJd
 gKT
 xSK
-auJ
 sgJ
 sgJ
 sgJ
@@ -138733,27 +139339,28 @@ sgJ
 sgJ
 sgJ
 sgJ
-sgJ
 auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
-bgK
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
+yhR
 lQD
 kse
 set
@@ -139025,18 +139632,18 @@ pTM
 mJd
 sSf
 xSK
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
+sgJ
 auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
-auJ
+yhR
+yhR
 xSK
 xSK
 xSK
@@ -139338,7 +139945,7 @@ xSK
 xSK
 xSK
 xSK
-auJ
+yhR
 xSK
 mPd
 pet
@@ -139640,7 +140247,7 @@ tju
 tju
 rwb
 xSK
-auJ
+yhR
 xSK
 cKx
 xvo
@@ -139942,7 +140549,7 @@ pLs
 wIh
 vSB
 xSK
-auJ
+yhR
 xSK
 xvo
 gKT
@@ -140244,7 +140851,7 @@ nek
 tju
 fqr
 xSK
-auJ
+yhR
 xSK
 uJi
 dAF
@@ -140546,7 +141153,7 @@ oab
 tju
 hJn
 xSK
-auJ
+yhR
 xSK
 cKx
 pet
@@ -140848,7 +141455,7 @@ anJ
 tju
 hJn
 xSK
-auJ
+yhR
 xSK
 viP
 wsJ


### PR DESCRIPTION
## What this adds/tweaks, screenshots included.
-Green hell radioactive bunker of doom stocked with ghouls and once you get past the initial area, protectons, sentries, gutsies, bla. A pre-war research post. Rewards for this are EXTREMELY good. May require tweaking later. Who's to say
<img width="322" height="850" alt="Screenshot 2026-04-06 143342" src="https://github.com/user-attachments/assets/e50f5077-8df1-4cba-b448-327befdf1bb3" />

-Gives the Followers 4 disablers off spawn. I'm grudgecoding this out the minute I see a follower dual wield disablers with raider triggers on them. This is just for your pacifist larp.

-Adds a brutalist architecture base that is essentially entirely ready to use the minute it's cleared, just requires cleaning and power for the generator. And locks probably.
<img width="670" height="288" alt="Screenshot 2026-04-06 143326" src="https://github.com/user-attachments/assets/8dd66457-5c5d-4574-94f7-2a4f784d330d" />

-Adjusted some stuff with the square of dense rock in Tiny's place, there's now more caves for sewer mines, and the dense rock just lines the path.
<img width="763" height="566" alt="Screenshot 2026-04-06 143349" src="https://github.com/user-attachments/assets/1728c7d1-abb1-4242-a8b1-e84f4932f783" />

-new sewer goon den
<img width="430" height="546" alt="Screenshot 2026-04-06 144345" src="https://github.com/user-attachments/assets/6a5ab66d-6a20-4bb4-814b-6ef24f0552f4" />