### PR TITLE
Mapping Fixes / Less static loot

### DIFF
--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Sky.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Sky.dmm
@@ -429,6 +429,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"bw" = (
+/obj/machinery/power/port_gen/pacman/diesel{
+	anchored = 1
+	},
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "bx" = (
 /obj/structure/lattice,
 /obj/effect/decal/cleanable/dirt,
@@ -606,6 +614,12 @@
 /obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/wood_fancy,
 /area/maintenance/bar)
+"ca" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "cb" = (
 /obj/structure/table,
 /turf/open/floor/holofloor/carpet,
@@ -617,6 +631,12 @@
 /obj/machinery/light,
 /turf/open/floor/wood_wide,
 /area/f13/ambientlighting/building/j)
+"cd" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "ce" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -801,6 +821,13 @@
 /obj/item/clothing/under/f13/ncr_camo,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"cT" = (
+/obj/structure/fluff/railing,
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "cU" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowvertical"
@@ -836,6 +863,11 @@
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
+/area/f13/building/powered)
+"da" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "db" = (
 /turf/open/floor/holofloor/carpet,
@@ -892,6 +924,15 @@
 	icon_state = "darkrusty";
 	name = "dirty floor"
 	},
+/area/f13/building/powered)
+"di" = (
+/obj/structure/junk/locker,
+/obj/item/clothing/mask/chameleon,
+/obj/item/clothing/glasses/hud/diagnostic{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "dk" = (
 /obj/machinery/light,
@@ -1136,6 +1177,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/f13/followers)
+"ec" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/junk/small/bed,
+/obj/effect/overlay/junk/curtain,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "ee" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
@@ -1203,6 +1250,12 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/p)
+"eo" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "er" = (
 /turf/open/floor/wood_common/wood_common_light,
 /area/f13/wasteland)
@@ -1612,6 +1665,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"fH" = (
+/obj/machinery/smoke_machine{
+	name = "generator mechanism"
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "fI" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -2096,6 +2155,11 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/ncr)
+"hm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/wardrobe,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "hn" = (
 /obj/structure/closet/locker,
 /turf/open/floor/f13/wood{
@@ -2509,6 +2573,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/maintenance/bar)
+"iH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/blanket,
+/obj/effect/overlay/junk/curtain,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "iJ" = (
 /obj/structure/fluff/railing/corner{
 	color = "#A47449";
@@ -2608,6 +2679,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/powered)
+"jb" = (
+/obj/structure/chair/stool/retro/tan,
+/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
+/area/f13/wasteland)
 "jc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/f13/decanvet,
@@ -2902,6 +2977,11 @@
 	icon_state = "greenrustyfull"
 	},
 /area/f13/followers)
+"kb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/dresser,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "kd" = (
 /obj/machinery/porta_turret/f13/turret_shotgun/burstfire/robot,
 /obj/structure/lattice,
@@ -3126,6 +3206,13 @@
 "kP" = (
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/p)
+"kQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "kR" = (
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/f13{
@@ -3142,6 +3229,22 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legioncamp)
+"kT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/f13/turret_shotgun/burstfire,
+/obj/machinery/light/fo13colored/Red{
+	desc = "A lighting fixture.";
+	dir = 8;
+	light_color = "#008000";
+	name = "light tube"
+	},
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
+"kU" = (
+/obj/item/trash/pistachios,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "kX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -3191,6 +3294,12 @@
 	icon_state = "darkdirtysolid"
 	},
 /area/f13/wasteland)
+"le" = (
+/obj/structure/fluff/railing/corner{
+	dir = 2
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "lf" = (
 /obj/item/bedsheet/blanket,
 /obj/structure/bed,
@@ -3225,6 +3334,9 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
+"lk" = (
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "ll" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -3689,6 +3801,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"mD" = (
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "mE" = (
 /turf/open/transparent/openspace{
 	name = "air";
@@ -3792,6 +3909,10 @@
 /obj/item/clothing/under/f13/ncr_camo,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"nf" = (
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "nh" = (
 /obj/effect/turf_decal/big{
 	dir = 1
@@ -3981,6 +4102,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/powered)
+"nT" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "nV" = (
 /obj/structure/janitorialcart,
 /obj/effect/decal/cleanable/dirt,
@@ -4140,6 +4265,12 @@
 	color = "#c5bab2"
 	},
 /area/f13/building/abandoned/z)
+"ot" = (
+/obj/structure/fluff/railing{
+	dir = 5
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "ou" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/big{
@@ -4640,6 +4771,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ambientlighting/building/c)
+"pR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/pet/dog/pug,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "pS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/ash/large,
@@ -4698,6 +4835,13 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"qd" = (
+/obj/structure/fluff/railing,
+/obj/structure/fluff/railing/corner{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "qe" = (
 /obj/machinery/msgterminal/followers{
 	dir = 8
@@ -4905,6 +5049,10 @@
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt"
 	},
+/area/f13/wasteland)
+"qO" = (
+/obj/structure/reagent_dispensers/rainwater_tank,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/wasteland)
 "qP" = (
 /obj/structure/chair/comfy/black{
@@ -5175,6 +5323,15 @@
 /obj/machinery/jukebox/radio,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/building/abandoned/l)
+"rG" = (
+/obj/structure/chair/stool/retro/black,
+/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
+/area/f13/wasteland)
+"rH" = (
+/obj/machinery/atmospherics/components/unary/tank,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "rK" = (
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/e)
@@ -5323,6 +5480,11 @@
 	icon_state = "wide-broken1"
 	},
 /area/f13/wasteland)
+"sk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/simple_door/bunker/glass,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "sl" = (
 /obj/effect/spawner/lootdrop/trash,
 /obj/effect/decal/cleanable/dirt{
@@ -5375,6 +5537,10 @@
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"st" = (
+/obj/structure/simple_door/bunker/glass,
+/turf/closed/wall/f13/store,
+/area/f13/building/powered)
 "su" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/wood_wide,
@@ -5413,6 +5579,13 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"sB" = (
+/obj/item/storage/trash_stack{
+	icon_state = "Junk_11"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "sC" = (
 /obj/structure/sign/poster/prewar/poster81,
 /turf/closed/wall/mineral/concrete,
@@ -5557,6 +5730,14 @@
 	},
 /turf/open/floor/plating,
 /area/engine/workshop)
+"tb" = (
+/obj/item/storage/trash_stack,
+/obj/item/storage/trash_stack{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "tc" = (
 /obj/machinery/light{
 	dir = 4
@@ -5628,6 +5809,10 @@
 /obj/structure/bed/old,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/m)
+"to" = (
+/obj/machinery/atmospherics/components/unary/tank,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "tp" = (
 /mob/living/simple_animal/hostile/securitron/sentrybot,
 /obj/machinery/light/fo13colored/Red{
@@ -6069,6 +6254,13 @@
 /turf/open/floor/wood_wide{
 	icon_state = "wide-broken5"
 	},
+/area/f13/wasteland)
+"uR" = (
+/obj/machinery/smoke_machine{
+	name = "generator mechanism"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/wasteland)
 "uS" = (
 /obj/item/storage/toolbox/mechanical/old,
@@ -6962,6 +7154,12 @@
 "xM" = (
 /turf/closed/wall/f13/wood/interior,
 /area/f13/clinic)
+"xN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bedsheetbin,
+/obj/structure/table,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "xO" = (
 /mob/living/simple_animal/hostile/handy/gutsy/flamer,
 /turf/open/floor/plasteel/f13/vault_floor/blue/side,
@@ -7016,6 +7214,12 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"xX" = (
+/obj/machinery/workbench,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/floor,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "xY" = (
 /obj/machinery/photocopier,
 /turf/open/floor/f13{
@@ -7368,6 +7572,14 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/building/abandoned/n)
+"zk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_metal,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/weapons/oldarmyelite,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "zl" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/wood_common,
@@ -7620,6 +7832,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"Ab" = (
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "Ac" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/wood_common,
@@ -7767,6 +7983,10 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"AC" = (
+/obj/machinery/workbench/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "AD" = (
 /obj/structure/table/wood/bar,
 /obj/item/binoculars,
@@ -7850,6 +8070,15 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"AV" = (
+/obj/structure/fluff/railing/corner{
+	dir = 8
+	},
+/obj/structure/fluff/railing{
+	dir = 1
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "AW" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -7978,6 +8207,13 @@
 /obj/effect/landmark/start/f13/mayor,
 /turf/open/floor/carpet/black,
 /area/maintenance/bar)
+"By" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/mre,
+/obj/effect/spawner/lootdrop/mre,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "Bz" = (
 /obj/structure/chair/comfy/plywood{
 	dir = 8
@@ -8014,6 +8250,11 @@
 	},
 /turf/open/floor/wood_wide,
 /area/f13/wasteland)
+"BE" = (
+/obj/structure/wreck/trash/machinepiletwo,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "BF" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier3,
@@ -8033,6 +8274,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/purple,
 /area/f13/ambientlighting/building/c)
+"BH" = (
+/obj/structure/junk/locker,
+/obj/item/clothing/mask/chameleon,
+/obj/item/clothing/glasses/hud/diagnostic{
+	pixel_y = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "BJ" = (
 /obj/structure/debris/v1,
 /turf/open/floor/f13{
@@ -8129,6 +8382,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet,
 /area/f13/ambientlighting/building/c)
+"BZ" = (
+/obj/structure/fluff/railing/corner{
+	dir = 4
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "Cb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -9009,6 +9268,10 @@
 /obj/machinery/light,
 /turf/open/transparent/openspace,
 /area/f13/bar)
+"EU" = (
+/obj/structure/table/booth,
+/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
+/area/f13/wasteland)
 "EV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -9494,6 +9757,11 @@
 	},
 /turf/open/floor/wood_fancy,
 /area/f13/bar)
+"Gv" = (
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "Gw" = (
 /obj/structure/tires/five,
 /obj/item/clothing/head/welding,
@@ -9773,6 +10041,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/legioncamp)
+"Hp" = (
+/obj/structure/simple_door/bunker/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "Hq" = (
 /obj/item/stack/cable_coil/cut,
 /obj/effect/decal/cleanable/oil{
@@ -9969,6 +10243,11 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"HV" = (
+/obj/machinery/porta_turret/f13/turret_shotgun/burstfire,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "HW" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/structure/chair/office{
@@ -10110,6 +10389,9 @@
 /obj/item/gun/energy/laser/plasma/glock,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/powered)
+"Ip" = (
+/turf/closed/wall/f13/store,
+/area/f13/building/powered)
 "Ir" = (
 /obj/item/storage/trash_stack{
 	icon_state = "trash_2"
@@ -10243,6 +10525,13 @@
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 8
 	},
+/area/f13/building/powered)
+"IO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/blanket,
+/obj/structure/curtain,
+/turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "IP" = (
 /mob/living/simple_animal/hostile/securitron,
@@ -10725,6 +11014,11 @@
 	color = "#c5bab2"
 	},
 /area/f13/wasteland)
+"Kw" = (
+/obj/machinery/atmospherics/components/unary/tank,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "Kx" = (
 /obj/item/stack/cable_coil/cut,
 /obj/effect/decal/cleanable/dirt,
@@ -10813,6 +11107,13 @@
 	dir = 4
 	},
 /area/f13/building/powered)
+"KL" = (
+/obj/machinery/power/port_gen/pacman/diesel{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "KM" = (
 /obj/machinery/shower{
 	pixel_y = 16
@@ -11296,6 +11597,10 @@
 	color = "#c5bab2"
 	},
 /area/f13/ncr)
+"Ml" = (
+/obj/item/trash/f13/borscht,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "Mm" = (
 /turf/open/floor/wood_wide{
 	icon_state = "wide-broken3"
@@ -11438,6 +11743,15 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"MM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/bed/wooden,
+/obj/item/bedsheet/blanket/blanketalt,
+/obj/structure/curtain{
+	color = "#808080"
+	},
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "MN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/locker/oldstyle,
@@ -11493,6 +11807,11 @@
 /obj/item/clothing/head/beret/qm,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
+/area/f13/building/powered)
+"MW" = (
+/obj/machinery/autolathe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "MX" = (
 /obj/item/clothing/ears/earmuffs,
@@ -11550,6 +11869,10 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"Nl" = (
+/obj/item/trash/f13/dog,
+/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
+/area/f13/wasteland)
 "Nn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/spacecash/c10,
@@ -12151,6 +12474,11 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
+"Pr" = (
+/obj/structure/table/booth,
+/obj/item/trash/f13/cram,
+/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
+/area/f13/wasteland)
 "Ps" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/junk/small/tv,
@@ -12879,6 +13207,11 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"RG" = (
+/obj/machinery/power/smes/engineering,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "RH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/poster_spawner/prewar,
@@ -13120,15 +13453,29 @@
 /obj/machinery/light,
 /turf/open/floor/wood_wide/wood_wide_light,
 /area/engine/workshop)
+"Sn" = (
+/obj/machinery/autolathe/ammo,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "So" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/barricade/tentclothedge,
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/ncr)
+"Sp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "Sq" = (
 /obj/structure/marker_beacon,
 /turf/open/floor/plasteel/f13,
+/area/f13/wasteland)
+"Sr" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/fakelattice,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/wasteland)
 "Ss" = (
 /obj/structure/target_stake,
@@ -13168,6 +13515,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"SA" = (
+/obj/effect/decal/fakelattice,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "SB" = (
 /obj/machinery/light/small{
 	light_color = "#ff4747"
@@ -13195,6 +13547,12 @@
 /obj/structure/sign/poster/official/fruit_bowl,
 /turf/closed/wall/f13/wood/house,
 /area/f13/clinic)
+"SG" = (
+/obj/structure/table/reinforced,
+/obj/structure/barricade/bars,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "SH" = (
 /obj/machinery/grill,
 /obj/item/reagent_containers/food/snacks/meat/slab/synthmeat,
@@ -13573,6 +13931,13 @@
 /obj/item/reagent_containers/food/drinks/bottle/sunset,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/building/abandoned/l)
+"TQ" = (
+/obj/item/storage/trash_stack{
+	icon_state = "trash_3"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "TS" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -13589,6 +13954,11 @@
 /obj/structure/obstacle/old_locked_door,
 /turf/open/floor/wood_fancy,
 /area/maintenance/bar)
+"TV" = (
+/obj/structure/table/booth,
+/obj/item/binoculars,
+/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
+/area/f13/wasteland)
 "TW" = (
 /obj/effect/decal/cleanable/robot_debris,
 /obj/effect/decal/cleanable/dirt,
@@ -13868,6 +14238,11 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"UV" = (
+/obj/item/storage/trash_stack,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "UW" = (
 /obj/structure/tank_dispenser,
 /obj/effect/decal/cleanable/dirt,
@@ -15211,6 +15586,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/legioncamp)
+"ZA" = (
+/obj/structure/wreck/trash/machinepile,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "ZB" = (
 /obj/effect/decal/fakelattice,
 /obj/effect/turf_decal/weather/dirt,
@@ -15240,6 +15620,15 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/carpet/royalblue,
 /area/f13/building/powered)
+"ZI" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
+"ZJ" = (
+/obj/item/trash/f13/rotten,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
 "ZK" = (
 /obj/effect/spawner/lootdrop/f13/advcrafting,
 /obj/effect/turf_decal/bot_white,
@@ -15267,6 +15656,14 @@
 /obj/effect/gibspawner/human,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
+/area/f13/building/powered)
+"ZP" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/armylootbasic,
+/obj/effect/spawner/lootdrop/armylootbasic,
+/obj/effect/spawner/lootdrop/armylootelite,
+/turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "ZQ" = (
 /obj/structure/table/wood/junk,
@@ -17067,17 +17464,17 @@ FO
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+le
+no
+no
+no
+no
+no
+no
+no
+no
+no
+BZ
 xm
 xm
 xm
@@ -17369,7 +17766,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -17379,7 +17776,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -17665,13 +18062,13 @@ FO
 FO
 FO
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+le
+no
+no
+no
+no
+no
+gr
 Bs
 Bs
 Bs
@@ -17681,7 +18078,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -17967,7 +18364,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -17983,7 +18380,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -18269,7 +18666,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -18285,7 +18682,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -18571,7 +18968,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -18587,7 +18984,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -18873,7 +19270,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -18889,7 +19286,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -19175,7 +19572,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -19191,7 +19588,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -19477,7 +19874,7 @@ Ao
 Ao
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -19493,7 +19890,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -19753,14 +20150,14 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
 FO
 FO
 FO
@@ -19779,7 +20176,7 @@ kP
 Ao
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -19795,7 +20192,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -20055,14 +20452,14 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
+Ip
+HV
+SG
+By
+ZP
+ca
+HV
+Ip
 FO
 FO
 FO
@@ -20081,10 +20478,10 @@ kP
 Ao
 xm
 xm
-xm
-xm
-xm
-xm
+dD
+BC
+BC
+Re
 Bs
 Bs
 Bs
@@ -20097,7 +20494,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -20357,14 +20754,14 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
+Ip
+SG
+SG
+da
+Sp
+ca
+ca
+Ip
 FO
 FO
 FO
@@ -20386,7 +20783,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -20399,7 +20796,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -20659,14 +21056,14 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
+Ip
+Ip
+MW
+Sp
+Sp
+Sn
+Ip
+Ip
 FO
 FO
 FO
@@ -20688,7 +21085,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -20699,9 +21096,9 @@ Bs
 Bs
 Bs
 Bs
-xm
-xm
-xm
+DD
+BC
+AI
 xm
 xm
 xm
@@ -20962,12 +21359,12 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
-FO
-FO
+Ip
+zk
+Sp
+Sp
+xX
+Ip
 FO
 FO
 FO
@@ -20990,8 +21387,8 @@ Ao
 xm
 xm
 xm
-xm
-xm
+dD
+Re
 Bs
 Bs
 Bs
@@ -21001,7 +21398,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -21260,22 +21657,22 @@ FO
 FO
 FO
 FO
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+Gv
+Ip
+Ip
 FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-xm
-xm
+ot
+BZ
 xm
 xm
 xm
@@ -21293,7 +21690,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -21303,7 +21700,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -21562,23 +21959,23 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
+Ip
+MM
+hm
+ec
+pR
+Ip
+kT
+Sp
+Sp
+Ip
 FO
 FO
 FO
 zi
-xm
-xm
+zi
+ot
+BZ
 xm
 xm
 xm
@@ -21594,8 +21991,8 @@ Ao
 xm
 xm
 xm
-xm
-xm
+le
+gr
 Bs
 Bs
 Bs
@@ -21605,7 +22002,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -21864,24 +22261,24 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
+Ip
+kQ
+Sp
+Sp
+Sp
+Hp
+Sp
+Sp
+xw
+Ip
 FO
 FO
 zi
 zi
 zi
-xm
-xm
+zi
+ot
+BZ
 xm
 xm
 xm
@@ -21896,7 +22293,7 @@ en
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -21907,7 +22304,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -22166,24 +22563,24 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
+Ip
+iH
+kb
+IO
+xN
+Ip
+Sp
+Sp
+Ip
+Ip
 FO
 zi
 zi
 zi
 zi
 zi
-xm
+zi
+lC
 xm
 xm
 xm
@@ -22198,7 +22595,7 @@ Ao
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -22209,7 +22606,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -22468,24 +22865,24 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
-FO
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+Ip
+st
+Ip
 zi
 zi
 zi
 zi
 zi
 zi
-xm
+zi
+zi
+lC
 xm
 xm
 xm
@@ -22500,7 +22897,7 @@ Ao
 xm
 xm
 xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -22511,7 +22908,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -22771,12 +23168,11 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
-FO
-FO
+Ip
+di
+Sp
+Sp
+Ip
 zi
 zi
 zi
@@ -22785,8 +23181,13 @@ zi
 zi
 zi
 zi
+Nl
 zi
 zi
+ot
+no
+no
+BZ
 xm
 xm
 xm
@@ -22797,12 +23198,8 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
+le
+gr
 Bs
 Bs
 Bs
@@ -22813,7 +23210,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -23073,25 +23470,26 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-FO
+Ip
+BH
+Sp
+Sp
+sk
 zi
 zi
 zi
 zi
 zi
+ZI
+ZJ
+kU
+ZI
+Kw
 zi
 zi
 zi
 zi
-zi
-zi
-zi
-zi
-zi
-zi
+lC
 xm
 xm
 xm
@@ -23102,8 +23500,7 @@ xm
 xm
 xm
 xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -23115,7 +23512,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -23375,28 +23772,26 @@ FO
 FO
 FO
 FO
-FO
-FO
-FO
-xm
+Ip
+di
+Sp
+Sp
+Ip
 zi
 zi
 zi
 zi
 zi
+ZI
+ZI
+SA
+UV
+Kw
 zi
 zi
 zi
 zi
-zi
-zi
-zi
-zi
-zi
-zi
-xm
-xm
-xm
+lC
 xm
 xm
 xm
@@ -23406,6 +23801,8 @@ xm
 xm
 xm
 xm
+xm
+cw
 Bs
 Bs
 Bs
@@ -23417,7 +23814,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -23677,28 +24074,26 @@ FO
 FO
 FO
 FO
-FO
-FO
-xm
-xm
+Ip
+Ip
+Ip
+Ip
+Ip
 zi
 zi
 zi
 zi
 zi
+Kw
+ZI
+eo
+SA
+ZI
 zi
 zi
 zi
 zi
-zi
-zi
-zi
-zi
-zi
-zi
-xm
-xm
-xm
+lC
 xm
 xm
 xm
@@ -23708,6 +24103,8 @@ xm
 xm
 xm
 xm
+le
+gr
 Bs
 Bs
 Bs
@@ -23715,11 +24112,11 @@ Bs
 Bs
 Bs
 Bs
-xm
-xm
-xm
-xm
-xm
+DD
+BC
+BC
+BC
+AI
 xm
 xm
 xm
@@ -23980,9 +24377,6 @@ FO
 FO
 FO
 FO
-xm
-xm
-xm
 zi
 zi
 zi
@@ -23998,17 +24392,20 @@ zi
 zi
 zi
 zi
-xm
-xm
-xm
-xm
-xm
+zi
+zi
+zi
+lC
 xm
 xm
 xm
 xm
 xm
 xm
+xm
+xm
+xm
+cw
 Bs
 Bs
 Bs
@@ -24016,8 +24413,8 @@ Bs
 Bs
 Bs
 Bs
-xm
-xm
+DD
+AI
 xm
 xm
 xm
@@ -24281,25 +24678,26 @@ FO
 FO
 xm
 xm
-xm
-xm
-xm
-xm
+cw
+zi
+qO
+qO
+lk
+to
+lk
+fH
 zi
 zi
 zi
 zi
 zi
 zi
+Kw
+BE
+KL
 zi
 zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
+lC
 xm
 xm
 xm
@@ -24309,8 +24707,7 @@ xm
 xm
 xm
 xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -24318,7 +24715,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -24583,36 +24980,36 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
+cw
+zi
+qO
+qO
+tb
+ZI
+Ml
+Sr
+zi
+zi
+rG
 zi
 zi
 zi
+Ab
+SA
+ZI
 zi
 zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-xm
-xm
-xm
-xm
-xm
-xm
+lC
 xm
 xm
 xm
 xm
 xm
+xm
+xm
+xm
+xm
+cw
 Bs
 Bs
 Bs
@@ -24620,7 +25017,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -24879,31 +25276,32 @@ FO
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+le
+no
+no
+no
+no
+no
+qd
+zi
+lk
+sB
+ZI
+ZI
+Ab
+rH
+zi
+rG
+EU
+jb
 zi
 zi
+RG
+Ab
+SA
 zi
 zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
+lC
 xm
 xm
 xm
@@ -24913,8 +25311,7 @@ xm
 xm
 xm
 xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -24922,7 +25319,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -25178,19 +25575,16 @@ FO
 xm
 xm
 xm
-xm
-xm
-xm
-xm
+le
+no
+no
+gr
 gs
 gs
 gs
 gs
 gs
-xm
-xm
-xm
-xm
+cT
 zi
 zi
 zi
@@ -25204,19 +25598,22 @@ zi
 zi
 zi
 zi
+nf
+cd
+to
 zi
 zi
+lC
 xm
 xm
+le
+no
+no
+no
+BZ
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -25224,7 +25621,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -25476,11 +25873,11 @@ FO
 FO
 FO
 FO
-xm
-xm
-xm
-xm
-xm
+le
+no
+no
+no
+gr
 gs
 gs
 gs
@@ -25489,36 +25886,36 @@ gs
 gs
 gs
 gs
+cT
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+ZA
+lk
+AC
+zi
+zi
+lC
 xm
 xm
-xm
-xm
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-xm
-xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
-xm
-xm
-xm
-xm
+ot
+no
+no
+gr
 Bs
 Bs
 Bs
@@ -25526,7 +25923,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -25778,42 +26175,42 @@ FO
 FO
 FO
 xm
+cw
+gs
+gs
+gs
+gs
+gs
+gs
+gs
+gs
+gs
+gs
+gs
+gs
+AV
+Re
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+zi
+uR
+ZI
+nf
+zi
+zi
+lC
 xm
-gs
-gs
-gs
-gs
-gs
-gs
-gs
-gs
-gs
-gs
-gs
-gs
 xm
-xm
-xm
-xm
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-xm
-xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -25828,7 +26225,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -26080,7 +26477,7 @@ FO
 FO
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -26093,29 +26490,29 @@ gs
 gs
 gs
 gs
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+lC
+dD
+BC
+Re
+zi
+zi
+zi
+TQ
+Ab
+ZI
 zi
 zi
 zi
 zi
+uR
+ZI
+nf
 zi
 zi
-zi
-zi
-zi
-zi
-zi
-zi
+lC
 xm
 xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -26130,7 +26527,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -26382,7 +26779,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -26395,29 +26792,29 @@ gs
 gs
 gs
 gs
+lC
 xm
 xm
-xm
-xm
-xm
-xm
-xm
+cw
+zi
+zi
+zi
+mD
+bw
+nT
+zi
+zi
+jb
 zi
 zi
 zi
 zi
 zi
 zi
-zi
-zi
-zi
-zi
-zi
-zi
+lC
 xm
 xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -26432,7 +26829,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -26684,7 +27081,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -26697,13 +27094,10 @@ gs
 gs
 gs
 gs
+lC
 xm
 xm
-xm
-xm
-xm
-xm
-xm
+cw
 zi
 zi
 zi
@@ -26711,15 +27105,18 @@ zi
 zi
 zi
 zi
+Pr
+TV
+EU
 zi
 zi
 zi
 zi
 zi
+lC
 xm
 xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -26734,7 +27131,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -26986,7 +27383,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -26999,29 +27396,29 @@ gs
 gs
 gs
 gs
+lC
 xm
 xm
+dD
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+AI
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -27036,7 +27433,7 @@ Bs
 Bs
 Bs
 Bs
-xm
+lC
 xm
 xm
 xm
@@ -27288,7 +27685,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -27301,6 +27698,7 @@ gs
 gs
 gs
 gs
+lC
 xm
 xm
 xm
@@ -27322,8 +27720,7 @@ xm
 xm
 xm
 xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
@@ -27337,8 +27734,8 @@ Bs
 Bs
 Bs
 Bs
-xm
-xm
+DD
+AI
 xm
 zy
 zy
@@ -27590,7 +27987,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -27603,6 +28000,7 @@ gs
 gs
 gs
 gs
+lC
 xm
 xm
 xm
@@ -27624,22 +28022,21 @@ xm
 xm
 xm
 xm
-xm
-xm
+cw
 Bs
 Bs
 Bs
 Bs
 Bs
 Bs
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+DD
+BC
+BC
+BC
+BC
+BC
+BC
+AI
 xm
 xm
 zy
@@ -27892,11 +28289,11 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
+dD
+BC
+BC
+BC
+Re
 gs
 gs
 gs
@@ -27904,6 +28301,8 @@ gs
 gs
 gs
 gs
+DD
+AI
 xm
 xm
 xm
@@ -27925,16 +28324,14 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+dD
+BC
+BC
+BC
+BC
+BC
+BC
+AI
 xm
 xm
 xm
@@ -28198,7 +28595,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -28206,7 +28603,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -28500,7 +28897,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -28508,7 +28905,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -28797,12 +29194,12 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
+le
+no
+no
+no
+no
+gr
 gs
 gs
 gs
@@ -28810,7 +29207,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -29099,7 +29496,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -29112,7 +29509,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -29401,7 +29798,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -29414,7 +29811,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -29703,7 +30100,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -29716,7 +30113,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -30005,7 +30402,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -30018,7 +30415,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -30307,7 +30704,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -30320,7 +30717,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -30609,7 +31006,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -30622,7 +31019,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -30911,7 +31308,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -30924,7 +31321,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -31212,8 +31609,8 @@ xm
 xm
 xm
 xm
-xm
-xm
+le
+gr
 gs
 gs
 gs
@@ -31226,8 +31623,8 @@ gs
 gs
 gs
 gs
-xm
-xm
+ot
+BZ
 xm
 xm
 xm
@@ -31514,7 +31911,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -31529,7 +31926,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -31816,7 +32213,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -31831,7 +32228,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -32118,7 +32515,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -32133,7 +32530,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -32420,7 +32817,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -32435,7 +32832,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -32722,7 +33119,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -32737,7 +33134,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -33024,7 +33421,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -33038,8 +33435,8 @@ gs
 gs
 gs
 gs
-xm
-xm
+DD
+AI
 xm
 xm
 xm
@@ -33326,7 +33723,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -33340,7 +33737,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -33628,7 +34025,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -33642,7 +34039,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -33930,7 +34327,7 @@ xm
 xm
 xm
 xm
-xm
+cw
 gs
 gs
 gs
@@ -33944,7 +34341,7 @@ gs
 gs
 gs
 gs
-xm
+lC
 xm
 xm
 xm
@@ -34232,21 +34629,21 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+dD
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+BC
+AI
 xm
 xm
 xm
@@ -43069,7 +43466,7 @@ xm
 xm
 xm
 xm
-xm
+lw
 lw
 lw
 lw
@@ -43371,7 +43768,7 @@ xm
 xm
 xm
 xm
-xm
+lw
 lw
 lw
 lw
@@ -43672,8 +44069,8 @@ xm
 xm
 xm
 xm
-xm
-xm
+lw
+lw
 lw
 lw
 lw
@@ -43974,8 +44371,8 @@ xm
 xm
 xm
 xm
-xm
-xm
+lw
+lw
 lw
 lw
 lw
@@ -44276,8 +44673,8 @@ SU
 SU
 SU
 xm
-xm
-xm
+lw
+lw
 lw
 lw
 lw
@@ -44578,8 +44975,8 @@ SU
 SU
 SU
 xm
-xm
-xm
+lw
+lw
 lw
 lw
 lw
@@ -44880,8 +45277,8 @@ SU
 SU
 SU
 xm
-xm
-xm
+lw
+lw
 lw
 lw
 lw
@@ -45182,8 +45579,8 @@ SU
 SU
 SU
 xm
-xm
-xm
+lw
+lw
 lw
 lw
 lw
@@ -45485,7 +45882,7 @@ SU
 SU
 xm
 xm
-xm
+lw
 lw
 lw
 lw

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Sky.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Sky.dmm
@@ -120,6 +120,17 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"aq" = (
+/obj/structure/flora/branch_broken,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"ar" = (
+/obj/structure/flora/tree/joshua,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 6;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "as" = (
 /obj/structure/railing{
 	dir = 10
@@ -129,6 +140,13 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/followers)
+"au" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/decal/remains/bottles/three,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "av" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -278,6 +296,10 @@
 	color = "#A47449"
 	},
 /turf/open/transparent/openspace,
+/area/f13/wasteland)
+"aW" = (
+/obj/structure/flora/brushwood,
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "aX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -552,6 +574,12 @@
 	dir = 4
 	},
 /area/f13/building/powered)
+"bN" = (
+/obj/structure/flora/tree/cactus,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "bO" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants/random,
@@ -569,6 +597,13 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"bR" = (
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1
+	},
+/turf/open/transparent/openspace,
 /area/f13/wasteland)
 "bS" = (
 /obj/structure/table,
@@ -697,6 +732,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/cyan,
 /area/maintenance/bar)
+"cm" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "cp" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -1183,6 +1224,11 @@
 /obj/effect/overlay/junk/curtain,
 /turf/open/floor/pod/dark,
 /area/f13/building/powered)
+"ed" = (
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
 "ee" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_mid,
@@ -1256,6 +1302,26 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/wasteland)
+"ep" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/wood/post{
+	desc = "A wooden stanchion.";
+	name = "wooden stanchion";
+	pixel_y = 24;
+	pixel_x = -16
+	},
+/obj/structure/chalkboard{
+	icon_state = "board_text1"
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 6
+	},
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "er" = (
 /turf/open/floor/wood_common/wood_common_light,
 /area/f13/wasteland)
@@ -1466,6 +1532,10 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"eY" = (
+/obj/structure/flora/grass/coyote/nineteen,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "eZ" = (
 /obj/structure/sink{
 	pixel_y = 17
@@ -1585,6 +1655,22 @@
 /obj/structure/sink/puddle,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"fr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/wood/post{
+	desc = "A wooden stanchion.";
+	name = "wooden stanchion";
+	pixel_x = 16
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 9
+	},
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "fs" = (
 /obj/machinery/shower{
 	dir = 4
@@ -1863,6 +1949,13 @@
 /obj/structure/table,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/m)
+"gl" = (
+/obj/structure/flora/grass/coyote/seven,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 5;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "gm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -1934,6 +2027,13 @@
 	dir = 8
 	},
 /area/f13/building/powered)
+"gA" = (
+/obj/structure/flora/tree/cactus{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "gB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
@@ -2069,6 +2169,16 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/building/powered)
+"gU" = (
+/obj/structure/flora/tree/tall{
+	layer = 2;
+	pixel_y = 9
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "gV" = (
 /obj/effect/turf_decal/loading_area,
 /obj/effect/decal/cleanable/oil,
@@ -2107,6 +2217,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/ambientlighting/building/u)
+"hb" = (
+/obj/structure/fence/corner/wooden{
+	pixel_y = 24
+	},
+/obj/structure/fence/wooden{
+	dir = 1;
+	pixel_y = 11
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "hc" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
@@ -2226,6 +2346,24 @@
 /turf/open/indestructible/ground/outside/ruins{
 	icon_state = "rubblepillar"
 	},
+/area/f13/wasteland)
+"hz" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
+"hA" = (
+/obj/effect/decal/remains/cans,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "hB" = (
 /obj/structure/flora/tree/joshua,
@@ -2359,6 +2497,14 @@
 "hS" = (
 /turf/open/floor/wood_fancy,
 /area/maintenance/bar)
+"hT" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "hU" = (
 /obj/structure/railing/wood/post{
 	desc = "A wooden stanchion.";
@@ -2424,6 +2570,12 @@
 	icon_state = "dirt";
 	dir = 4
 	},
+/area/f13/wasteland)
+"ie" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "if" = (
 /mob/living/simple_animal/hostile/handy/gutsy/flamer,
@@ -2536,6 +2688,10 @@
 /obj/structure/chair/sofa,
 /turf/open/floor/carpet/red,
 /area/maintenance/bar)
+"ix" = (
+/obj/item/trash/plate,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "iy" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 4
@@ -2561,6 +2717,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/powered)
+"iD" = (
+/obj/structure/flora/tree/joshua,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "iE" = (
 /turf/open/transparent/openspace,
 /area/f13/building/abandoned/j)
@@ -2616,6 +2778,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/abandoned/l)
+"iP" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/item/trash/f13/tin_large,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "iR" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/rust,
@@ -2863,6 +3032,15 @@
 /obj/structure/destructible/tribal_torch/lit,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/m)
+"jK" = (
+/obj/structure/flora/tree/cactus{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "jL" = (
 /obj/structure/closet/locker/fridge{
 	pixel_x = 8;
@@ -3244,6 +3422,10 @@
 /obj/item/trash/pistachios,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/wasteland)
+"kW" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "kX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3761,6 +3943,12 @@
 	icon_state = "wide-broken3"
 	},
 /area/f13/wasteland)
+"my" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6"
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "mz" = (
 /obj/structure/curtain{
 	color = "#845f58";
@@ -3828,6 +4016,12 @@
 	icon_state = "housebase"
 	},
 /area/f13/wasteland)
+"mI" = (
+/obj/structure/flora/tree/cactus,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
 "mK" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/dirt,
@@ -3847,6 +4041,17 @@
 /obj/effect/spawner/lootdrop/f13/medical/wasteland/meds,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/p)
+"mO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "mP" = (
 /obj/structure/junk/small/bed,
 /turf/open/floor/wood_wide{
@@ -3877,6 +4082,17 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"mW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 8
+	},
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "mX" = (
 /obj/structure/weightmachine/stacklifter,
 /obj/effect/decal/cleanable/dirt,
@@ -3943,11 +4159,29 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"nm" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_6";
+	pixel_x = -11;
+	pixel_y = 11
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"nn" = (
+/obj/effect/decal/remains/bottles/three,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "no" = (
 /obj/structure/fluff/railing{
 	dir = 4
 	},
 /turf/open/transparent/openspace,
+/area/f13/wasteland)
+"np" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3"
+	},
+/turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
 "nq" = (
 /obj/item/storage/trash_stack{
@@ -3994,6 +4228,12 @@
 	},
 /turf/open/floor/wood_fancy,
 /area/f13/bar)
+"ny" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "nA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain{
@@ -4062,6 +4302,20 @@
 	},
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"nK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "nL" = (
 /obj/effect/decal/fakelattice,
 /obj/item/bedsheet/blanket,
@@ -4106,6 +4360,17 @@
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/wasteland)
+"nU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 4
+	},
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "nV" = (
 /obj/structure/janitorialcart,
 /obj/effect/decal/cleanable/dirt,
@@ -4265,6 +4530,12 @@
 	color = "#c5bab2"
 	},
 /area/f13/building/abandoned/z)
+"os" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	dir = 1
+	},
+/area/f13/wasteland)
 "ot" = (
 /obj/structure/fluff/railing{
 	dir = 5
@@ -4325,6 +4596,10 @@
 	},
 /turf/open/floor/wood_common/wood_common_light,
 /area/f13/followers)
+"oE" = (
+/obj/structure/flora/grass/coyote/three,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "oF" = (
 /obj/item/clothing/head/hardhat/red,
 /obj/effect/decal/cleanable/dirt,
@@ -4514,6 +4789,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/f13/outside/roof/metal,
 /area/f13/wasteland)
+"pf" = (
+/obj/structure/flora/grass/coyote/nine,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "pg" = (
 /obj/structure/table/wood/junk,
 /obj/structure/bedsheetbin/empty,
@@ -4589,6 +4868,20 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/p)
+"pq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 1
+	},
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "pr" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -4793,6 +5086,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"pU" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = 12
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "pV" = (
 /obj/structure/table,
 /obj/item/clothing/suit/armor/tiered/medium/combat/enclave,
@@ -4891,6 +5191,9 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"ql" = (
+/turf/closed/wall/f13/tunnel,
+/area/f13/wasteland)
 "qm" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood_common,
@@ -5289,6 +5592,10 @@
 	icon_state = "housewood2-broken"
 	},
 /area/f13/legioncamp)
+"rz" = (
+/obj/structure/flora/tree/tall,
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "rA" = (
 /obj/item/storage/secure/safe,
 /turf/closed/indestructible/f13vaultrusted,
@@ -5357,7 +5664,15 @@
 /turf/open/floor/carpet/red,
 /area/f13/ambientlighting/building/c)
 "rN" = (
-/turf/closed/mineral/random/high_chance,
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5;
+	pixel_x = -2
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 10;
+	icon_state = "dirt"
+	},
 /area/f13/wasteland)
 "rO" = (
 /obj/structure/railing{
@@ -5563,6 +5878,13 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"sx" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress1"
+	},
+/obj/item/bedsheet/ian,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "sz" = (
 /obj/structure/table_frame,
 /obj/item/stack/sheet/metal,
@@ -5906,6 +6228,13 @@
 /obj/item/paper_bin,
 /turf/open/floor/holofloor/carpet,
 /area/f13/ambientlighting/building/e)
+"tH" = (
+/obj/structure/bed/mattress{
+	icon_state = "mattress1"
+	},
+/obj/item/bedsheet/blanket/blanketalt,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "tI" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -5922,6 +6251,15 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"tN" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "tO" = (
 /obj/structure/fence/wooden,
 /turf/open/transparent/openspace,
@@ -6417,6 +6755,12 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"vo" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "vp" = (
 /obj/structure/table,
 /obj/item/stack/crafting/electronicparts,
@@ -6433,6 +6777,16 @@
 	},
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar)
+"vs" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
+"vt" = (
+/obj/structure/flora/tree/cactus,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "vu" = (
 /turf/open/floor/f13/wood{
 	icon_state = "oakfloor4-broken"
@@ -6491,6 +6845,16 @@
 	},
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/d)
+"vC" = (
+/obj/structure/railing/wood{
+	pixel_y = 23
+	},
+/obj/structure/fence/wooden{
+	dir = 1;
+	pixel_y = 11
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "vD" = (
 /obj/machinery/light/fo13colored/Red,
 /obj/effect/decal/cleanable/blood/old,
@@ -6665,6 +7029,10 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/f13/clinic)
+"wd" = (
+/obj/item/trash/f13/mre,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "we" = (
 /obj/structure/table,
 /obj/structure/railing/dancing_pole{
@@ -6770,6 +7138,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/powered)
+"wv" = (
+/obj/structure/flora/grass/coyote/thirty,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "wy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/firstaid/radbgone,
@@ -6848,6 +7220,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/blue/whitebluefull,
 /area/f13/building/powered)
+"wK" = (
+/obj/structure/gallow{
+	pixel_x = -17;
+	pixel_y = 21
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "wL" = (
 /obj/machinery/shower{
 	dir = 8
@@ -6913,6 +7292,16 @@
 /obj/structure/lattice/catwalk,
 /turf/open/transparent/openspace,
 /area/f13/wasteland)
+"wU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/junk,
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "wW" = (
 /turf/closed/indestructible/f13vaultrusted,
 /area/f13/wasteland)
@@ -6976,6 +7365,14 @@
 /obj/item/storage/backpack/satchel/trekker,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"xj" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_8";
+	pixel_x = -1;
+	pixel_y = 2
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "xk" = (
 /turf/open/indestructible/ground/outside/dirt{
 	dir = 4;
@@ -7318,6 +7715,13 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"ys" = (
+/obj/structure/flora/grass/coyote/seven,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	dir = 4
+	},
+/area/f13/wasteland)
 "yt" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -7710,6 +8114,12 @@
 	icon_state = "wide-broken1"
 	},
 /area/f13/ambientlighting/building/j)
+"zK" = (
+/obj/structure/railing/wood{
+	pixel_y = 23
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
 "zL" = (
 /obj/machinery/computer/rdconsole/core,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -7728,6 +8138,15 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/building/powered)
+"zN" = (
+/obj/structure/railing/wood,
+/obj/structure/barricade/tentclothedge{
+	pixel_y = -14;
+	layer = 5
+	},
+/obj/structure/barricade/tentclothedge,
+/turf/closed/wall/f13/tentwall,
+/area/f13/caves)
 "zO" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/f13{
@@ -7898,6 +8317,25 @@
 	icon_state = "housewood3-broken"
 	},
 /area/f13/ambientlighting/building/p)
+"Am" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/wood/post{
+	desc = "A wooden stanchion.";
+	name = "wooden stanchion";
+	pixel_x = -16
+	},
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 5
+	},
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "An" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 1;
@@ -7965,6 +8403,15 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"Az" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/table/wood/junk,
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "AA" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/supermutant/nightkin,
@@ -8184,6 +8631,10 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"Bq" = (
+/obj/effect/decal/remains/cans/two,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "Bs" = (
 /turf/open/floor/plating/f13/outside/roof/metal/verdigris,
 /area/f13/wasteland)
@@ -8683,6 +9134,11 @@
 /obj/structure/barricade/wooden/strong,
 /turf/closed/wall/f13/wood/house,
 /area/f13/legioncamp)
+"CX" = (
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "CY" = (
 /obj/structure/table/wood/settler,
 /obj/item/storage/belt/fannypack/pink,
@@ -8863,6 +9319,12 @@
 /obj/item/clothing/accessory/armband/engine/ncr,
 /turf/open/floor/f13/wood,
 /area/f13/ncr)
+"Dy" = (
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "Dz" = (
 /obj/machinery/light{
 	dir = 1;
@@ -9155,6 +9617,10 @@
 /obj/structure/window/fulltile/wood_window,
 /turf/open/floor/plating/f13/outside/roof,
 /area/f13/followers)
+"EA" = (
+/obj/effect/decal/remains/cans/three,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "EB" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/storage/toolbox/electrical,
@@ -9175,6 +9641,12 @@
 	icon_state = "housebase"
 	},
 /area/f13/legioncamp)
+"EE" = (
+/obj/item/binoculars{
+	pixel_y = 8
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "EF" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 4
@@ -9448,6 +9920,15 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"Fv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/overlay/desert/sonora/edge,
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "Fx" = (
 /obj/structure/closet/secure/loot,
 /obj/effect/decal/cleanable/dirt,
@@ -9781,6 +10262,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/legioncamp)
+"Gy" = (
+/obj/structure/barricade/bars,
+/turf/open/floor/plating/f13/outside/roof/metal/corrugated,
+/area/f13/wasteland)
 "Gz" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13{
@@ -9881,6 +10366,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
 /area/f13/building/powered)
+"GN" = (
+/obj/structure/campfire,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "GO" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/remains/human,
@@ -10122,6 +10611,10 @@
 /obj/item/binoculars,
 /turf/open/transparent/openspace,
 /area/engine/workshop)
+"HD" = (
+/obj/effect/decal/remains/bottles/two,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "HE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -10408,6 +10901,10 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/cyan,
 /area/maintenance/bar)
+"It" = (
+/obj/structure/flora/grass/coyote/seventeen,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "Iv" = (
 /obj/structure/lattice,
 /obj/structure/table_frame,
@@ -10457,6 +10954,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/f13/ambientlighting/building/c)
+"IC" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 1;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "ID" = (
 /obj/structure/fence/end/wooden{
 	dir = 8
@@ -10477,6 +10981,12 @@
 /obj/item/clothing/glasses/sunglasses/blindfold,
 /turf/open/floor/wood_fancy,
 /area/f13/bar)
+"IF" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "IG" = (
 /obj/machinery/door/window{
 	dir = 1
@@ -10510,6 +11020,17 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"IL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "IM" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 8
@@ -10832,6 +11353,13 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
+"JQ" = (
+/obj/structure/flora/grass/coyote/sixteen,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "JR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/gibs,
@@ -11014,6 +11542,10 @@
 	color = "#c5bab2"
 	},
 /area/f13/wasteland)
+"Kv" = (
+/obj/item/trash/f13/porknbeans,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "Kw" = (
 /obj/machinery/atmospherics/components/unary/tank,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -11027,6 +11559,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"Ky" = (
+/obj/structure/destructible/tribal_torch/lit,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "Kz" = (
 /obj/machinery/light/fo13colored/Red,
 /obj/effect/decal/cleanable/dirt,
@@ -11464,6 +12000,23 @@
 /obj/machinery/photocopier,
 /turf/open/floor/carpet/royalblack,
 /area/f13/clinic)
+"LO" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland33"
+	},
+/area/f13/wasteland)
+"LP" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = -11
+	},
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "LQ" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -11835,6 +12388,14 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/building/abandoned/m)
+"Na" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "Nb" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/tunnel{
@@ -12049,6 +12610,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/royalblack,
 /area/f13/clinic)
+"NT" = (
+/obj/structure/flora/tree/tall{
+	icon_state = "tree_3";
+	pixel_y = -11
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "NU" = (
 /turf/closed/wall/mineral/concrete,
 /area/engine/workshop)
@@ -12062,6 +12630,10 @@
 	dir = 1
 	},
 /area/f13/building/powered)
+"NW" = (
+/obj/item/trash/tray,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "NX" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/side{
 	dir = 8
@@ -12194,6 +12766,13 @@
 /obj/item/storage/trash_stack,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"Or" = (
+/obj/structure/flora/branch,
+/turf/open/indestructible/ground/outside/dirt{
+	dir = 9;
+	icon_state = "dirt"
+	},
+/area/f13/wasteland)
 "Os" = (
 /obj/machinery/light/fo13colored/Red,
 /obj/effect/decal/cleanable/dirt,
@@ -12474,6 +13053,12 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
+"Pq" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "Pr" = (
 /obj/structure/table/booth,
 /obj/item/trash/f13/cram,
@@ -12937,6 +13522,24 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"QK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/railing/wood/post{
+	desc = "A wooden stanchion.";
+	name = "wooden stanchion";
+	pixel_y = 24;
+	pixel_x = 16
+	},
+/obj/effect/overlay/desert/sonora/edge{
+	dir = 10
+	},
+/obj/effect/decal/remains/bottles/three,
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "QL" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/f13{
@@ -13347,6 +13950,10 @@
 	icon_state = "floordirtysolid"
 	},
 /area/f13/building/abandoned/m)
+"RX" = (
+/obj/item/pitchfork,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "RY" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -13543,6 +14150,12 @@
 	},
 /turf/open/floor/wood_mosaic/wood_mosaic_dark,
 /area/f13/building/abandoned/o)
+"SE" = (
+/obj/effect/decal/remains/bottles/two,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "SF" = (
 /obj/structure/sign/poster/official/fruit_bowl,
 /turf/closed/wall/f13/wood/house,
@@ -13826,6 +14439,10 @@
 	icon_state = "bar"
 	},
 /area/f13/bar)
+"Tx" = (
+/obj/structure/flora/grass/coyote/eighteen,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "Ty" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Red{
@@ -13850,6 +14467,10 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"TC" = (
+/obj/structure/lattice,
+/turf/open/floor/plating/rust,
+/area/f13/wasteland)
 "TF" = (
 /obj/structure/shelf_wood,
 /obj/effect/spawner/lootdrop/f13/weapon/melee/random_high,
@@ -13997,6 +14618,13 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"Ud" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
 "Ue" = (
 /obj/machinery/light/small,
 /obj/structure/railing{
@@ -14204,6 +14832,14 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/building/powered)
+"UP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "UQ" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/handy,
@@ -14552,6 +15188,10 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/followers)
+"VS" = (
+/obj/structure/flora/grass/coyote/sixteen,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "VT" = (
 /obj/structure/railing/corner{
 	color = "#A47449";
@@ -14992,6 +15632,13 @@
 /obj/item/reagent_containers/food/snacks/grown/harebell,
 /turf/open/floor/wood_fancy,
 /area/f13/ambientlighting/building/c)
+"Xv" = (
+/turf/open/floor/plasteel/stairs{
+	barefootstep = "woodbarefoot";
+	color = "#A47449";
+	footstep = "wood"
+	},
+/area/f13/wasteland)
 "Xw" = (
 /obj/structure/flora/twig3,
 /turf/open/floor/f13/wood,
@@ -15160,6 +15807,21 @@
 "XU" = (
 /turf/open/floor/wood_common/wood_common_light,
 /area/f13/building/abandoned/z)
+"XV" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 5;
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"XW" = (
+/obj/structure/railing/wood{
+	pixel_y = 23
+	},
+/turf/open/transparent/openspace,
+/area/f13/wasteland)
 "XY" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
@@ -15305,6 +15967,12 @@
 /obj/structure/window/fulltile/store,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/p)
+"YB" = (
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	dir = 4
+	},
+/area/f13/wasteland)
 "YC" = (
 /obj/structure/railing{
 	dir = 1
@@ -15472,6 +16140,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/ambientlighting/building/c)
+"Zg" = (
+/obj/structure/railing/wood{
+	pixel_y = 23
+	},
+/obj/structure/fence/wooden{
+	dir = 1;
+	pixel_y = 11
+	},
+/turf/closed/mineral/random/low_chance,
+/area/f13/wasteland)
 "Zh" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/wood_common,
@@ -15497,6 +16175,18 @@
 	icon_state = "oakfloor1"
 	},
 /area/f13/wasteland)
+"Zl" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/overlay/desert/sonora/edge,
+/obj/structure/guncase{
+	anchored = 1
+	},
+/turf/open/floor/padded{
+	color = "634A46";
+	name = "tarp";
+	desc = "A simple tarp laid out on the ground."
+	},
+/area/f13/caves)
 "Zm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/trash_stack{
@@ -15512,6 +16202,10 @@
 	color = "#A47449"
 	},
 /turf/open/transparent/openspace,
+/area/f13/wasteland)
+"Zo" = (
+/obj/structure/flora/grass/coyote/one,
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "Zp" = (
 /obj/structure/table,
@@ -15678,6 +16372,13 @@
 	},
 /turf/open/floor/plating/f13/outside/roof,
 /area/f13/wasteland)
+"ZT" = (
+/obj/structure/flora/grass/wasteland{
+	icon_state = "tall_grass_4";
+	layer = 6
+	},
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "ZW" = (
 /obj/structure/closet/wardrobe/cargotech,
 /turf/open/floor/f13{
@@ -15695,6 +16396,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/p)
+"ZZ" = (
+/obj/structure/flora/tree/joshua,
+/turf/open/indestructible/ground/outside/dirt{
+	icon_state = "dirt";
+	dir = 4
+	},
+/area/f13/wasteland)
 
 (1,1,1) = {"
 EI
@@ -37744,14 +38452,14 @@ EI
 "}
 (74,1,1) = {"
 EI
+FO
 xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
+li
+li
+li
 xm
 xm
 xm
@@ -38046,14 +38754,14 @@ EI
 "}
 (75,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+FO
+li
+li
+li
+li
+li
 xm
 xm
 xm
@@ -38348,14 +39056,14 @@ EI
 "}
 (76,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+FO
+li
+li
+li
+li
+zi
 xm
 xm
 xm
@@ -38650,14 +39358,14 @@ EI
 "}
 (77,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+ql
+ql
+ql
+ql
+Gy
+Gy
+Gy
+Gy
 xm
 xm
 xm
@@ -38952,14 +39660,14 @@ EI
 "}
 (78,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+FO
+zi
+zi
+zi
+zi
+zi
 xm
 xm
 xm
@@ -39254,14 +39962,14 @@ EI
 "}
 (79,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+zi
+zi
+zi
+zi
+zi
+zi
 xm
 xm
 xm
@@ -39556,14 +40264,14 @@ EI
 "}
 (80,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+zi
+zi
+zi
+zi
+zi
+zi
 xm
 xm
 xm
@@ -39858,14 +40566,14 @@ EI
 "}
 (81,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+zi
+zi
+zi
+zi
+zi
+zi
 xm
 xm
 xm
@@ -40160,14 +40868,14 @@ EI
 "}
 (82,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+zi
+zi
+zi
+zi
+zi
+zi
 xm
 xm
 xm
@@ -40462,36 +41170,36 @@ EI
 "}
 (83,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+FO
 zi
+zi
+zi
+zi
+zi
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+oA
 zi
 zi
 zi
@@ -40764,37 +41472,37 @@ EI
 "}
 (84,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-zi
-zi
+ql
+ql
+ql
+ql
+Gy
+Gy
+ql
+ql
+ql
+Gy
+Gy
+Gy
+Gy
+ql
+Gy
+Gy
+Gy
+Gy
+ql
+Gy
+Gy
+Gy
+Gy
+ql
+Gy
+Gy
+Gy
+Gy
+ql
+oA
+oA
 zi
 zi
 zi
@@ -41066,39 +41774,39 @@ EI
 "}
 (85,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+FO
+FO
+li
+li
+li
+li
+li
+Pa
+li
+li
+li
+li
+li
+It
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -41368,39 +42076,39 @@ EI
 "}
 (86,1,1) = {"
 EI
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+FO
+FO
+FO
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+Pa
+li
+li
+bN
+gA
+li
+li
+li
+li
+li
+li
+li
+Zt
+Zt
 xm
 xm
 xm
@@ -41670,39 +42378,39 @@ EI
 "}
 (87,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+FO
+FO
+FO
+li
+iX
+ZZ
+YB
+YB
+fd
+li
+li
+Zt
+Zt
+li
+li
+li
+li
+li
+li
+CX
+mI
+jK
+li
+ZT
+li
+li
+li
+li
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -41972,38 +42680,38 @@ EI
 "}
 (88,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+FO
+FO
+li
+iX
+ar
+AZ
+Ud
+AZ
+vi
+fd
+li
+li
+Zt
+Zt
+li
+Pa
+li
+xj
+li
+CX
+CX
+li
+li
+li
+li
+li
+li
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -42274,38 +42982,38 @@ EI
 "}
 (89,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+FO
+FO
+li
+qN
+aW
+AZ
+AZ
+hB
+AZ
+os
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+oE
+li
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -42576,38 +43284,38 @@ EI
 "}
 (90,1,1) = {"
 EI
-rN
-rN
+FO
+FO
+FO
+FO
+li
+qN
+NT
+AZ
+zQ
+jQ
+jQ
+yN
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+iX
+YB
+ys
+fd
+li
+li
+li
+li
 Zt
 Zt
-Zt
-Zt
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
 xm
 xm
 xm
@@ -42878,38 +43586,38 @@ EI
 "}
 (91,1,1) = {"
 EI
-rN
-rN
-Zt
-rN
-rN
-rN
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+FO
+li
+li
+hk
+mp
+XV
+Dy
+li
+li
+li
+SC
+SC
+li
+Tx
+li
+li
+li
+li
+iX
+YB
+Lh
+hT
+AZ
+Dy
+Bq
+li
+nn
+li
+EA
+Zg
 xm
 fn
 fn
@@ -43180,38 +43888,38 @@ EI
 "}
 (92,1,1) = {"
 EI
-rN
-rN
-Zt
-rN
-rN
-rN
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+li
+li
+li
+li
+od
+jQ
+yN
+li
+li
+kW
+oT
+oT
+XM
+li
+li
+li
+li
+Pa
+qN
+AZ
+AZ
+AZ
+gU
+yN
+li
+Pa
+li
+li
+li
+zK
 xm
 fn
 fn
@@ -43482,38 +44190,38 @@ EI
 "}
 (93,1,1) = {"
 EI
-rN
-rN
-Zt
-rN
-rN
-rN
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+li
+li
+li
+li
+It
+li
+li
+li
+li
+si
+oT
+oT
+oT
+XM
+SC
+li
+li
+li
+LP
+AZ
+Or
+jQ
+yN
+wd
+EA
+li
+li
+HD
+EE
+vC
 xm
 fn
 fn
@@ -43784,38 +44492,38 @@ EI
 "}
 (94,1,1) = {"
 EI
-rN
-rN
+FO
+FO
+Ky
+li
+li
+li
+li
+li
+li
+li
+si
+oT
+xm
+xm
+xm
 Zt
-Zt
-Zt
-Zt
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
-xm
-xm
+Xv
+IF
+li
+li
+hk
+jQ
+yN
+li
+li
+li
+li
+li
+Kv
+wd
+li
+XW
 xm
 fn
 fn
@@ -44086,38 +44794,38 @@ EI
 "}
 (95,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
+FO
+zN
+ep
+nU
+nK
+nK
+Am
+li
+li
+kW
+oT
+Zt
+Zt
 xm
 xm
-xm
-xm
-xm
-xm
+wK
+tN
+li
+li
+li
+li
+li
+li
+li
+li
+li
+NW
+li
+hA
+cE
+li
+vC
 xm
 fn
 fn
@@ -44388,38 +45096,38 @@ EI
 "}
 (96,1,1) = {"
 EI
-rN
-rN
+FO
+zN
+Fv
+UP
+IL
+IL
+pq
+li
+li
+li
+cm
+oT
 Zt
 Zt
-Zt
-Zt
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
 xm
 xm
 xm
-xm
-xm
-xm
+IF
+li
+gA
+li
+li
+li
+RX
+RX
+li
+li
+Pa
+GN
+ix
+li
+XW
 xm
 xm
 xm
@@ -44690,38 +45398,38 @@ EI
 "}
 (97,1,1) = {"
 EI
-rN
-rN
+FO
+zN
+Zl
+UP
+UP
+UP
+mO
+li
+li
+gA
+li
+cm
+oT
 Zt
-rN
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
-xm
+oT
+oT
+ie
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+wd
+li
+EE
+vC
 xm
 xm
 xm
@@ -44992,38 +45700,38 @@ EI
 "}
 (98,1,1) = {"
 EI
-rN
-rN
-Zt
-rN
-Zt
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
-xm
+FO
+zN
+wU
+Az
+UP
+UP
+mO
+li
+li
+gA
+li
+li
+cm
+oT
+ie
+vo
+li
+li
+vt
+gA
+li
+li
+li
+li
+li
+li
+wd
+Bq
+li
+Pa
+SE
+XW
 xm
 xm
 xm
@@ -45294,38 +46002,38 @@ EI
 "}
 (99,1,1) = {"
 EI
-rN
-rN
+FO
+zN
+QK
+hz
+mW
+mW
+fr
+li
+vt
+li
+li
+li
+li
+vo
+li
+li
+pf
+li
+iX
+YB
+fd
+li
+li
+li
+wv
+SC
+SC
+SC
+au
+iP
 Zt
-Zt
-Zt
-rN
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
+hb
 xm
 xm
 xm
@@ -45596,37 +46304,37 @@ EI
 "}
 (100,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
+FO
+FO
+Ky
+li
+li
+eY
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+li
+iX
+Zu
+AZ
+vi
+fd
+li
+li
+si
 xm
 xm
+xm
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -45898,37 +46606,37 @@ EI
 "}
 (101,1,1) = {"
 EI
-rN
-rN
-Zt
-Zt
-Zt
-Zt
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
+FO
+FO
+FO
+li
+li
+li
+FO
+FO
+li
+li
+Pa
+li
+iX
+Hs
+fd
+li
+li
+qN
+rz
+nm
+AZ
+vi
+fd
+kW
 xm
 xm
+xm
+xm
+xm
+Zt
+Zt
 xm
 xm
 xm
@@ -46200,37 +46908,37 @@ EI
 "}
 (102,1,1) = {"
 EI
-rN
-rN
-Zt
-rN
-Zt
-rN
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
+FO
+FO
+FO
+sx
+tH
+FO
+FO
+FO
+FO
+li
+li
+iX
+Lh
+AZ
+gl
+fd
+li
+hk
+mp
+AZ
+AZ
+NT
+Dy
+kW
+vs
 xm
 xm
+xm
+ny
+Zt
+Zt
 xm
 xm
 xm
@@ -46502,37 +47210,37 @@ EI
 "}
 (103,1,1) = {"
 EI
-rN
-rN
+FO
+FO
+FO
+FO
+FO
+FO
+FO
+li
+li
+li
+iX
+Lh
+AZ
+rz
+AZ
+os
+li
+li
+hk
+mp
+AZ
+zQ
+yN
+kW
+oT
+Pq
+Pq
+Pq
+oT
 Zt
-rN
 Zt
-rN
-Zt
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
 xm
 xm
 xm
@@ -46804,36 +47512,36 @@ EI
 "}
 (104,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
+FO
+FO
+FO
+FO
+li
+li
+li
+li
+li
+li
+td
+AZ
+np
+hT
+AZ
+os
+li
+li
+li
+hk
+jQ
+yN
+li
+si
+oT
+oT
+oT
+oT
+Zt
+Zt
 xm
 xm
 xm
@@ -47106,37 +47814,37 @@ EI
 "}
 (105,1,1) = {"
 EI
+FO
+FO
+FO
+FO
+li
+li
+li
+li
+li
+li
+hk
 rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
+AZ
+aq
+zQ
+yN
+li
+CX
+CX
+li
+li
+li
+kW
+oT
+oT
+oT
+oT
+Zt
+Zt
+Zt
+Zt
 xm
 xm
 xm
@@ -47408,41 +48116,41 @@ EI
 "}
 (106,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-xm
-xm
-xm
-xm
-xm
+FO
+FO
+FO
+li
+VS
+li
+li
+li
+CX
+ed
+li
+hk
+jQ
+jQ
+yN
+li
+li
+CX
+CX
+CX
+li
+li
+kW
+oT
+oT
+Zt
+Zt
+Zt
+Zt
+Zt
+bR
+bR
+bR
+bR
+eK
 xm
 xm
 xm
@@ -47710,41 +48418,41 @@ EI
 "}
 (107,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
+FO
+FO
+vi
+fd
+li
+li
+li
+li
+li
+Na
+LO
+li
+li
+li
+li
+li
+CX
+CX
+CX
+li
+li
+Pa
+kW
+oT
+Zt
+Zt
+Zt
+Zt
+TC
 zi
 zi
 zi
 zi
 zi
-zi
-xm
+YC
 xm
 xm
 xm
@@ -48012,41 +48720,41 @@ EI
 "}
 (108,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
+FO
+FO
+AZ
+vi
+fd
+Pa
+li
+li
+si
+oT
+oT
+XM
+li
+li
+li
+CX
+ed
+CX
+iX
+Hs
+fd
+li
+kW
+Zt
+Zt
+Zt
+Zt
+Zt
+TC
 zi
 zi
 zi
 zi
 zi
-zi
-xm
+YC
 xm
 xm
 xm
@@ -48314,41 +49022,41 @@ EI
 "}
 (109,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
+FO
+AZ
+AZ
+pU
+vi
+fd
+li
+si
+oT
+oT
+oT
+oT
+IF
+li
+li
+Zo
+CX
+iX
+Lh
+my
+os
+li
+li
+vo
+vo
+Zt
+Zt
+Zt
+TC
+zi
+TC
 zi
 zi
 zi
-zi
-zi
-zi
-xm
+YC
 xm
 xm
 xm
@@ -48616,41 +49324,41 @@ EI
 "}
 (110,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-zi
-zi
-zi
-zi
-zi
-zi
-zi
+FO
+hT
+Ud
+AZ
+AZ
+Dy
+si
+Zt
+Zt
 xm
+xm
+oT
+XM
+li
+li
+li
+li
+td
+Ud
+hT
+os
+li
+li
+li
+Pa
+li
+Zt
+zi
+zi
+zi
+TC
+TC
+zi
+zi
+YC
 xm
 xm
 xm
@@ -48918,41 +49626,41 @@ EI
 "}
 (111,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-zi
-zi
-zi
-zi
-zi
-zi
-zi
+FO
+AZ
+AZ
+AZ
+hB
+IC
+Zt
+Zt
 xm
+xm
+xm
+oT
+oT
+IF
+li
+li
+li
+td
+rz
+zQ
+yN
+li
+li
+Pa
+li
+li
+li
+zi
+zi
+zi
+TC
+TC
+zi
+zi
+YC
 xm
 xm
 xm
@@ -49220,41 +49928,41 @@ EI
 "}
 (112,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-zi
-zi
-zi
-zi
-zi
-zi
-zi
+FO
+FO
+NT
+AZ
+XV
+Dy
+cm
 xm
+xm
+xm
+xm
+xm
+oT
+IF
+li
+li
+li
+hk
+jQ
+yN
+li
+gA
+li
+li
+li
+li
+CX
+zi
+zi
+zi
+TC
+TC
+zi
+zi
+YC
 xm
 xm
 xm
@@ -49522,41 +50230,41 @@ EI
 "}
 (113,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-zi
-zi
-zi
-zi
-zi
-zi
+FO
+FO
+AZ
+AZ
+zQ
+yN
+li
+cm
 xm
 xm
+xm
+xm
+ie
+li
+Zt
+qy
+li
+li
+li
+li
+vt
+gA
+li
+li
+li
+CX
+ed
+TC
+zi
+zi
+zi
+zi
+zi
+qU
+sU
 xm
 xm
 xm
@@ -49824,40 +50532,40 @@ EI
 "}
 (114,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
+FO
+FO
+nm
+zQ
+yN
+CX
+VS
+li
+vo
+vo
+vo
+vo
+li
+li
+Zt
+Zt
+li
+li
+Pa
+li
+li
+gA
+li
+li
+CX
+TC
+TC
+TC
 zi
 zi
 zi
 zi
 zi
-zi
-zi
-zi
-xm
+YC
 xm
 xm
 xm
@@ -50126,30 +50834,30 @@ EI
 "}
 (115,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
+FO
+FO
+zQ
+yN
+CX
+ed
+CX
+li
+li
+li
+li
+li
+li
+li
+Zt
+Zt
+li
+li
+li
+li
+li
+li
+Pa
+li
 zi
 zi
 zi
@@ -50159,7 +50867,7 @@ zi
 zi
 zi
 zi
-xm
+YC
 xm
 xm
 xm
@@ -50428,40 +51136,40 @@ EI
 "}
 (116,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
+FO
+FO
+FO
+li
+li
+iD
+ed
+CX
+li
+li
+Pa
+li
+li
+li
+Zt
+Zt
+li
+Pa
+li
+li
+li
+si
+Zt
+Pa
 zi
 zi
 zi
 zi
+TC
+TC
 zi
 zi
 zi
-zi
-zi
-xm
+YC
 xm
 xm
 xm
@@ -50730,40 +51438,40 @@ EI
 "}
 (117,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
+FO
+FO
+FO
+li
+li
+li
+CX
+li
+li
+li
+li
+Pa
+li
+li
+li
+Zt
+li
+li
+li
+li
+kW
+Zt
+Zt
+Zt
 zi
 zi
 zi
+TC
+TC
+TC
 zi
+TC
 zi
-zi
-zi
-zi
-zi
-xm
+YC
 xm
 xm
 xm
@@ -51032,40 +51740,40 @@ EI
 "}
 (118,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
+FO
+FO
+FO
+FO
+li
+VS
+li
+li
 xm
+xm
+XM
+SC
+JQ
+SC
+SC
+SC
+SC
+SC
+SC
+SC
+si
+xm
+Zt
+Zt
+TC
+zi
+zi
+zi
+zi
+zi
+zi
+TC
+TC
+YC
 xm
 xm
 xm
@@ -51334,40 +52042,40 @@ EI
 "}
 (119,1,1) = {"
 EI
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-rN
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
-zi
+FO
+FO
+FO
+FO
+li
+li
 xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+xm
+Zt
+TC
+TC
+zi
+zi
+zi
+zi
+zi
+TC
+TC
+YC
 xm
 xm
 xm
@@ -51636,6 +52344,10 @@ EI
 "}
 (120,1,1) = {"
 EI
+FO
+FO
+FO
+FO
 xm
 xm
 xm
@@ -51655,21 +52367,17 @@ xm
 xm
 xm
 xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
-xm
+ZF
+yz
+yz
+yz
+yz
+yz
+yz
+yz
+yz
+yz
+sU
 xm
 xm
 xm
@@ -51938,9 +52646,9 @@ EI
 "}
 (121,1,1) = {"
 EI
-xm
-xm
-xm
+FO
+FO
+FO
 xm
 xm
 xm
@@ -52240,8 +52948,8 @@ EI
 "}
 (122,1,1) = {"
 EI
-xm
-xm
+FO
+FO
 xm
 xm
 xm
@@ -52542,7 +53250,7 @@ EI
 "}
 (123,1,1) = {"
 EI
-xm
+FO
 xm
 xm
 xm

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
@@ -211,15 +211,12 @@
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/n)
 "adi" = (
-/obj/structure/stairs/north{
-	color = "#A47449"
-	},
+/obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/weather/dirt{
-	dir = 1;
-	layer = 10000
+	dir = 4
 	},
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/turf/open/floor/plating/rust,
+/area/f13/sewer/powered)
 "adp" = (
 /obj/effect/spawner/lootdrop/wastelootgood,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -295,6 +292,7 @@
 	pixel_y = -4;
 	pixel_x = -16
 	},
+/obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "afe" = (
@@ -479,6 +477,17 @@
 /obj/machinery/chem_master/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/powered)
+"aib" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/caves)
 "aid" = (
 /obj/effect/spawner/lootdrop/toolsbasic,
 /obj/machinery/light{
@@ -570,6 +579,15 @@
 /obj/structure/reagent_dispensers/barrel/two,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"ajI" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "ajL" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/terminal,
@@ -848,6 +866,12 @@
 /obj/effect/decal/cleanable/dirt{
 	color = "#363636"
 	},
+/obj/item/bodypart/r_arm/robot/surplus,
+/obj/item/bodypart/r_arm/robot/surplus,
+/obj/item/bodypart/r_arm/robot/surplus,
+/obj/item/bodypart/l_arm/robot/surplus,
+/obj/item/bodypart/l_arm/robot/surplus,
+/obj/item/bodypart/l_arm/robot/surplus,
 /turf/open/floor/f13{
 	icon_state = "bluedirtychess2"
 	},
@@ -1752,7 +1776,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/legion)
 "aBw" = (
 /obj/structure/curtain,
@@ -2970,9 +2994,6 @@
 /area/maintenance/bar)
 "aUi" = (
 /obj/effect/spawner/lootdrop/wastelootgood,
-/obj/effect/decal/cleanable/cobweb{
-	icon_state = "cobweb2"
-	},
 /turf/open/floor/wood_common/wood_common_light,
 /area/f13/building/powered)
 "aUl" = (
@@ -3021,6 +3042,14 @@
 /obj/effect/spawner/lootdrop/f13/alcoholspawner,
 /turf/open/floor/wood_fancy,
 /area/f13/ambientlighting/building/m)
+"aUY" = (
+/obj/effect/decal/remains/human,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	light_color = "#f4e3b0"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "aVc" = (
 /obj/effect/decal/remains/human,
 /turf/open/indestructible/ground/outside/road{
@@ -3357,6 +3386,17 @@
 "aYN" = (
 /turf/open/floor/plasteel/darkbrown,
 /area/f13/ambientlighting/building/y)
+"aYP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/rack/large/shelf_rust,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/obj/effect/spawner/lootdrop/f13/advcrafting,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "rusted floor"
+	},
+/area/f13/sewer/powered)
 "aYS" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3756,10 +3796,9 @@
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/o)
 "beA" = (
-/obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/pen/fourcolor,
-/obj/item/paper_bin,
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/wastelootgood,
 /turf/open/floor/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -4060,11 +4099,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vault1,
 /area/maintenance/bar)
 "biK" = (
-/obj/item/radio/intercom/retro{
-	pixel_y = 32
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/wood_common/wood_common_light,
-/area/f13/building/powered)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "biP" = (
 /obj/machinery/hydroponics/soil,
 /turf/open/indestructible/ground/outside/desert,
@@ -4315,6 +4354,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/m)
+"bmW" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "bnd" = (
 /obj/structure/table/optable/primitive,
 /turf/open/floor/plasteel/f13/stone/rugged,
@@ -4513,9 +4558,7 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland/legion)
 "bqb" = (
-/obj/structure/flora/wasteplant/wild_fungus,
-/obj/effect/decal/cleanable/blood,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "bqj" = (
 /mob/living/simple_animal/hostile/ghoul/legendary,
@@ -5048,13 +5091,10 @@
 	},
 /area/f13/ambientlighting/building/m)
 "bya" = (
-/obj/structure/chair/f13chair2{
-	dir = 1;
-	icon_state = "f13chair2"
-	},
 /obj/machinery/light{
 	flickering = 1
 	},
+/obj/machinery/trading_machine,
 /turf/open/floor/f13{
 	icon_state = "floorrusty"
 	},
@@ -5090,6 +5130,13 @@
 /obj/structure/simple_door/metal/fence,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legioncamp)
+"bzA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/obstacle/barbedwire/end{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "bzD" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/remains/human,
@@ -5160,6 +5207,15 @@
 	icon_state = "verticalrightborderright0"
 	},
 /area/f13/wasteland)
+"bAZ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "bBa" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/reagent_dispensers/barrel/dangerous,
@@ -5608,6 +5664,20 @@
 	},
 /turf/open/floor/wood_common{
 	icon_state = "common-broken3"
+	},
+/area/f13/ambientlighting/building/m)
+"bHW" = (
+/obj/structure/closet/fridge/standard{
+	anchored = 1
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/obj/effect/spawner/lootdrop/f13/foodspawner,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
 	},
 /area/f13/ambientlighting/building/m)
 "bHY" = (
@@ -6243,6 +6313,13 @@
 	icon_state = "bar"
 	},
 /area/f13/ambientlighting/building/g)
+"bQQ" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 1;
+	pixel_y = 17
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "bRb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -6951,6 +7028,16 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/clinic)
+"cbo" = (
+/obj/structure/chair/stool{
+	dir = 8;
+	icon_state = "bench"
+	},
+/obj/machinery/light/fo13colored/Red,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/ambientlighting/building/m)
 "cbv" = (
 /obj/structure/lamp_post{
 	dir = 8
@@ -7336,6 +7423,13 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/wasteland/town)
+"chJ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "chN" = (
 /obj/effect/decal/marking{
 	icon_state = "dottedverticaldegraded"
@@ -8501,11 +8595,8 @@
 /turf/open/floor/carpet/purple,
 /area/f13/bar)
 "cym" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/bin/trashbin,
 /turf/open/floor/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -8626,6 +8717,13 @@
 /mob/living/simple_animal/hostile/mirelurk/baby,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/underground/cave)
+"czL" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "czV" = (
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -8925,7 +9023,7 @@
 /area/f13/tunnel/southwest)
 "cDF" = (
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/legion)
 "cDN" = (
 /obj/effect/overlay/desert/sonora/edge{
@@ -9303,6 +9401,14 @@
 	icon_state = "verticalleftborderleft0"
 	},
 /area/f13/ambientlighting/building/i)
+"cIc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/pill/healingpowder,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "cId" = (
 /obj/structure/barricade/wooden/strong,
 /obj/effect/overlay/fog,
@@ -9916,6 +10022,13 @@
 	icon_state = "horizontaloutermain1"
 	},
 /area/f13/wasteland)
+"cQR" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "cRa" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 1;
@@ -10934,6 +11047,15 @@
 	icon_state = "horizontaloutermain0"
 	},
 /area/f13/wasteland)
+"deZ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "dfk" = (
 /obj/structure/fence{
 	dir = 1;
@@ -11277,7 +11399,7 @@
 	pixel_x = 2;
 	pixel_y = 1
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "dkz" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -11459,8 +11581,8 @@
 /turf/closed/indestructible/riveted,
 /area/f13/tcoms)
 "dnw" = (
-/turf/open/indestructible/ground/outside/water/running,
-/area/f13/caves)
+/turf/closed/wall/mineral/concrete/blastproof,
+/area/f13/building/powered)
 "dnx" = (
 /obj/effect/decal/riverbank{
 	icon_state = "stones";
@@ -12008,6 +12130,13 @@
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/wasteland)
+"duy" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "duM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/fakelattice,
@@ -12106,6 +12235,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"dvT" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dwe" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/simple_door/bunker,
@@ -12685,10 +12820,10 @@
 /area/f13/building/abandoned/o)
 "dFu" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/power/smes,
 /obj/structure/cable/outdoors{
 	icon_state = "0-2"
 	},
+/obj/machinery/power/smes/magical,
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -12797,6 +12932,15 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/ambientlighting/building/h)
+"dHe" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "dHg" = (
 /obj/effect/decal/cleanable/dirt/dust{
 	dir = 4
@@ -14586,10 +14730,12 @@
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
 "egZ" = (
-/obj/item/twohanded/legionaxe,
-/obj/effect/decal/cleanable/generic,
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/mre,
+/obj/effect/spawner/lootdrop/mre,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "ehf" = (
 /turf/open/floor/plating/f13/outside/road{
 	dir = 4;
@@ -14833,8 +14979,8 @@
 /area/f13/followers)
 "ekY" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/syndicate,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/belt/utility/full/engi,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/ambientlighting/building/i)
 "elf" = (
@@ -15517,6 +15663,13 @@
 "euU" = (
 /turf/closed/wall/rust,
 /area/f13/bunker)
+"euZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/fo13colored/Red{
+	dir = 1
+	},
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "evg" = (
 /obj/structure/junk/drawer,
 /obj/effect/overlay/desert/sonora/edge/corner{
@@ -16902,13 +17055,13 @@
 	},
 /area/f13/wasteland)
 "eSs" = (
-/obj/item/storage/toolbox/infiltrator,
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/crafting,
 /obj/structure/sign/poster/contraband/pinup_ride{
 	pixel_y = 31
 	},
+/obj/item/storage/toolbox/mechanical/old,
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/ambientlighting/building/i)
 "eSw" = (
@@ -18333,6 +18486,23 @@
 	icon_state = "horizontalbottomborderbottom2left"
 	},
 /area/f13/building/powered)
+"flf" = (
+/obj/structure/closet/crate/bin/trashbin,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/ambientlighting/building/m)
+"fli" = (
+/obj/structure/filingcabinet{
+	pixel_x = -6
+	},
+/obj/structure/filingcabinet{
+	pixel_x = 11
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/ambientlighting/building/m)
 "flp" = (
 /obj/structure/flora/twig,
 /turf/open/indestructible/ground/outside/dirt,
@@ -18397,12 +18567,12 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/ambientlighting/building/i)
 "fmr" = (
-/obj/effect/decal/cleanable/blood{
-	icon_state = "gib2";
-	pixel_y = 4
+/obj/machinery/door/password{
+	door_id = "veryevilroom"
 	},
-/turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "fmy" = (
 /turf/open/floor/wood_common,
 /area/f13/clinic)
@@ -18443,12 +18613,10 @@
 /turf/open/indestructible/ground/outside/gravel,
 /area/f13/building/abandoned/o)
 "fnx" = (
-/obj/effect/spawner/lootdrop/f13/junkspawners,
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 4;
-	icon_state = "outercorner"
-	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden,
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "fnz" = (
 /obj/structure/bookcase/random/religion,
 /obj/effect/decal/cleanable/dirt{
@@ -18691,6 +18859,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road,
 /area/f13/wasteland)
+"fra" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/caves)
 "frc" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/rust,
@@ -19083,6 +19257,13 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plasteel/dark,
 /area/engine/workshop)
+"fwR" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	light_color = "#f4e3b0"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fwX" = (
 /obj/structure/curtain{
 	color = "#363636"
@@ -19278,11 +19459,12 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
 "fzD" = (
-/obj/effect/decal/cleanable/blood{
-	icon_state = "tracks"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/mob/living/simple_animal/hostile/radscorpion/black,
-/turf/open/indestructible/ground/inside/mountain,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood2-broken"
+	},
 /area/f13/caves)
 "fzH" = (
 /obj/structure/fence/wooden{
@@ -19867,6 +20049,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/cell_charger,
 /obj/structure/table,
+/obj/structure/cable/outdoors{
+	icon_state = "1-10"
+	},
+/obj/structure/cable/outdoors{
+	icon_state = "2-9"
+	},
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -19909,6 +20097,11 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/f13/vault_floor/misc/bar,
 /area/f13/building/abandoned/l)
+"fJe" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fJf" = (
 /obj/structure/decoration/hatch{
 	dir = 4
@@ -20343,12 +20536,15 @@
 /area/f13/building/abandoned/g)
 "fOd" = (
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable/outdoors{
-	icon_state = "1-10"
-	},
 /obj/machinery/light{
 	dir = 4;
 	flickering = 1
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/outdoors{
+	icon_state = "0-2"
 	},
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -20397,17 +20593,7 @@
 	},
 /area/f13/wasteland)
 "fOT" = (
-/obj/effect/overlay/desert_side{
-	pixel_x = -15
-	},
-/obj/effect/overlay/desert_side{
-	dir = 1;
-	pixel_x = -11
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	dir = 9;
-	icon_state = "outerpavement"
-	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "fOW" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -20675,6 +20861,10 @@
 /obj/structure/barricade/wooden,
 /turf/closed/wall/f13/wood/house,
 /area/f13/legioncamp)
+"fTF" = (
+/obj/item/crowbar,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "fTI" = (
 /obj/structure/reagent_dispensers/barrel/dangerous{
 	pixel_y = -5;
@@ -21903,7 +22093,7 @@
 	pixel_x = -5;
 	pixel_y = -2
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/legion)
 "gka" = (
 /obj/machinery/pool/drain,
@@ -22017,6 +22207,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/abandoned/t)
+"glA" = (
+/obj/structure/wreck/car/bike,
+/obj/item/weldingtool/advanced,
+/turf/open/floor/plasteel/f13/vault_floor/plating,
+/area/f13/ambientlighting/building/i)
 "glH" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22078,10 +22273,11 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legioncamp)
 "gmQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/workbench,
-/turf/open/floor/pod/dark,
-/area/f13/building/powered)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "gmU" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/indestructible/ground/outside/desert,
@@ -22213,6 +22409,13 @@
 /obj/item/storage/pill_bottle/chem_tin/radx,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"got" = (
+/obj/effect/decal/cleanable/generic,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "gou" = (
 /obj/structure/window/fulltile/house{
 	icon_state = "housewindowbroken"
@@ -22820,6 +23023,11 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
+/obj/item/storage/box/medicine/stimpaks/stimpaks5,
 /turf/open/floor/plating/rust,
 /area/f13/followers)
 "gza" = (
@@ -24461,6 +24669,17 @@
 	},
 /turf/open/floor/plating/f13/outside/roof/metal/corrugated,
 /area/f13/building/abandoned/l)
+"gWc" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/caves)
 "gWd" = (
 /turf/open/floor/carpet/green,
 /area/maintenance/bar)
@@ -24877,6 +25096,10 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/ambientlighting/building/f)
+"hbE" = (
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hbJ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/low,
@@ -25214,11 +25437,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/ambientlighting/building/m)
 "hgr" = (
-/obj/effect/spawner/lootdrop/wastelootgood,
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
-/area/f13/ambientlighting/building/m)
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "hgu" = (
 /obj/structure/rack/shelf_metal,
 /obj/item/book/granter/crafting_recipe/gunsmith_one,
@@ -25281,6 +25504,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"hho" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "hhp" = (
 /obj/structure/flora/grass/wasteland{
 	pixel_x = 4;
@@ -25410,6 +25640,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/building/abandoned/a)
+"hji" = (
+/obj/effect/decal/remains/human,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "hjj" = (
 /obj/structure/simple_door/metal/store{
 	icon_state = "brokenstore"
@@ -25766,6 +26004,7 @@
 	dir = 8;
 	icon_state = "tracks"
 	},
+/obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "hnL" = (
@@ -26085,6 +26324,12 @@
 /obj/effect/decal/fakelattice,
 /turf/open/floor/plating/f13,
 /area/f13/wasteland)
+"hrB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/electronic_assembly/medium/radio,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "hrC" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -27670,15 +27915,8 @@
 	},
 /area/f13/building/abandoned/t)
 "hMe" = (
-/obj/structure/cable/outdoors{
-	icon_state = "4-8"
-	},
-/obj/structure/junk/locker,
-/obj/item/clothing/mask/chameleon,
-/obj/item/clothing/glasses/hud/diagnostic{
-	pixel_y = 6
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/obstacle/barbedwire/end,
 /turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "hMh" = (
@@ -27917,6 +28155,13 @@
 /obj/structure/flora/tree/tall,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
+"hPt" = (
+/obj/structure/rack/shelf_metal,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/bundle/f13/plasmapistol,
+/obj/effect/spawner/lootdrop/f13/blueprintMid,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "hPu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28777,6 +29022,9 @@
 /obj/structure/cable/outdoors{
 	icon_state = "6-9"
 	},
+/obj/structure/cable/outdoors{
+	icon_state = "1-10"
+	},
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
 	},
@@ -29065,6 +29313,15 @@
 /obj/structure/flora/tree/wasteland,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/town)
+"igg" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "igj" = (
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
@@ -29896,6 +30153,12 @@
 "isK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/booth,
+/obj/item/bodypart/l_arm/robot,
+/obj/item/bodypart/l_arm/robot,
+/obj/item/bodypart/l_arm/robot,
+/obj/item/bodypart/r_arm/robot,
+/obj/item/bodypart/r_arm/robot,
+/obj/item/bodypart/r_arm/robot,
 /turf/open/floor/carpet/arcade,
 /area/f13/ambientlighting/building/m)
 "isQ" = (
@@ -31148,10 +31411,6 @@
 	},
 /area/f13/wasteland/town)
 "iLq" = (
-/obj/structure/chair/stool{
-	dir = 4;
-	icon_state = "bench"
-	},
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/f13{
 	icon_state = "yellowrustyfull"
@@ -31395,13 +31654,16 @@
 	},
 /area/f13/wasteland/legion)
 "iOW" = (
-/obj/effect/decal/cleanable/blood{
-	icon_state = "tracks"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/machinery/door/locked/easy/trapped,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/f13/building/powered)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood3-broken"
+	},
+/area/f13/caves)
 "iOY" = (
 /obj/effect/overlay/desert_side,
 /obj/effect/overlay/desert_side{
@@ -32299,6 +32561,8 @@
 /area/f13/wasteland)
 "jcL" = (
 /obj/structure/table/reinforced,
+/obj/machinery/plantgenes/seedvault,
+/obj/item/storage/box/disks_plantgene,
 /turf/open/floor/f13{
 	icon_state = "whitegreenrustychess"
 	},
@@ -32635,11 +32899,8 @@
 /turf/open/floor/wood_fancy,
 /area/f13/building/powered)
 "jii" = (
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood{
-	icon_state = "tracks"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/porta_turret/f13/turret_shotgun/burstfire,
 /turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "jio" = (
@@ -33496,6 +33757,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
+"juj" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "juM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -33610,6 +33878,10 @@
 	icon_state = "verticalinnermainbottom"
 	},
 /area/f13/building/lower_firetower)
+"jwt" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "jwu" = (
 /obj/structure/barricade/wooden,
 /turf/closed/mineral/random/low_chance,
@@ -33727,6 +33999,13 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
+"jxS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/simple_door/bunker,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "rusted floor"
+	},
+/area/f13/sewer/powered)
 "jxU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -34332,7 +34611,9 @@
 /area/f13/ambientlighting/building/b)
 "jHn" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
+/obj/effect/spawner/lootdrop/f13/crafting,
 /turf/open/floor/f13{
 	icon_state = "yellowrustyfull"
 	},
@@ -34901,6 +35182,15 @@
 	},
 /turf/closed/wall/f13/tentwall,
 /area/f13/building/tribal)
+"jQC" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/ambientlighting/building/m)
 "jQH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/sofa{
@@ -35063,7 +35353,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/legion)
 "jSQ" = (
 /obj/structure/destructible/tribal_torch/lit,
@@ -35439,6 +35729,22 @@
 /obj/structure/fence/corner/wooden,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/building/tribal)
+"jZx" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/filingcabinet{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/obj/structure/filingcabinet{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/ambientlighting/building/m)
 "jZz" = (
 /obj/effect/overlay/desert/sonora/edge,
 /obj/structure/flora/tree/wasteland,
@@ -36677,6 +36983,7 @@
 /area/f13/ambientlighting/building/o)
 "krJ" = (
 /mob/living/simple_animal/hostile/deathclaw/legendary,
+/obj/item/twohanded/legionaxe,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "krK" = (
@@ -36737,6 +37044,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/f13/wood/interior,
 /area/f13/ambientlighting/building/m)
+"ktl" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood_common/wood_common_light,
+/area/f13/building/powered)
 "ktq" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5";
@@ -37257,10 +37568,18 @@
 /obj/item/reagent_containers/food/snacks/f13/deathclawegg,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"kBm" = (
+/obj/structure/table/booth,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/ambientlighting/building/m)
 "kBp" = (
-/obj/structure/bed/old,
-/obj/effect/overlay/junk/curtain,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood{
+	dir = 5;
+	icon_state = "tracks"
+	},
 /turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "kBr" = (
@@ -37425,8 +37744,12 @@
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legioncamp)
 "kDp" = (
-/obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gib2_flesh";
+	pixel_y = 4;
+	pixel_x = -9
+	},
 /turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "kDs" = (
@@ -38676,6 +38999,12 @@
 /obj/structure/closet/locker,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/building/abandoned/m)
+"kSR" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "kSS" = (
 /obj/effect/landmark/start/f13/ncrheavytrooper,
 /obj/effect/landmark/start/f13/ncrheavytrooper,
@@ -39831,6 +40160,16 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ambientlighting/building/i)
+"llX" = (
+/obj/structure/railing/wood/post{
+	desc = "A wooden stanchion.";
+	name = "wooden stanchion";
+	pixel_y = -4;
+	pixel_x = -16
+	},
+/obj/structure/destructible/tribal_torch/wall/lit,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "lmc" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -40954,7 +41293,7 @@
 	icon_state = "tracks"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
+/turf/closed/wall/f13/store,
 /area/f13/building/powered)
 "lCA" = (
 /obj/structure/barricade/tentclothcorner{
@@ -42681,6 +43020,14 @@
 /obj/machinery/smartfridge/drying_rack,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mdb" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin,
+/obj/item/pen/fourcolor,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/ambientlighting/building/m)
 "mdc" = (
 /obj/effect/decal/fakelattice,
 /obj/structure/disposalpipe/segment{
@@ -42944,7 +43291,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/water/running,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "mfS" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -43925,6 +44272,12 @@
 "mvc" = (
 /turf/closed/wall/f13/tentwall,
 /area/f13/wasteland)
+"mvl" = (
+/obj/machinery/smartfridge/bottlerack/lootshelf/books,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/ambientlighting/building/m)
 "mvp" = (
 /obj/structure/chair/sofa/right{
 	color = "#475340";
@@ -44581,8 +44934,10 @@
 /area/f13/building/tribal)
 "mEh" = (
 /obj/item/restraints/legcuffs/beartrap,
-/turf/open/floor/plating/f13/inside/gravel,
-/area/f13/wasteland)
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/ambientlighting/building/m)
 "mEm" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/reinforced,
@@ -45736,6 +46091,15 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"mUV" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "mUX" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/raider/legendary,
@@ -45995,6 +46359,16 @@
 /obj/item/clothing/shoes/ballandchain,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"mZN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/machinery/computer/terminal/stored_password{
+	door_id = "veryevilroom";
+	proj_pass_rate = 25;
+	dir = 4
+	},
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "mZT" = (
 /obj/item/mop,
 /obj/item/reagent_containers/glass/bucket/plastic,
@@ -48634,7 +49008,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/weather/dirt,
-/turf/open/indestructible/ground/outside/water/running,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "nKO" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -50410,9 +50784,6 @@
 	icon_state = "bench";
 	pixel_y = 17
 	},
-/obj/structure/billboard/superduper1{
-	pixel_y = 33
-	},
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain0"
 	},
@@ -51279,6 +51650,13 @@
 	icon_state = "horizontalinnermain0"
 	},
 /area/f13/wasteland)
+"oxZ" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "oya" = (
 /obj/structure/table,
 /obj/item/clothing/suit/armor/tiered/medium/vest/breastplate/scrap/mutie/reinforced,
@@ -51402,9 +51780,6 @@
 	pixel_x = 6;
 	pixel_y = 33
 	},
-/obj/structure/fluff/railing{
-	dir = 8
-	},
 /turf/open/floor/f13{
 	icon_state = "purplerustyfull"
 	},
@@ -51459,8 +51834,11 @@
 /obj/structure/cable/outdoors{
 	icon_state = "6-10"
 	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
 /obj/structure/cable/outdoors{
-	icon_state = "1-10"
+	icon_state = "0-2"
 	},
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -53559,7 +53937,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/legion)
 "pfN" = (
 /obj/structure/sink{
@@ -53857,6 +54235,15 @@
 /obj/structure/flora/tree/oak_three,
 /turf/open/indestructible/ground/outside/grass/corner,
 /area/f13/wasteland)
+"pjI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood{
+	dir = 5;
+	icon_state = "tracks"
+	},
+/obj/machinery/door/locked/easy/maybe_trapped,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "pjK" = (
 /obj/structure/rack/shelf_metal,
 /obj/structure/cable{
@@ -54786,7 +55173,7 @@
 "pxT" = (
 /obj/structure/barricade/wooden/planks/pregame,
 /obj/structure/barricade/wooden,
-/turf/closed/mineral/random/low_chance,
+/turf/closed/mineral/random/high_chance,
 /area/f13/caves)
 "pyb" = (
 /obj/structure/wreck/trash/engine,
@@ -55106,6 +55493,15 @@
 	dir = 4
 	},
 /area/f13/ambientlighting/building/t)
+"pDK" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/lootdrop/f13/advboards,
+/obj/effect/spawner/lootdrop/f13/advboards,
+/obj/effect/spawner/lootdrop/f13/advboards,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "rusted floor"
+	},
+/area/f13/sewer/powered)
 "pDN" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/outside/road{
@@ -55871,9 +56267,11 @@
 /turf/open/indestructible/ground/outside/ruins,
 /area/f13/ambientlighting/building/j)
 "pOm" = (
-/obj/structure/table,
-/obj/item/electronic_assembly/medium/radio,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
+/obj/item/radio/headset,
 /turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "pOr" = (
@@ -56073,6 +56471,12 @@
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ambientlighting/building/m)
+"pSv" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "pSA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/table/wood,
@@ -56195,6 +56599,13 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"pUb" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave,
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/ambientlighting/building/m)
 "pUe" = (
 /obj/structure/cross,
 /turf/open/indestructible/ground/outside/dirt,
@@ -56541,6 +56952,19 @@
 	icon_state = "bar"
 	},
 /area/f13/ambientlighting/building/m)
+"pYk" = (
+/obj/structure/filingcabinet{
+	pixel_x = -4;
+	pixel_y = 1
+	},
+/obj/structure/filingcabinet{
+	pixel_x = -10;
+	pixel_y = -6
+	},
+/turf/open/floor/f13{
+	icon_state = "yellowrustyfull"
+	},
+/area/f13/ambientlighting/building/m)
 "pYn" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -56825,6 +57249,12 @@
 /obj/item/paper_bin,
 /turf/open/floor/carpet/airless,
 /area/f13/ambientlighting/building/c)
+"qcd" = (
+/obj/structure/billboard/superduper1,
+/turf/open/indestructible/ground/outside/desert{
+	icon_state = "wasteland32"
+	},
+/area/f13/wasteland)
 "qcq" = (
 /obj/structure/reagent_dispensers/barrel/dangerous,
 /obj/structure/reagent_dispensers/barrel/dangerous{
@@ -59264,6 +59694,13 @@
 /obj/machinery/workbench/forge,
 /turf/open/floor/plasteel/dark,
 /area/engine/workshop)
+"qKG" = (
+/obj/structure/flora/wasteplant/wild_fungus,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "qKK" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden,
@@ -59357,6 +59794,18 @@
 /obj/effect/spawner/lootdrop/f13/medical/vault/meds,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/neutralchess,
 /area/f13/ambientlighting/building/m)
+"qLY" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/caves)
 "qLZ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -59522,14 +59971,14 @@
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "qOs" = (
-/obj/structure/chair/stool{
-	dir = 8;
-	icon_state = "bench"
+/obj/item/radio/intercom/retro{
+	pixel_y = 32
 	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/ambientlighting/building/m)
+/obj/structure/shelf_wood,
+/obj/item/implant/radio,
+/obj/item/implant/radio,
+/turf/open/floor/wood_common/wood_common_light,
+/area/f13/building/powered)
 "qOw" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13,
@@ -59653,14 +60102,14 @@
 /turf/open/floor/plating/rust,
 /area/f13/building/abandoned/u)
 "qPS" = (
+/obj/structure/rack/shelf_metal,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	light_color = "red"
-	},
-/turf/open/floor/f13{
-	icon_state = "yellowrustyfull"
-	},
-/area/f13/ambientlighting/building/m)
+/obj/item/clothing/shoes/combat,
+/obj/item/clothing/gloves/combat,
+/obj/item/clothing/suit/armor/tiered/medium/combat/mk2,
+/obj/item/clothing/head/helmet/f13/combat/mk2,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "qPW" = (
 /obj/structure/obstacle/barbedwire/end{
 	dir = 1;
@@ -60982,7 +61431,7 @@
 	},
 /area/f13/wasteland)
 "rhT" = (
-/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/high,
+/obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/highmid,
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "rhY" = (
@@ -61315,7 +61764,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "rmK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -62128,6 +62577,10 @@
 /mob/living/simple_animal/hostile/raider,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/building/abandoned/g)
+"rzQ" = (
+/obj/structure/barricade/wooden,
+/turf/closed/mineral/random/high_chance,
+/area/f13/caves)
 "rzR" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/indestructible/ground/inside/dirt,
@@ -62679,6 +63132,11 @@
 	pixel_y = 12
 	},
 /mob/living/simple_animal/hostile/ghoul/glowing/strong,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
+"rHJ" = (
+/mob/living/simple_animal/hostile/radscorpion/black,
+/obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
 "rHP" = (
@@ -63499,6 +63957,15 @@
 	icon_state = "verticalinnermain0"
 	},
 /area/f13/wasteland)
+"rUt" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "rUx" = (
 /obj/structure/window/fulltile/house,
 /obj/structure/barricade/wooden/strong,
@@ -63586,6 +64053,12 @@
 /obj/structure/car/rubbish3,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"rWc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/obstacle/barbedwire/end,
+/obj/item/mine/shrapnel,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "rWd" = (
 /obj/structure/destructible/tribal_torch/wall/lit{
 	dir = 8
@@ -63938,6 +64411,12 @@
 	},
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
+"scl" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "sct" = (
 /turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland/legion)
@@ -64092,6 +64571,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"seo" = (
+/obj/structure/flora/rock/jungle{
+	icon_state = "rock4";
+	pixel_x = -3
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "set" = (
 /obj/structure/destructible/tribal_torch/wall/lit,
 /turf/open/indestructible/ground/outside/desert,
@@ -64211,6 +64697,11 @@
 	icon_state = "horizontalinnermain1"
 	},
 /area/f13/ambientlighting/building/f)
+"sfT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stairs/west,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "sfX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mineral/wasteland_trader/general,
@@ -64451,7 +64942,7 @@
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
 "siN" = (
-/obj/structure/signpost,
+/obj/effect/decal/remains/sign/two,
 /turf/open/indestructible/ground/outside/dirt{
 	icon_state = "dirt";
 	dir = 4
@@ -64855,15 +65346,11 @@
 /turf/open/floor/wood_fancy/wood_fancy_dark,
 /area/f13/bar)
 "soD" = (
-/obj/structure/table,
-/obj/machinery/computer/terminal/stored_password{
-	door_id = "veryevilroom";
-	proj_pass_rate = 25
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/fo13colored/Red{
 	dir = 1
 	},
+/obj/machinery/porta_turret/f13/turret_shotgun/burstfire,
 /turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "soS" = (
@@ -65284,6 +65771,11 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/ambientlighting/building/b)
+"svO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/mine/shrapnel,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "svS" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -65514,6 +66006,15 @@
 /mob/living/simple_animal/hostile/supermutant/nightkin/rangedmutant,
 /turf/open/floor/plating/rust,
 /area/f13/building/powered)
+"szm" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "szn" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier2,
 /turf/open/indestructible/ground/outside/dirt{
@@ -65899,7 +66400,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/legion)
 "sEV" = (
 /obj/structure/curtain{
@@ -66282,6 +66783,18 @@
 /obj/effect/spawner/lootdrop/f13/junkspawners,
 /turf/open/floor/wood_common,
 /area/f13/clinic)
+"sKK" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	pixel_y = -8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/caves)
 "sKM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/overlay/desert/sonora/edge{
@@ -66677,6 +67190,9 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
 	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/caves)
 "sQJ" = (
@@ -66711,6 +67227,12 @@
 	name = "statue of a soldier"
 	},
 /turf/open/indestructible/ground/outside/ruins,
+/area/f13/wasteland)
+"sRf" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "sRm" = (
 /obj/structure/barricade/concrete,
@@ -66956,6 +67478,11 @@
 	dir = 8
 	},
 /area/f13/wasteland)
+"sUy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/remains/human,
+/turf/open/floor/pod/dark,
+/area/f13/building/powered)
 "sUH" = (
 /obj/structure/flora/junglebush/large,
 /turf/open/indestructible/ground/outside/dirt{
@@ -67788,6 +68315,17 @@
 	icon_state = "horizontaltopborderbottom0"
 	},
 /area/f13/wasteland)
+"tfQ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/caves)
 "tfW" = (
 /turf/open/floor/f13/wood{
 	icon_state = "housewood2"
@@ -68384,7 +68922,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
-/turf/open/indestructible/ground/outside/water/running,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "toA" = (
 /obj/structure/chair/bench{
@@ -68694,6 +69232,15 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/wasteland)
+"tsS" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/f13/wood,
+/area/f13/caves)
 "tsU" = (
 /obj/structure/flora/grass/coyote/eighteen,
 /turf/open/indestructible/ground/outside/desert,
@@ -69654,6 +70201,17 @@
 	},
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legioncamp)
+"tHh" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/caves)
 "tHr" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks/pregame,
@@ -69886,6 +70444,12 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"tLp" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/wasteland)
 "tLG" = (
 /obj/structure/closet/cabinet,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
@@ -69933,18 +70497,12 @@
 	},
 /area/f13/ambientlighting/building/i)
 "tMu" = (
-/obj/structure/rack/shelf_metal,
-/obj/item/clothing/head/helmet/f13/combat/mk2,
-/obj/item/clothing/suit/armor/tiered/medium/combat/mk2,
-/obj/item/clothing/gloves/combat,
-/obj/item/clothing/shoes/combat,
-/obj/machinery/light/fo13colored/Red{
-	dir = 4
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/lootdrop/f13/blueprintMid,
-/obj/effect/spawner/bundle/f13/plasmapistol,
-/turf/open/floor/pod/dark,
+/obj/structure/shelf_wood,
+/obj/item/radio/headset,
+/turf/open/floor/wood_common/wood_common_light,
 /area/f13/building/powered)
 "tMB" = (
 /turf/closed/wall/f13/ruins,
@@ -71681,10 +72239,11 @@
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/m)
 "ukc" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe/ammo,
-/turf/open/floor/pod/dark,
-/area/f13/building/powered)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "ukn" = (
 /obj/effect/decal/cleanable/robot_debris/gib,
 /obj/item/storage/trash_stack,
@@ -71843,6 +72402,19 @@
 	icon_state = "path_desert_end"
 	},
 /area/f13/wasteland)
+"umz" = (
+/obj/structure/railing/wood/post{
+	desc = "A wooden stanchion.";
+	name = "wooden stanchion";
+	pixel_y = -4;
+	pixel_x = -16
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4;
+	light_color = "#f4e3b0"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "umB" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/box,
@@ -71974,6 +72546,17 @@
 /obj/item/melee/onehanded/knife/bowie,
 /turf/open/floor/wood_common,
 /area/f13/building/abandoned/o)
+"uoi" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
+/area/f13/caves)
 "uoq" = (
 /obj/structure/decoration/hatch{
 	dir = 8
@@ -72170,7 +72753,7 @@
 /obj/effect/decal/cleanable/generic{
 	pixel_x = -8
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "ury" = (
 /obj/structure/rack/shelf_metal,
@@ -72794,13 +73377,10 @@
 	},
 /area/f13/ncr)
 "uBD" = (
-/obj/structure/cable/outdoors{
-	icon_state = "4-8"
-	},
-/turf/open/indestructible/ground/outside/sidewalk{
-	icon_state = "horizontaloutermain0"
-	},
-/area/f13/wasteland)
+/obj/structure/barricade/wooden/planks/pregame,
+/obj/structure/barricade/wooden/strong,
+/turf/closed/mineral/random/low_chance,
+/area/f13/sewer/powered)
 "uBG" = (
 /obj/structure/wreck/trash/machinepiletwo,
 /turf/open/indestructible/ground/outside/dirt,
@@ -73388,7 +73968,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
 	},
-/turf/open/indestructible/ground/outside/water/running,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland)
 "uJq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -74234,10 +74814,10 @@
 	},
 /area/f13/wasteland)
 "uWU" = (
-/obj/structure/cable/outdoors{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood{
+	icon_state = "gib2_flesh"
+	},
 /turf/open/floor/pod/dark,
 /area/f13/building/powered)
 "uWW" = (
@@ -74673,6 +75253,15 @@
 	},
 /turf/open/floor/plating/f13/inside/gravel,
 /area/f13/wasteland)
+"vcX" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "vcZ" = (
 /obj/structure/table/wood,
 /obj/structure/barricade/bars,
@@ -75272,6 +75861,19 @@
 	},
 /turf/closed/wall/mineral/brick,
 /area/f13/ncr)
+"vlt" = (
+/obj/structure/railing/wood/post{
+	desc = "A wooden stanchion.";
+	name = "wooden stanchion";
+	pixel_y = 24;
+	pixel_x = 16
+	},
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8;
+	light_color = "#f4e3b0"
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vlJ" = (
 /obj/structure/barricade/tentclothedge{
 	dir = 4
@@ -76582,6 +77184,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/building/abandoned/q)
+"vFb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/fo13colored/Red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	name = "rusted floor"
+	},
+/area/f13/sewer/powered)
 "vFh" = (
 /obj/structure/fence/corner{
 	dir = 6
@@ -76743,9 +77354,10 @@
 	},
 /area/f13/ambientlighting/building/p)
 "vGz" = (
-/obj/structure/barricade/wooden,
-/obj/structure/barricade/wooden/planks/pregame,
-/turf/open/indestructible/ground/outside/desert,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "vGF" = (
 /obj/structure/flora/grass/wasteland{
@@ -76859,7 +77471,8 @@
 /area/f13/wasteland/town)
 "vIm" = (
 /obj/structure/grille,
-/turf/open/indestructible/ground/outside/water/running,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/caves)
 "vIu" = (
 /obj/structure/barricade/wooden,
@@ -77262,6 +77875,13 @@
 	},
 /turf/open/indestructible/ground/outside/sidewalkdirt,
 /area/f13/wasteland/followers)
+"vQx" = (
+/obj/effect/decal/cleanable/blood{
+	icon_state = "tracks";
+	dir = 5
+	},
+/turf/open/floor/wood_common/wood_common_light,
+/area/f13/building/powered)
 "vQF" = (
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood{
@@ -77785,6 +78405,13 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/followers)
+"vZn" = (
+/obj/structure/flora/rock/jungle{
+	icon_state = "rock5";
+	pixel_x = -3
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "vZp" = (
 /obj/structure/rack/shelf_metal,
 /obj/effect/spawner/lootdrop/f13/cash_random_high,
@@ -81960,6 +82587,10 @@
 	},
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legioncamp)
+"xfH" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "xfJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/f13/wood{
@@ -82623,12 +83254,15 @@
 /turf/open/floor/wood_wide,
 /area/f13/building/abandoned/g)
 "xom" = (
-/obj/effect/decal/cleanable/blood{
-	icon_state = "floor6";
-	pixel_x = -18;
-	pixel_y = 15
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/turf/open/indestructible/ground/inside/mountain,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/f13/wood{
+	icon_state = "housewood4-broken"
+	},
 /area/f13/caves)
 "xoA" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -83091,7 +83725,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/legion)
 "xuB" = (
 /obj/structure/table/booth,
@@ -83236,10 +83870,9 @@
 	},
 /area/f13/building/abandoned/j)
 "xwX" = (
-/obj/machinery/door/password{
-	door_id = "veryevilroom"
-	},
-/turf/open/floor/pod/dark,
+/obj/structure/shelf_wood,
+/obj/item/grenade/frag,
+/turf/open/floor/wood_common/wood_common_light,
 /area/f13/building/powered)
 "xwY" = (
 /obj/structure/barricade/tentclothcorner{
@@ -84035,7 +84668,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/legion)
 "xJg" = (
 /obj/structure/chair/wood{
@@ -84160,6 +84793,13 @@
 	icon_state = "housewood2"
 	},
 /area/f13/ambientlighting/building/w)
+"xKV" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/caves)
 "xKW" = (
 /obj/structure/flora/tree/oak_three,
 /obj/effect/turf_decal/weather/dirt{
@@ -84512,7 +85152,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/power/port_gen/pacman/super,
 /obj/structure/cable/outdoors{
-	icon_state = "0-9"
+	icon_state = "0-1"
 	},
 /turf/open/floor/f13{
 	icon_state = "greenrustyfull"
@@ -85334,6 +85974,12 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/ambientlighting/building/m)
+"yce" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/indestructible/ground/outside/water,
+/area/f13/caves)
 "yci" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
@@ -85968,7 +86614,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
-/turf/open/indestructible/ground/outside/desert,
+/turf/open/indestructible/ground/outside/water,
 /area/f13/wasteland/legion)
 "ykS" = (
 /obj/structure/table/wood/fancy/red,
@@ -86562,8 +87208,8 @@ eyn
 eyn
 eyn
 eyn
-dnw
-dnw
+ukc
+xfH
 eyn
 eyn
 eyn
@@ -86864,8 +87510,8 @@ eyn
 eyn
 eyn
 eyn
-dnw
-dnw
+ukc
+xfH
 eyn
 eyn
 eyn
@@ -87166,9 +87812,9 @@ eyn
 eyn
 eyn
 eyn
-dnw
-dnw
-dnw
+pSv
+bqb
+scl
 eyn
 eyn
 eyn
@@ -87469,8 +88115,8 @@ eyn
 eyn
 eyn
 eyn
-dnw
-dnw
+ukc
+xfH
 eyn
 eyn
 eyn
@@ -87747,7 +88393,7 @@ sks
 swK
 cpw
 qoT
-taO
+juj
 fIO
 eyn
 eyn
@@ -87771,8 +88417,8 @@ eyn
 eyn
 eyn
 eyn
-dnw
-dnw
+ukc
+xfH
 eyn
 eyn
 eyn
@@ -88045,7 +88691,7 @@ eyn
 eyn
 wmc
 jnl
-wWz
+hji
 taO
 cfW
 taO
@@ -88073,7 +88719,7 @@ eyn
 eyn
 eyn
 eyn
-vIm
+czL
 vIm
 eyn
 eyn
@@ -88084,8 +88730,8 @@ eyn
 fow
 taO
 qBX
-eyn
-eyn
+taO
+taO
 eyn
 eyn
 eyn
@@ -88375,8 +89021,8 @@ eyn
 kex
 eyn
 eyn
-dnw
-dnw
+ukc
+xfH
 eyn
 eyn
 eyn
@@ -88384,11 +89030,11 @@ eyn
 eyn
 taO
 taO
-dnw
-dnw
-dnw
-eyn
-eyn
+hgr
+cQR
+aib
+taO
+taO
 eyn
 eyn
 eyn
@@ -88666,8 +89312,8 @@ eyn
 eyn
 eyn
 mCj
-dDN
 bdX
+taO
 fow
 fIO
 bFY
@@ -88677,20 +89323,20 @@ sJu
 lCb
 rnY
 taO
-dnw
-dnw
+pSv
+oxZ
 eyn
 eyn
 eyn
 eyn
 taO
 fIO
-dnw
-dnw
-dnw
-dnw
-dnw
-taO
+bAZ
+biK
+hho
+qLY
+deZ
+hbE
 eyn
 eyn
 eyn
@@ -88970,7 +89616,7 @@ taO
 mCj
 bdX
 bdX
-bdX
+taO
 rDO
 sJu
 daT
@@ -88980,19 +89626,19 @@ taO
 taO
 taO
 fow
-dnw
-dnw
-dnw
-eyn
-eyn
+tHh
+uoi
+gWc
+juj
+taO
 rnY
-dnw
-dnw
+tfQ
+xom
 fdE
 coY
-eyn
-dnw
 taO
+ukc
+scl
 rnY
 eyn
 eyn
@@ -89253,9 +89899,9 @@ wdx
 taO
 taO
 taO
-eyn
-wmc
-eyn
+vyT
+fnx
+vyT
 tum
 taO
 fow
@@ -89271,10 +89917,10 @@ taO
 taO
 mCj
 sZZ
-dDN
-aHq
-aHq
-aHq
+bdX
+eyn
+eyn
+taO
 hYg
 sJu
 sJu
@@ -89283,18 +89929,18 @@ mTa
 cfW
 taO
 taO
-dnw
-dnw
-dnw
-dnw
-dnw
-dnw
+szm
+vGz
+vGz
+vGz
+vGz
+igg
 eyn
 qoT
-eyn
-eyn
-dnw
-dnw
+taO
+taO
+ukc
+xfH
 qoT
 eyn
 eyn
@@ -89554,14 +90200,14 @@ tbh
 taO
 taO
 ivX
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
 wWz
 taO
 cpw
@@ -89571,32 +90217,32 @@ oJW
 gai
 taO
 rnY
-taO
+fTF
 sZZ
-aHq
 eyn
 eyn
-aHq
 eyn
 eyn
-kex
+taO
+hbE
+eyn
 eyn
 eyn
 eyn
 ijh
 taO
-dnw
-dnw
-dnw
-dnw
-dnw
+pSv
+bqb
+biK
+biK
+yce
 eyn
 eyn
 eyn
-eyn
-eyn
-dnw
-dnw
+taO
+taO
+ukc
+xfH
 eyn
 eyn
 eyn
@@ -89856,50 +90502,50 @@ taO
 taO
 taO
 taO
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
 taO
 fow
-qoT
+qKG
 taO
-wmc
+fnx
 cfW
 taO
 rnY
 aZv
-aHq
+eyn
 qHu
 gzM
-kex
-aHq
-aHq
-aHq
 eyn
 eyn
 eyn
 eyn
 eyn
 eyn
-dnw
+eyn
+eyn
+eyn
+eyn
+mUV
 eyn
 eyn
 eyn
 eyn
 sJu
 rtj
-fzD
+sJu
+taO
+ukc
+xfH
 eyn
-eyn
-dnw
-dnw
 eyn
 eyn
 eyn
@@ -90157,33 +90803,31 @@ taO
 rnY
 taO
 fIO
-wmc
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-wmc
-eyn
-eyn
+fnx
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+fnx
+vyT
+vyT
 sFX
 taO
-aHq
-aHq
+eyn
+eyn
 jiW
 tts
 krJ
 rPw
-egZ
-aHq
 eyn
 eyn
 eyn
@@ -90194,15 +90838,17 @@ eyn
 eyn
 eyn
 eyn
-dnw
-dnw
-dnw
-dnw
-dnw
-dnw
 eyn
-dnw
-dnw
+eyn
+duy
+iOW
+chJ
+ajI
+vGz
+bqb
+yce
+eyn
+eyn
 eyn
 eyn
 eyn
@@ -90451,41 +91097,40 @@ eyn
 eyn
 eyn
 eyn
-wWz
+aUY
 tbh
 taO
 krt
 taO
 mAQ
 taO
-wmc
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-wmc
+fnx
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+fnx
 nZP
 taO
-eyn
-eyn
-eyn
-eyn
-rnY
+vyT
+vyT
+vyT
+vyT
+got
 taO
 sZZ
-aHq
+eyn
 taO
 rPw
 mqN
 yka
 cRc
-aHq
 eyn
 eyn
 eyn
@@ -90495,16 +91140,17 @@ eyn
 eyn
 eyn
 eyn
-dnw
-dnw
-dnw
+eyn
+hgr
+xfH
+bmW
+fra
+vcX
+biK
+yce
 eyn
 eyn
 eyn
-dnw
-eyn
-eyn
-dnw
 eyn
 eyn
 eyn
@@ -90759,35 +91405,35 @@ rnY
 taO
 taO
 fDt
-wmc
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-wmc
+fnx
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+fnx
 taO
 wWz
 taO
 ddn
 dof
-eyn
-eyn
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
 mca
 bdX
-aHq
-aHq
+eyn
+eyn
 ewE
 vSX
 sEs
 qDO
-aHq
+eyn
 eyn
 eyn
 taO
@@ -90796,18 +91442,18 @@ taO
 eyn
 eyn
 eyn
-dnw
-dnw
-dnw
+hgr
+bqb
+xfH
+fzD
+sKK
 eyn
 eyn
 eyn
 eyn
-dnw
 eyn
-taO
-dnw
-taO
+eyn
+eyn
 eyn
 eyn
 eyn
@@ -91061,30 +91707,30 @@ wmc
 taO
 taO
 wid
-wmc
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-wmc
+fnx
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+fnx
 qoT
 nyh
 taO
 sBk
 raQ
-eyn
-eyn
-eyn
-eyn
-eyn
-vGz
+vyT
+vyT
+vyT
+vyT
+vyT
+bdX
 taO
 taO
-aHq
+eyn
 eyn
 rPw
 hnJ
@@ -91098,18 +91744,18 @@ uPc
 taO
 eyn
 tts
-dnw
-dnw
+pSv
+bqb
+hho
+tsS
 eyn
 eyn
 eyn
 eyn
-dnw
-dnw
 eyn
-fow
-dnw
-taO
+eyn
+eyn
+eyn
 eyn
 eyn
 eyn
@@ -91364,29 +92010,29 @@ nYQ
 taO
 wid
 aeY
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
 lbU
 gai
 dof
 cDz
 cDz
-eyn
-eyn
-eyn
-adi
+vyT
+vyT
+vyT
+vfL
 vwC
 dof
 dof
 tGU
-aHq
+eyn
 eyn
 sZZ
 sZZ
@@ -91401,17 +92047,17 @@ fow
 taO
 taO
 fIO
-eyn
-eyn
-eyn
-eyn
-eyn
-dnw
-eyn
-eyn
-xom
-dnw
+mUV
 taO
+taO
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 eyn
 eyn
 eyn
@@ -91666,29 +92312,29 @@ mVp
 taO
 wid
 taO
-eyn
-eyn
-eyn
-eyn
-wmc
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
+fnx
+vyT
+vyT
 pxT
 tNM
 hKK
 rDO
 shY
-eyn
-eyn
-eyn
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
+vyT
 vfL
 vwC
 dof
 dof
 dof
-aHq
+eyn
 eyn
 taO
 qoT
@@ -91703,16 +92349,16 @@ taO
 qoT
 taO
 taO
-eyn
-eyn
-eyn
-eyn
-dnw
-dnw
-eyn
 taO
-dnw
-dnw
+taO
+tNM
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 eyn
 eyn
 eyn
@@ -91969,28 +92615,28 @@ nYQ
 wid
 fow
 tJl
-eyn
-eyn
+vyT
+vyT
 taO
 qda
-eyn
-eyn
+vyT
+vyT
 rnY
 taO
 taO
 taO
-eyn
-eyn
-eyn
-eyn
-noM
-eyn
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
+rzQ
+vyT
+vyT
+vyT
 xbw
 dof
 eyn
-aHq
+eyn
 eyn
 rnY
 wjC
@@ -92001,20 +92647,20 @@ taO
 fow
 eyn
 eyn
-taO
+fwR
 fow
 gbB
 rUE
 rnY
+whm
 eyn
 eyn
-fow
-dnw
-dnw
-dnw
-dnw
-dnw
-dnw
+eyn
+eyn
+eyn
+eyn
+eyn
+eyn
 eyn
 eyn
 lxh
@@ -92271,7 +92917,7 @@ tum
 wid
 taO
 taO
-eyn
+vyT
 taO
 ddn
 lKN
@@ -92282,7 +92928,7 @@ taO
 dof
 taO
 iXz
-cpw
+vlt
 taO
 bki
 iXz
@@ -92292,14 +92938,14 @@ dof
 dof
 taO
 eyn
-aHq
+eyn
 eyn
 wjC
 wjC
 taO
 eyn
 eyn
-taO
+tyk
 cfW
 eyn
 eyn
@@ -92307,21 +92953,21 @@ eyn
 taO
 hKK
 bHY
-rnY
+fJe
+hgr
+xfH
+dHe
 eyn
-eyn
-cfW
 dnw
 dnw
 dnw
 dnw
-dnw
-fIO
-eyn
-eyn
 sgz
-fKQ
-uBD
+sgz
+sgz
+sgz
+sgz
+sgz
 fKQ
 sLI
 jKr
@@ -92569,11 +93215,11 @@ eyn
 eyn
 eyn
 wmc
-taO
+tNM
 wid
 taO
 rnY
-eyn
+vyT
 tNM
 xSm
 dof
@@ -92590,40 +93236,40 @@ taO
 taO
 iXz
 taO
-taO
-taO
 eyn
 eyn
-aHq
+eyn
+eyn
+eyn
 eyn
 cfW
 taO
 tyk
 eyn
+dvT
 taO
-taO
-taO
+tyk
 eyn
 eyn
 eyn
 cfW
 taO
 lIE
-taO
+xKV
+ukc
+bqb
+vGz
 eyn
-eyn
-rnY
 dnw
-dnw
-dnw
-eyn
+sfT
+uYa
 fmr
-eyn
-eyn
-tmQ
+svO
+uYa
+mZN
+jii
+jii
 sgz
-sgz
-uBD
 fKQ
 sLI
 azA
@@ -92875,12 +93521,12 @@ taO
 aQx
 lbU
 bki
-eyn
+vyT
 gLH
 taO
 bzD
 aYu
-ddn
+cIc
 taO
 xmD
 eyn
@@ -92891,40 +93537,40 @@ eyn
 eyn
 eyn
 eyn
+uBD
+uBD
+bgw
+bgw
+bgw
 eyn
-eyn
-eyn
-eyn
-eyn
-aHq
 eyn
 eyn
 tyk
 tyk
 sZZ
-taO
-taO
-eyn
-eyn
-eyn
-eyn
-eyn
-taO
+vZn
 taO
 eyn
 eyn
 eyn
+taO
+taO
+taO
+xOc
+hgr
 bqb
-tts
-taO
+bqb
+bqb
 eyn
-eyn
-eyn
-eyn
-sgz
+dnw
+euZ
+uYa
+dnw
+egZ
+uYa
+uYa
 hMe
-hMe
-sgz
+bzA
 sgz
 oKZ
 nqZ
@@ -93173,16 +93819,16 @@ eyn
 eyn
 eyn
 eyn
-taO
+bQQ
 wid
 gai
 taO
-wmc
+fnx
 nyh
 taO
-wmc
-eyn
-eyn
+fnx
+vyT
+vyT
 fGd
 taO
 taO
@@ -93193,39 +93839,39 @@ eyn
 eyn
 eyn
 eyn
+bgw
+qrg
+vFb
+aYP
+bgw
 eyn
 eyn
-eyn
-eyn
-eyn
-aHq
-aHq
 eyn
 tyk
 sZZ
 taO
 taO
 taO
-eyn
-eyn
-eyn
-eyn
-eyn
+taO
+taO
+taO
 rnY
-fow
+taO
+rnY
+rHJ
+ukc
+bqb
+bqb
 eyn
 eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-sgz
+dnw
+qPS
+hPt
+dnw
+hrB
 uWU
 uYa
-uYa
+sUy
 kDp
 sgz
 tdD
@@ -93479,13 +94125,13 @@ eCn
 xvT
 taO
 aaI
-wmc
+fnx
 oxJ
 taO
-eyn
-eyn
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
 tts
 taO
 qoT
@@ -93495,19 +94141,24 @@ eyn
 eyn
 eyn
 eyn
+bgw
+qrg
+qrg
+pDK
+bgw
 eyn
 eyn
 eyn
-eyn
-eyn
-eyn
-aHq
-aHq
 eyn
 taO
 taO
 taO
 taO
+taO
+taO
+seo
+tyk
+tyk
 eyn
 eyn
 eyn
@@ -93515,19 +94166,14 @@ eyn
 eyn
 eyn
 eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-qmk
-qmk
-qmk
-sgz
+dnw
+dnw
+dnw
+dnw
 pOm
 uYa
 uYa
-uYa
+svO
 kBp
 sgz
 sLI
@@ -93781,14 +94427,14 @@ qoT
 taO
 taO
 cfW
-eyn
+vyT
 rie
 qoT
-eyn
-eyn
-eyn
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
+vyT
 taO
 cvT
 taO
@@ -93798,10 +94444,10 @@ eyn
 bgw
 bgw
 bgw
+jxS
 bgw
 bgw
 bgw
-eyn
 eyn
 fIO
 aaI
@@ -93810,27 +94456,27 @@ taO
 taO
 taO
 taO
+taO
+taO
 eyn
 eyn
 eyn
 eyn
 eyn
 eyn
-eyn
-eyn
-eyn
-eyn
+qmk
+qmk
 qmk
 qmk
 qmk
 mDZ
 mDZ
 sgz
-hMe
-uYa
-uYa
+rWc
+bzA
+tmQ
 sgz
-sgz
+pjI
 sgz
 sgz
 sgz
@@ -94083,13 +94729,13 @@ fIO
 kAA
 wid
 taO
-wmc
-eyn
+fnx
+vyT
 taO
-eyn
-eyn
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
 pxT
 hhY
 rnY
@@ -94097,10 +94743,10 @@ taO
 djf
 tts
 eyn
-bgw
+uBD
 cTy
 xJn
-cvy
+adi
 cvy
 bgw
 eyn
@@ -94111,6 +94757,7 @@ taO
 taO
 fIO
 rnY
+taO
 eyn
 eyn
 eyn
@@ -94118,21 +94765,20 @@ eyn
 eyn
 eyn
 eyn
-eyn
-eyn
-eyn
-azA
 qmk
+qmk
+jZx
+fli
+pYk
+rHn
 qQJ
-qMR
-fAj
 fAj
 sgz
 soD
 jii
 lCr
-iOW
-cCJ
+lpb
+vQx
 xDO
 lpb
 rTC
@@ -94385,15 +95031,15 @@ taO
 kAA
 wid
 taO
-wmc
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
+fnx
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
 rZz
 dof
 gLl
@@ -94401,7 +95047,7 @@ dof
 eyn
 bgw
 dJC
-vjP
+qrg
 vjP
 lxr
 bgw
@@ -94410,10 +95056,6 @@ taO
 taO
 eWg
 taO
-aHq
-eyn
-aHq
-aHq
 eyn
 eyn
 eyn
@@ -94422,18 +95064,22 @@ eyn
 eyn
 eyn
 eyn
-azA
-azA
+eyn
+eyn
+eyn
 qmk
-hgr
+hJJ
+fAj
+fAj
+tba
 beA
 dFc
 cjZ
 sgz
-gmQ
-uYa
-uYa
-sgz
+tmQ
+tmQ
+tmQ
+lpb
 nBE
 oLn
 eCV
@@ -94686,14 +95332,14 @@ eyn
 yfF
 taO
 mAQ
-aaI
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
+llX
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
 taO
 taO
 nMC
@@ -94712,9 +95358,6 @@ taO
 rnY
 noM
 eyn
-aHq
-aHq
-aHq
 eyn
 eyn
 eyn
@@ -94723,20 +95366,23 @@ eyn
 eyn
 eyn
 eyn
-azA
-efD
-azA
+eyn
+eyn
+eyn
 qmk
-qmk
-qmk
+pUb
+fAj
+fAj
+fAj
+xKg
 hqE
 fAj
+kBm
 sgz
-ukc
-uYa
-sgz
-biK
+qOs
 lpb
+lpb
+ktl
 lpb
 fbv
 cCJ
@@ -94989,12 +95635,12 @@ tvR
 taO
 taO
 taO
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
 tNM
 rPw
 lsU
@@ -95011,9 +95657,6 @@ vjP
 bgw
 cfW
 taO
-aHq
-aHq
-aHq
 eyn
 eyn
 eyn
@@ -95022,21 +95665,24 @@ eyn
 eyn
 eyn
 eyn
-azA
-azA
-azA
+eyn
+eyn
+eyn
 azA
 azA
 azA
 qmk
-tba
-xKg
+flf
+fAj
+fAj
+fAj
+fAj
 psL
-qPS
-sgz
+fAj
+qKq
 sgz
 xwX
-sgz
+lpb
 nBE
 gYJ
 dZm
@@ -95292,12 +95938,12 @@ eyn
 cSH
 rnY
 cfW
-eyn
-eyn
-eyn
-eyn
-eyn
-eyn
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
 rnY
 wWz
 qoT
@@ -95311,9 +95957,9 @@ uwq
 eiU
 aMQ
 bgw
-aHq
-aHq
-aHq
+eyn
+eyn
+eyn
 eyn
 eyn
 eyn
@@ -95327,18 +95973,18 @@ azA
 fCP
 azA
 azA
-azA
-azA
-azA
 qmk
+bHW
 fAj
-hJJ
+iLq
 fAj
-qMR
-qKq
+fAj
+fAj
+fAj
+cbo
 sgz
 tMu
-sgz
+lpb
 aUi
 wsn
 bMp
@@ -95598,8 +96244,8 @@ taO
 taO
 wWz
 fow
-eyn
-eyn
+vyT
+vyT
 eyn
 eyn
 eyn
@@ -95629,11 +96275,11 @@ azA
 azA
 azA
 azA
-azA
-azA
-azA
 qmk
-atw
+mvl
+fAj
+fAj
+mdb
 jHn
 fAj
 qav
@@ -95931,11 +96577,11 @@ glZ
 glZ
 glZ
 azA
-azA
-epF
-fnx
 qmk
+mvl
 fAj
+fAj
+tba
 mzh
 qMR
 fAj
@@ -96199,7 +96845,7 @@ eyn
 eyn
 wmc
 rnY
-aaI
+umz
 lbU
 sVZ
 qoT
@@ -96214,8 +96860,8 @@ eyn
 bgw
 bgw
 bgw
-bgw
-bgw
+uBD
+uBD
 bgw
 eyn
 eyn
@@ -96233,15 +96879,15 @@ nuS
 cYL
 glZ
 azA
-azA
-mUB
-qIr
 qmk
-tba
-xKg
+qmk
+fAj
+jQC
+fAj
+hJJ
 oez
 nFD
-qOs
+fAj
 qmk
 pMr
 lQS
@@ -96535,9 +97181,9 @@ wiE
 xUu
 afl
 qwC
-epF
-fOT
 azA
+qmk
+qmk
 qmk
 qmk
 qmk
@@ -96810,7 +97456,7 @@ taO
 taO
 cpw
 taO
-taO
+hbE
 ybZ
 plu
 sYc
@@ -96840,9 +97486,9 @@ ukT
 oeF
 qIr
 azA
-txN
-tyG
-tyG
+fqh
+fAj
+fAj
 fqh
 atw
 fAj
@@ -97142,8 +97788,8 @@ azA
 epF
 jOa
 bbF
-azA
-txN
+fqh
+fAj
 mEh
 fqh
 fAj
@@ -97444,9 +98090,9 @@ oMd
 vHL
 ioi
 gXS
-azA
-azA
-txN
+qmk
+qmk
+qmk
 ibC
 qmk
 qmk
@@ -103195,7 +103841,7 @@ fBy
 fBA
 fBy
 lmd
-dzm
+qcd
 pkS
 ahs
 uVn
@@ -113883,7 +114529,7 @@ nrg
 ukJ
 nGS
 piw
-nGS
+glA
 oql
 vsh
 nDt
@@ -129765,7 +130411,7 @@ cBf
 tou
 mfM
 mfM
-iom
+gmQ
 cBf
 cBf
 kuV
@@ -130065,9 +130711,9 @@ jbl
 cBf
 cBf
 eIG
-ooa
-kGJ
-wAj
+kSR
+fOT
+jwt
 hZS
 rRz
 kuV
@@ -130367,10 +131013,10 @@ dVy
 jbl
 cBf
 eIG
-iBK
-uOV
-kGJ
-iom
+tLp
+sRf
+fOT
+gmQ
 hZS
 gSD
 eyn
@@ -130671,9 +131317,9 @@ jbl
 cBf
 eKd
 gMR
-iBK
-kGJ
-iom
+tLp
+fOT
+gmQ
 kuV
 kuV
 kuV
@@ -164063,7 +164709,7 @@ mPY
 aXj
 ksO
 urr
-hHA
+gmQ
 rEw
 gkD
 cBf
@@ -164362,11 +165008,11 @@ jSv
 ykJ
 xuw
 pfI
-waj
-waj
+mfM
+mfM
 dkq
-azA
-dTu
+fOT
+rUt
 geh
 cBf
 dEl
@@ -164664,10 +165310,10 @@ sEU
 mAy
 sYI
 eVa
-nuY
-azA
-fag
-igE
+tLp
+sRf
+sRf
+jwt
 kDz
 cBf
 dJZ

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
@@ -33253,6 +33253,10 @@
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/item/clothing/under/syndicate/camo,
+/obj/item/clothing/under/syndicate/camo,
+/obj/item/clothing/under/syndicate/camo,
+/obj/item/clothing/under/syndicate/camo,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ambientlighting/building/m)
 "jnl" = (
@@ -53757,6 +53761,9 @@
 /obj/item/storage/belt/military/alt,
 /obj/item/storage/belt/military/alt,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
+/obj/item/storage/belt/military,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ambientlighting/building/m)
 "pcE" = (
@@ -61275,6 +61282,7 @@
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /obj/structure/rack/large/shelf_rust,
+/obj/item/clothing/under/syndicate/camo,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ambientlighting/building/m)
 "rfX" = (
@@ -62463,6 +62471,7 @@
 /obj/item/clothing/head/cowboyhat{
 	pixel_y = 15
 	},
+/obj/item/clothing/under/syndicate/camo,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ambientlighting/building/m)
 "rxL" = (
@@ -65984,6 +65993,17 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"syW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/effect/spawner/lootdrop/f13/armor/clothes,
+/obj/item/clothing/under/pants/camo,
+/turf/open/floor/plasteel/grimy,
+/area/f13/ambientlighting/building/m)
 "syX" = (
 /obj/effect/decal/marking{
 	pixel_x = -14
@@ -66626,6 +66646,7 @@
 /obj/effect/spawner/lootdrop/f13/armor/clothes,
 /obj/structure/rack/large/shelf_rust,
 /obj/machinery/light,
+/obj/item/clothing/under/syndicate/camo,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ambientlighting/building/m)
 "sIv" = (
@@ -83046,6 +83067,8 @@
 	dir = 4;
 	pixel_y = -16
 	},
+/obj/item/storage/belt/military/NCR_Bandolier,
+/obj/item/storage/belt/military/NCR_Bandolier,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ambientlighting/building/m)
 "xlp" = (
@@ -91182,7 +91205,7 @@ jVw
 jVw
 jVw
 jVw
-iWu
+syW
 xpW
 azA
 azA

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Surface.dmm
@@ -3703,8 +3703,9 @@
 /turf/open/indestructible/ground/outside/grass,
 /area/f13/wasteland)
 "bcQ" = (
-/turf/open/indestructible/ground/outside/desert,
-/area/f13/caves)
+/obj/effect/decal/cleanable/glass,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "bcS" = (
 /obj/effect/decal/cleanable/ash,
 /turf/open/indestructible/ground/outside/desert,
@@ -4364,6 +4365,10 @@
 /obj/structure/table/optable/primitive,
 /turf/open/floor/plasteel/f13/stone/rugged,
 /area/f13/legioncamp)
+"bng" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "bnk" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/weather/dirt{
@@ -17126,7 +17131,7 @@
 	dir = 8
 	},
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/wasteland)
 "eTD" = (
 /obj/structure/barricade/tentleatheredge,
 /obj/structure/decoration/rag{
@@ -18682,6 +18687,13 @@
 	location_description = "To the far southwest, behind the old farmhouse with that freaky basement in it."
 	},
 /turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
+"foA" = (
+/obj/effect/decal/riverbankcorner,
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/water/running,
 /area/f13/wasteland)
 "foC" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -22040,6 +22052,11 @@
 	},
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland)
+"giV" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "gja" = (
 /turf/open/floor/carpet/red,
 /area/f13/building/abandoned/t)
@@ -22683,6 +22700,25 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/inside/dirt,
 /area/f13/wasteland/town)
+"gsN" = (
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = 6
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -5;
+	pixel_x = -8
+	},
+/obj/structure/reagent_dispensers/barrel/dangerous{
+	pixel_y = -9
+	},
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "gsX" = (
 /obj/structure/barricade/sandbags,
 /turf/open/indestructible/ground/outside/sidewalk{
@@ -22902,6 +22938,15 @@
 "gwJ" = (
 /turf/closed/wall/mineral/wood,
 /area/f13/wasteland/legion)
+"gwR" = (
+/obj/effect/decal/riverbank{
+	dir = 8
+	},
+/obj/structure/railing{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/water/running,
+/area/f13/wasteland)
 "gxe" = (
 /obj/structure/car/rubbish1,
 /obj/structure/car/rubbish2{
@@ -33536,6 +33581,10 @@
 	icon_state = "outerpavement"
 	},
 /area/f13/wasteland)
+"jrg" = (
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "jri" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/effect/decal/cleanable/greenglow,
@@ -33564,6 +33613,12 @@
 	color = "#363636"
 	},
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"jrx" = (
+/obj/structure/stairs/west{
+	color = "#A47449"
+	},
+/turf/open/indestructible/ground/outside/desert,
 /area/f13/wasteland)
 "jrB" = (
 /obj/effect/turf_decal/weather,
@@ -36452,6 +36507,16 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"kiR" = (
+/obj/effect/decal/riverbank{
+	dir = 4
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water/running,
+/area/f13/wasteland)
 "kjl" = (
 /obj/machinery/door/unpowered/securedoor{
 	req_access_txt = "25"
@@ -37800,6 +37865,13 @@
 	},
 /turf/open/floor/f13/wood,
 /area/f13/legioncamp)
+"kDJ" = (
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water/running,
+/area/f13/wasteland)
 "kDK" = (
 /obj/structure/fence{
 	dir = 4
@@ -40134,6 +40206,17 @@
 /obj/structure/simple_door/house,
 /turf/open/floor/f13/wood,
 /area/f13/ambientlighting/building/m)
+"llJ" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	layer = 50
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1;
+	layer = 15000
+	},
+/turf/open/indestructible/ground/outside/water/running,
+/area/f13/wasteland)
 "llK" = (
 /obj/structure/simple_door/house{
 	icon_state = "room"
@@ -41642,6 +41725,16 @@
 	},
 /turf/open/indestructible/ground/outside/graveldirt,
 /area/f13/caves)
+"lIR" = (
+/obj/effect/decal/riverbankcorner{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "lIV" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ammo/tier1,
@@ -42051,6 +42144,10 @@
 	name = "dirty floor"
 	},
 /area/f13/building/powered)
+"lNP" = (
+/obj/structure/railing/wood/post,
+/turf/open/indestructible/ground/outside/desert,
+/area/f13/wasteland)
 "lOd" = (
 /obj/structure/barricade/wooden,
 /obj/structure/barricade/wooden/planks,
@@ -43090,6 +43187,10 @@
 /turf/open/indestructible/ground/outside/sidewalk{
 	icon_state = "horizontaloutermain1"
 	},
+/area/f13/wasteland)
+"mdy" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
 "mdQ" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -50010,6 +50111,11 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland/legion)
+"oaD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/shreds,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "oaE" = (
 /obj/machinery/door/locked/easy/maybe_trapped,
 /turf/open/floor/f13/wood,
@@ -53999,6 +54105,11 @@
 /obj/structure/simple_door/interior,
 /turf/open/floor/wood_common,
 /area/f13/ambientlighting/building/x)
+"pgp" = (
+/obj/effect/decal/cleanable/oil/slippery,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "pgq" = (
 /obj/structure/fence/wooden{
 	dir = 4;
@@ -55103,6 +55214,15 @@
 	dir = 1
 	},
 /turf/open/indestructible/ground/outside/sidewalk,
+/area/f13/wasteland)
+"pwl" = (
+/obj/effect/decal/riverbankcorner{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/turf/open/floor/wood_wide,
 /area/f13/wasteland)
 "pwv" = (
 /obj/structure/rack,
@@ -57932,7 +58052,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/f13/inside/gravel,
-/area/f13/caves)
+/area/f13/wasteland)
 "qlf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/f13/junkspawners,
@@ -58764,7 +58884,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/f13/inside/gravel,
-/area/f13/caves)
+/area/f13/wasteland)
 "qyp" = (
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/indestructible/ground/outside/dirt,
@@ -72067,6 +72187,12 @@
 	icon_state = "dirt"
 	},
 /area/f13/wasteland)
+"uhs" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "uhv" = (
 /obj/effect/overlay/desert/sonora/edge{
 	dir = 6
@@ -74149,6 +74275,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building/powered)
+"uMc" = (
+/obj/structure/nest/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "uMe" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	dir = 4
@@ -75523,6 +75653,12 @@
 /obj/structure/simple_door/brokenglass,
 /turf/open/floor/plasteel/grimy,
 /area/f13/ambientlighting/building/m)
+"vfY" = (
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d"
+	},
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "vfZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/junk/small/table,
@@ -75728,6 +75864,16 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/ambientlighting/building/o)
+"vjo" = (
+/obj/effect/decal/riverbankcorner{
+	dir = 4
+	},
+/obj/structure/railing{
+	color = "#A47449";
+	dir = 1
+	},
+/turf/open/indestructible/ground/outside/water/running,
+/area/f13/wasteland)
 "vjA" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/indestructible/ground/outside/dirt{
@@ -79487,6 +79633,11 @@
 	icon_state = "redrustyfull"
 	},
 /area/f13/building/abandoned/t)
+"wpt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/nest/ghoul,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/wasteland)
 "wpE" = (
 /obj/item/storage/trash_stack{
 	pixel_y = 18
@@ -79886,6 +80037,10 @@
 "wus" = (
 /obj/structure/table/wood/bar,
 /turf/open/indestructible/ground/outside/dirt,
+/area/f13/wasteland)
+"wut" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/indestructible/ground/inside/mountain,
 /area/f13/wasteland)
 "wuH" = (
 /obj/effect/landmark/legion_attack{
@@ -83287,6 +83442,14 @@
 	icon_state = "housewood4-broken"
 	},
 /area/f13/caves)
+"xon" = (
+/obj/effect/decal/riverbankcorner,
+/obj/effect/turf_decal/weather/dirt{
+	color = "#a98c5d";
+	dir = 1
+	},
+/turf/open/floor/wood_wide,
+/area/f13/wasteland)
 "xoA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human,
@@ -84287,7 +84450,7 @@
 "xCz" = (
 /obj/effect/spawner/lootdrop/f13/weapon/gun/energy/mid,
 /turf/open/indestructible/ground/inside/mountain,
-/area/f13/caves)
+/area/f13/wasteland)
 "xCC" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/blood,
@@ -108759,15 +108922,15 @@ rkv
 "}
 (74,1,1) = {"
 rkv
-yfv
-yfv
-yfv
-yfv
-yfv
-yfv
-yfv
-yfv
-yfv
+nrU
+azA
+azA
+azA
+azA
+nrU
+nrU
+nrU
+nrU
 rLf
 rLf
 rLf
@@ -109061,15 +109224,15 @@ rkv
 "}
 (75,1,1) = {"
 rkv
-yfv
-yfv
-yfv
-yfv
-yfv
-yfv
-yfv
-yfv
-yfv
+nrU
+nrU
+nrU
+nrU
+nrU
+nrU
+nrU
+nrU
+nrU
 azA
 azA
 lhS
@@ -109363,14 +109526,14 @@ rkv
 "}
 (76,1,1) = {"
 rkv
-yfv
-yfv
-yfv
-yfv
-yfv
-yfv
-yfv
-yfv
+nrU
+nrU
+nrU
+nrU
+nrU
+nrU
+nrU
+nrU
 fhC
 azA
 azA
@@ -112383,12 +112546,12 @@ rkv
 "}
 (86,1,1) = {"
 uGX
-aHq
-aHq
-aHq
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -112685,10 +112848,10 @@ rkv
 "}
 (87,1,1) = {"
 uGX
-aHq
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -112987,10 +113150,10 @@ rkv
 "}
 (88,1,1) = {"
 uGX
-aHq
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -113289,9 +113452,9 @@ rkv
 "}
 (89,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -113591,8 +113754,8 @@ rkv
 "}
 (90,1,1) = {"
 uGX
-aHq
-aHq
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -113893,8 +114056,8 @@ rkv
 "}
 (91,1,1) = {"
 uGX
-aHq
-aHq
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -114195,8 +114358,8 @@ rkv
 "}
 (92,1,1) = {"
 uGX
-aHq
-aHq
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -114497,8 +114660,8 @@ rkv
 "}
 (93,1,1) = {"
 uGX
-aHq
-aHq
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -114528,7 +114691,7 @@ vyT
 aHq
 aHq
 azA
-azA
+lNP
 azA
 vLk
 rSK
@@ -114799,8 +114962,8 @@ rkv
 "}
 (94,1,1) = {"
 uGX
-aHq
-aHq
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -114811,8 +114974,8 @@ taO
 taO
 taO
 jeF
-jeF
-jeF
+uhs
+uhs
 eTC
 eyn
 eyn
@@ -115101,8 +115264,8 @@ rkv
 "}
 (95,1,1) = {"
 uGX
-aHq
-aHq
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -115114,9 +115277,9 @@ taO
 rnY
 ali
 nQx
-taO
-dof
-voo
+rDQ
+mdy
+oaD
 eyn
 eyn
 eyn
@@ -115132,7 +115295,7 @@ aHq
 aHq
 aHq
 azA
-azA
+lNP
 azA
 vLk
 vLk
@@ -115403,7 +115566,7 @@ rkv
 "}
 (96,1,1) = {"
 uGX
-aHq
+vyT
 vyT
 vyT
 vyT
@@ -115417,9 +115580,9 @@ taO
 taO
 taO
 taO
-dGq
-dof
-dof
+pgp
+mdy
+mdy
 dof
 eyn
 eyn
@@ -115705,8 +115868,8 @@ rkv
 "}
 (97,1,1) = {"
 uGX
-aHq
-aHq
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -115736,7 +115899,7 @@ vyT
 aHq
 aHq
 azA
-azA
+lNP
 azA
 azA
 azA
@@ -116007,8 +116170,8 @@ rkv
 "}
 (98,1,1) = {"
 uGX
-aHq
-aHq
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -116309,8 +116472,8 @@ rkv
 "}
 (99,1,1) = {"
 uGX
-aHq
-aHq
+vyT
+vyT
 vyT
 vyT
 vyT
@@ -116340,7 +116503,7 @@ eyn
 eyn
 aHq
 azA
-azA
+lNP
 azA
 azA
 azA
@@ -116611,8 +116774,8 @@ rkv
 "}
 (100,1,1) = {"
 uGX
-aHq
-aHq
+vyT
+vyT
 vyT
 vyT
 vxq
@@ -116636,9 +116799,9 @@ eyn
 hIh
 dof
 dof
-dof
-dof
-eco
+mdy
+mdy
+giV
 eyn
 aHq
 azA
@@ -116913,9 +117076,9 @@ rkv
 "}
 (101,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 hhY
 hhY
 pOi
@@ -116937,11 +117100,11 @@ eyn
 eyn
 eyn
 eyn
-nLc
-dof
-hhY
-hhY
-laY
+wpt
+mdy
+bcQ
+bcQ
+wut
 aHq
 azA
 azA
@@ -117215,9 +117378,9 @@ rkv
 "}
 (102,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 hhY
 vyT
 vyT
@@ -117240,9 +117403,9 @@ eyn
 taO
 lfz
 dof
-hhY
-hhY
-fTI
+bcQ
+bcQ
+gsN
 vyT
 aHq
 azA
@@ -117517,9 +117680,9 @@ rkv
 "}
 (103,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 qSB
 vyT
 vyT
@@ -117819,9 +117982,9 @@ rkv
 "}
 (104,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 vyT
 eyn
 eyn
@@ -118121,9 +118284,9 @@ rkv
 "}
 (105,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 eyn
 eyn
 vyT
@@ -118423,9 +118586,9 @@ rkv
 "}
 (106,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 eyn
 vyT
 vyT
@@ -118725,9 +118888,9 @@ rkv
 "}
 (107,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 eyn
 vyT
 taO
@@ -119027,9 +119190,9 @@ rkv
 "}
 (108,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 vyT
 vyT
 taO
@@ -119329,9 +119492,9 @@ gXH
 "}
 (109,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 vyT
 taO
 taO
@@ -119631,17 +119794,17 @@ gXH
 "}
 (110,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 aNl
 cIa
 dof
 taO
 dmp
 ayt
-taO
-taO
+rDQ
+rDQ
 taO
 vyT
 vyT
@@ -119933,9 +120096,9 @@ gXH
 "}
 (111,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 taO
 taO
 pOi
@@ -119943,7 +120106,7 @@ taO
 hhY
 qyi
 qlb
-taO
+rDQ
 taO
 rnY
 vyT
@@ -120235,18 +120398,18 @@ rkv
 "}
 (112,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 fTI
 taO
 hhY
 hhY
-cIa
-taO
-taO
-oDz
-taO
+jrg
+rDQ
+rDQ
+uMc
+rDQ
 taO
 vyT
 eyn
@@ -120537,18 +120700,18 @@ rkv
 "}
 (113,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 taO
 taO
 rnY
 eyn
 eyn
-taO
+rDQ
 xCz
-taO
-taO
+rDQ
+rDQ
 pOi
 vyT
 eyn
@@ -120839,9 +121002,9 @@ rkv
 "}
 (114,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 taO
 taO
 eyn
@@ -121141,15 +121304,15 @@ rkv
 "}
 (115,1,1) = {"
 uGX
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
 taO
 nAz
 eyn
-eyn
-aHq
-aHq
+vyT
+vyT
+vyT
 eyn
 taO
 taO
@@ -121443,16 +121606,16 @@ rkv
 "}
 (116,1,1) = {"
 uGX
-aHq
-aHq
-aHq
-aHq
-eyn
-eyn
-aHq
-aHq
-aHq
-aHq
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
 vyT
 vyT
 eyn
@@ -121745,15 +121908,15 @@ rkv
 "}
 (117,1,1) = {"
 uGX
+vyT
+vyT
+vyT
+vyT
+vyT
+vyT
 aHq
 aHq
 aHq
-aHq
-aHq
-aHq
-aHq
-aHq
-nnH
 aHq
 aHq
 aHq
@@ -122054,9 +122217,9 @@ aHq
 aHq
 aHq
 aHq
-aHq
-azA
-azA
+nnH
+jrx
+jrx
 aHq
 aHq
 aHq
@@ -122068,7 +122231,7 @@ aHq
 tQx
 gBE
 fqD
-xOc
+bng
 gBE
 aHq
 idy
@@ -122655,7 +122818,7 @@ aHq
 aHq
 aHq
 aHq
-bcQ
+azA
 azA
 azA
 azA
@@ -129989,7 +130152,7 @@ kGJ
 fhY
 kGJ
 dSB
-cBf
+iQC
 cBf
 cBf
 cBf
@@ -130290,10 +130453,10 @@ fhY
 kGJ
 piJ
 kGJ
-ycn
-irJ
-cBf
-cBf
+foA
+lPz
+iQC
+ibm
 cBf
 cBf
 cBf
@@ -130592,10 +130755,10 @@ kGJ
 tma
 xhP
 kGJ
-kGJ
-ycn
-iGf
-iGf
+vgD
+xon
+vfY
+kiR
 irJ
 cBf
 cBf
@@ -130894,10 +131057,10 @@ kGJ
 kGJ
 kGJ
 kGJ
-kGJ
-cuj
-kGJ
-cuj
+vgD
+lPz
+vfY
+llJ
 ycn
 iGf
 irJ
@@ -131196,10 +131359,10 @@ pyQ
 bhE
 kGJ
 kGJ
-kGJ
-kGJ
-kGJ
-kGJ
+vgD
+lPz
+vfY
+kDJ
 kGJ
 kGJ
 ycn
@@ -131498,10 +131661,10 @@ cBf
 iyY
 pyQ
 pyQ
-pyQ
-bhE
-kGJ
-kGJ
+gwR
+lIR
+vfY
+kDJ
 kGJ
 kGJ
 kGJ
@@ -131800,10 +131963,10 @@ iRR
 cBf
 cBf
 cBf
-cBf
-cLF
-bhE
-kGJ
+cKa
+lPz
+pwl
+kDJ
 cuj
 kGJ
 kGJ
@@ -132103,9 +132266,9 @@ cBf
 cBf
 cBf
 cBf
-cBf
-cLF
-bhE
+cKa
+vfY
+vjo
 kGJ
 kGJ
 oLu
@@ -132406,7 +132569,7 @@ cBf
 cBf
 cBf
 cBf
-cBf
+cKa
 iyY
 bhE
 kGJ

--- a/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
+++ b/_maps/map_files/Vegas Valley/Vegas_Valley_Underground.dmm
@@ -3261,7 +3261,7 @@
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/bunker)
 "biS" = (
-/mob/living/simple_animal/hostile/raider/junker,
+/mob/living/simple_animal/hostile/raider/firefighter,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},
@@ -4464,6 +4464,10 @@
 	icon_state = "tunnelchess2"
 	},
 /area/f13/vault)
+"bHv" = (
+/obj/item/pickaxe,
+/turf/open/indestructible/ground/inside/subway,
+/area/maintenance/disposal)
 "bHz" = (
 /obj/effect/spawner/lootdrop/f13/weapon/melee/tier3,
 /turf/open/floor/plating/dirt/dark,
@@ -5820,7 +5824,7 @@
 /obj/structure/rack/shelf_metal,
 /obj/effect/decal/fakelattice,
 /obj/effect/spawner/bundle/f13/r84,
-/obj/item/book/granter/crafting_recipe/blueprint/r84,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
 /turf/open/floor/plating/tunnel,
 /area/maintenance/disposal)
 "cim" = (
@@ -11693,8 +11697,8 @@
 /area/f13/bar/heaven)
 "eCo" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/automatic/combat,
-/obj/item/book/granter/crafting_recipe/blueprint/combatrifle,
+/obj/effect/spawner/lootdrop/f13/blueprintHigh,
+/obj/effect/spawner/lootdrop/weapons/oldarmyelite,
 /turf/open/floor/f13{
 	icon_state = "darkrusty"
 	},
@@ -26982,12 +26986,9 @@
 /turf/open/floor/plasteel/dark,
 /area/f13/caves)
 "kCH" = (
-/obj/structure/chair/stool/retro/black,
-/mob/living/simple_animal/hostile/raider/junker,
-/turf/open/floor/plasteel/f13{
-	icon_state = "darkrustysolid"
-	},
-/area/f13/ambientlighting/building/i)
+/obj/structure/barricade/wooden/planks/pregame,
+/turf/closed/wall/f13/ruins,
+/area/maintenance/disposal)
 "kCM" = (
 /mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/f13/wood{
@@ -34195,6 +34196,7 @@
 /obj/structure/sign/poster/prewar/poster93{
 	pixel_y = 31
 	},
+/mob/living/simple_animal/hostile/raider/ranged,
 /turf/open/floor/plasteel/f13{
 	icon_state = "darkrustysolid"
 	},
@@ -49964,6 +49966,12 @@
 /obj/effect/spawner/lootdrop/f13/weapon/gun/ballistic/mid,
 /turf/open/floor/plasteel/f13,
 /area/f13/tunnel)
+"tlk" = (
+/mob/living/simple_animal/hostile/raider/ranged,
+/turf/open/floor/plasteel/f13{
+	icon_state = "darkrustysolid"
+	},
+/area/f13/ambientlighting/building/i)
 "tlB" = (
 /obj/structure/table/wood,
 /obj/machinery/processor/chopping_block{
@@ -56393,6 +56401,10 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor,
 /area/f13/vault/garden)
+"vDQ" = (
+/obj/structure/ore_furnace,
+/turf/open/indestructible/ground/inside/subway,
+/area/maintenance/disposal)
 "vDS" = (
 /obj/machinery/light{
 	dir = 4
@@ -88714,7 +88726,7 @@ ivg
 kZE
 dTZ
 ivg
-ivg
+tlk
 gny
 lUy
 yhR
@@ -89016,7 +89028,7 @@ ivg
 mLx
 lUy
 ivg
-biS
+ivg
 rVB
 lUy
 oEb
@@ -89621,7 +89633,7 @@ ivg
 lUy
 lUy
 ivg
-ivg
+biS
 mhk
 dWW
 lUy
@@ -90214,7 +90226,7 @@ yhR
 lUy
 ivg
 kZE
-ivg
+biS
 ivg
 ivg
 hMz
@@ -90517,7 +90529,7 @@ lUy
 beP
 ivg
 ivg
-kCH
+rVB
 ivg
 dys
 lUy
@@ -91128,7 +91140,7 @@ lUy
 fuW
 lUy
 nmi
-biS
+ivg
 ivg
 dys
 gny
@@ -97503,10 +97515,10 @@ gxT
 yhR
 yhR
 oeO
-oeO
-oeO
-oeO
-oeO
+kCH
+bHv
+vDQ
+kCH
 oeO
 oeO
 oeO


### PR DESCRIPTION
- Expanded on mall pre-established base location with the secret radio-station, added threats in there past the blast door.
- Removes the static R84 & R84 blueprint spawn from the storage facility
- Removed static combat carbine & combat carbine blueprint spawn from train station 
- Fixed water by the legion base
- Removed tackle gloves from mechanic store (oops lol)
- Made the cave for tech bunker less hellish to navigate
- Replaced junkers with basic raiders in mechanic's shop underground 
- The Followers now start with a wasteland vending machine they can get the key for and 5 boxes of 5 stims. (25 Stims)